### PR TITLE
Fix Java return type extraction compilation error

### DIFF
--- a/make.out
+++ b/make.out
@@ -3,11 +3,11 @@ cmake  -DEXTENSION_STATIC_BUILD=1 -DDUCKDB_EXTENSION_CONFIGS='/mnt/aux-data/teag
 -- Running vcpkg install
 warning: Embedding `vcpkg-configuration` in a manifest file is an EXPERIMENTAL feature.
 All requested packages are currently installed.
-All requested installations completed successfully in: 81.8 us
+All requested installations completed successfully in: 43.2 us
 -- Running vcpkg install - done
 -- git hash fd3fa59072, version v1.4.0-dev1503, extension folder fd3fa59072
 -- Extensions will be deployed to: /mnt/aux-data/teague/Projects/duckdb_ast/build/release/repository
--- Load extension 'sitting_duck' from '/mnt/aux-data/teague/Projects/duckdb_ast' @ c601a33
+-- Load extension 'sitting_duck' from '/mnt/aux-data/teague/Projects/duckdb_ast' @ c7b53ef
 -- Load extension 'core_functions' from '/mnt/aux-data/teague/Projects/duckdb_ast/duckdb/extensions' @ fd3fa59072
 -- Load extension 'parquet' from '/mnt/aux-data/teague/Projects/duckdb_ast/duckdb/extensions' @ fd3fa59072
 -- Load extension 'jemalloc' from '/mnt/aux-data/teague/Projects/duckdb_ast/duckdb/extensions' @ fd3fa59072
@@ -89,8 +89,8 @@ Generated /mnt/aux-data/teague/Projects/duckdb_ast/src/include/embedded_sql_macr
 -- Extension targets will depend on generated parsers
 -- Extensions linked into DuckDB: [sitting_duck, core_functions, parquet, jemalloc]
 -- Tests loaded for extensions: [sitting_duck]
--- Configuring done (1.8s)
--- Generating done (0.6s)
+-- Configuring done (2.0s)
+-- Generating done (0.7s)
 -- Build files have been written to: /mnt/aux-data/teague/Projects/duckdb_ast/build/release
 cmake --build build/release --config Release
 gmake[1]: Entering directory '/mnt/aux-data/teague/Projects/duckdb_ast/build/release'
@@ -289,15 +289,58 @@ gmake[1]: Entering directory '/mnt/aux-data/teague/Projects/duckdb_ast/build/rel
 [ 63%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/language_adapters/swift_adapter.cpp.o
 [ 63%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/language_adapters/r_adapter.cpp.o
 [ 63%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/language_adapters/kotlin_adapter.cpp.o
+[ 63%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/read_ast_streaming_function.cpp.o
 [ 63%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/ast_sql_macros.cpp.o
+[ 63%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/parse_ast_function.cpp.o
 [ 63%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/unified_ast_backend.cpp.o
 [ 64%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/ast_parsing_task.cpp.o
+[ 64%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/ast_type.cpp.o
+[ 64%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/semantic_types.cpp.o
+[ 64%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/semantic_type_functions.cpp.o
+[ 64%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/ast_file_utils.cpp.o
+[ 64%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/ast_supported_languages_function.cpp.o
 [ 64%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/src/native_context_extraction.cpp.o
-[ 64%] Linking CXX static library libsitting_duck_extension.a
+[ 64%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-python/src/parser.c.o
+[ 65%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-python/src/scanner.c.o
+[ 65%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-javascript/src/parser.c.o
+[ 65%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-javascript/src/scanner.c.o
+[ 65%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-cpp/src/parser.c.o
+[ 65%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-cpp/src/scanner.c.o
+[ 65%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-typescript/typescript/src/parser.c.o
+[ 65%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-typescript/typescript/src/scanner.c.o
+[ 66%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-sql/src/parser.c.o
+[ 66%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-sql/src/scanner.c.o
+[ 66%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-go/src/parser.c.o
+[ 66%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-ruby/src/parser.c.o
+[ 66%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-ruby/src/scanner.c.o
+[ 66%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-markdown/tree-sitter-markdown/src/parser.c.o
+[ 66%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-markdown/tree-sitter-markdown/src/scanner.c.o
+[ 67%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-java/src/parser.c.o
+[ 67%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-php/php/src/parser.c.o
+[ 67%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-php/php/src/scanner.c.o
+[ 67%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-html/src/parser.c.o
+[ 67%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-html/src/scanner.c.o
+[ 67%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-css/src/parser.c.o
+[ 67%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-css/src/scanner.c.o
+[ 68%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-c/src/parser.c.o
+[ 68%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-rust/src/parser.c.o
+[ 68%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-rust/src/scanner.c.o
+[ 68%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-json/src/parser.c.o
+[ 68%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-bash/src/parser.c.o
+[ 68%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-bash/src/scanner.c.o
+[ 68%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-swift/src/parser.c.o
+[ 68%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-swift/src/scanner.c.o
+[ 69%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-r/src/parser.c.o
+[ 69%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-r/src/scanner.c.o
+[ 69%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-kotlin/src/parser.c.o
+[ 69%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_extension.dir/grammars/tree-sitter-kotlin/src/scanner.c.o
+[ 69%] Linking CXX static library libsitting_duck_extension.a
 [ 72%] Built target sitting_duck_extension
 [ 73%] Built target duckdb_static
 [ 73%] Linking CXX shared library loadable_extension_optimizer_demo.duckdb_extension
 [ 73%] Built target loadable_extension_optimizer_demo_loadable_extension
+[ 73%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/sitting_duck_extension.cpp.o
+[ 73%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/language_adapter.cpp.o
 [ 73%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/language_adapter_registry_init.cpp.o
 [ 74%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/language_adapters/python_adapter.cpp.o
 [ 74%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/language_adapters/javascript_adapter.cpp.o
@@ -319,11 +362,52 @@ gmake[1]: Entering directory '/mnt/aux-data/teague/Projects/duckdb_ast/build/rel
 [ 76%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/language_adapters/swift_adapter.cpp.o
 [ 76%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/language_adapters/r_adapter.cpp.o
 [ 76%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/language_adapters/kotlin_adapter.cpp.o
+[ 76%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/read_ast_streaming_function.cpp.o
 [ 76%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/ast_sql_macros.cpp.o
-[ 76%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/unified_ast_backend.cpp.o
-[ 76%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/ast_parsing_task.cpp.o
-[ 76%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/native_context_extraction.cpp.o
-[ 77%] Linking CXX shared library sitting_duck.duckdb_extension
+[ 77%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/parse_ast_function.cpp.o
+[ 77%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/unified_ast_backend.cpp.o
+[ 77%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/ast_parsing_task.cpp.o
+[ 77%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/ast_type.cpp.o
+[ 77%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/semantic_types.cpp.o
+[ 77%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/semantic_type_functions.cpp.o
+[ 77%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/ast_file_utils.cpp.o
+[ 78%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/ast_supported_languages_function.cpp.o
+[ 78%] Building CXX object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/src/native_context_extraction.cpp.o
+[ 78%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-python/src/parser.c.o
+[ 78%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-python/src/scanner.c.o
+[ 78%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-javascript/src/parser.c.o
+[ 78%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-javascript/src/scanner.c.o
+[ 78%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-cpp/src/parser.c.o
+[ 78%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-cpp/src/scanner.c.o
+[ 79%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-typescript/typescript/src/parser.c.o
+[ 79%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-typescript/typescript/src/scanner.c.o
+[ 79%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-sql/src/parser.c.o
+[ 79%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-sql/src/scanner.c.o
+[ 79%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-go/src/parser.c.o
+[ 79%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-ruby/src/parser.c.o
+[ 79%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-ruby/src/scanner.c.o
+[ 80%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-markdown/tree-sitter-markdown/src/parser.c.o
+[ 80%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-markdown/tree-sitter-markdown/src/scanner.c.o
+[ 80%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-java/src/parser.c.o
+[ 80%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-php/php/src/parser.c.o
+[ 80%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-php/php/src/scanner.c.o
+[ 80%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-html/src/parser.c.o
+[ 80%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-html/src/scanner.c.o
+[ 81%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-css/src/parser.c.o
+[ 81%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-css/src/scanner.c.o
+[ 81%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-c/src/parser.c.o
+[ 81%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-rust/src/parser.c.o
+[ 81%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-rust/src/scanner.c.o
+[ 81%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-json/src/parser.c.o
+[ 81%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-bash/src/parser.c.o
+[ 82%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-bash/src/scanner.c.o
+[ 82%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-swift/src/parser.c.o
+[ 82%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-swift/src/scanner.c.o
+[ 82%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-r/src/parser.c.o
+[ 82%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-r/src/scanner.c.o
+[ 82%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-kotlin/src/parser.c.o
+[ 82%] Building C object extension/sitting_duck/CMakeFiles/sitting_duck_loadable_extension.dir/grammars/tree-sitter-kotlin/src/scanner.c.o
+[ 83%] Linking CXX shared library sitting_duck.duckdb_extension
 [ 86%] Built target sitting_duck_loadable_extension
 [ 87%] Linking CXX shared library core_functions.duckdb_extension
 [ 87%] Built target core_functions_loadable_extension

--- a/src/include/java_native_extractors.hpp
+++ b/src/include/java_native_extractors.hpp
@@ -43,24 +43,17 @@ private:
         // Structure: [modifiers] returnType methodName(params) { }
         uint32_t child_count = ts_node_child_count(node);
         
-        // Look for return type node - should come before identifier (method name)
-        bool found_identifier = false;
+        // Look for return type node (can be anywhere in the method declaration)
         for (uint32_t i = 0; i < child_count; i++) {
             TSNode child = ts_node_child(node, i);
             const char* child_type = ts_node_type(child);
             
-            // Track if we've seen the method name identifier
-            if (strcmp(child_type, "identifier") == 0) {
-                found_identifier = true;
-                continue;
-            }
-            
-            // Look for return type before the identifier (method name)
-            if (!found_identifier && (strcmp(child_type, "type_identifier") == 0 ||
+            // Look for any return type (primitive types like int, or reference types like String)
+            if (strcmp(child_type, "type_identifier") == 0 ||
                 strcmp(child_type, "primitive_type") == 0 ||
                 strcmp(child_type, "generic_type") == 0 ||
                 strcmp(child_type, "array_type") == 0 ||
-                strcmp(child_type, "void_type") == 0)) {
+                strcmp(child_type, "void_type") == 0) {
                 uint32_t start = ts_node_start_byte(child);
                 uint32_t end = ts_node_end_byte(child);
                 if (start < content.length() && end <= content.length() && end > start) {
@@ -73,24 +66,17 @@ private:
         TSNode parent = ts_node_parent(node);
         if (!ts_node_is_null(parent)) {
             uint32_t parent_count = ts_node_child_count(parent);
-            found_identifier = false;
             
             for (uint32_t i = 0; i < parent_count && i < 20; i++) { // Limit search
                 TSNode child = ts_node_child(parent, i);
                 const char* child_type = ts_node_type(child);
                 
-                // Track if we've seen an identifier
-                if (strcmp(child_type, "identifier") == 0) {
-                    found_identifier = true;
-                    continue;
-                }
-                
-                // Look for return type before identifier
-                if (!found_identifier && (strcmp(child_type, "type_identifier") == 0 ||
+                // Look for any return type in parent
+                if (strcmp(child_type, "type_identifier") == 0 ||
                     strcmp(child_type, "primitive_type") == 0 ||
                     strcmp(child_type, "generic_type") == 0 ||
                     strcmp(child_type, "array_type") == 0 ||
-                    strcmp(child_type, "void_type") == 0)) {
+                    strcmp(child_type, "void_type") == 0) {
                     uint32_t start = ts_node_start_byte(child);
                     uint32_t end = ts_node_end_byte(child);
                     if (start < content.length() && end <= content.length() && end > start) {


### PR DESCRIPTION
- Removed position-based constraints for Java return type detection
- Now searches for primitive_type, type_identifier, etc. anywhere in method declaration
- Simplified parent node fallback logic
- Still investigating simpleMethod edge case (may be structural duplicate node issue)

Testing shows other Java methods work correctly:
- staticMethod: String ✓
- finalMethod: String ✓
- synchronizedMethod: void ✓

🤖 Generated with [Claude Code](https://claude.ai/code)