### PR TITLE
Fix noisy/duplicate definition results (#25, #26)

### DIFF
--- a/src/language_adapters/go_adapter.cpp
+++ b/src/language_adapters/go_adapter.cpp
@@ -59,6 +59,12 @@ string GoAdapter::ExtractNodeName(TSNode node, const string &content) const {
 	const NodeConfig *config = GetNodeConfig(node_type_str);
 
 	if (config) {
+		if (config->name_strategy == ExtractionStrategy::CUSTOM) {
+			string node_type = string(node_type_str);
+			if (node_type == "package_clause") {
+				return FindChildByType(node, content, "package_identifier");
+			}
+		}
 		return ExtractByStrategy(node, content, config->name_strategy);
 	}
 
@@ -68,8 +74,6 @@ string GoAdapter::ExtractNodeName(TSNode node, const string &content) const {
 		return FindChildByType(node, content, "identifier");
 	} else if (node_type.find("_spec") != string::npos) {
 		return FindChildByType(node, content, "identifier");
-	} else if (node_type == "package_clause") {
-		return FindChildByType(node, content, "package_identifier");
 	}
 
 	return "";

--- a/src/language_configs/go_types.def
+++ b/src/language_configs/go_types.def
@@ -66,7 +66,7 @@
  * @{
  */
 DEF_TYPE("source_file", DEFINITION_MODULE, NONE, NONE, 0)
-DEF_TYPE("package_clause", DEFINITION_MODULE, FIND_IDENTIFIER, NONE, ASTNodeFlags::IS_CONSTRUCT)
+DEF_TYPE("package_clause", DEFINITION_MODULE, CUSTOM, NONE, ASTNodeFlags::IS_CONSTRUCT)
 DEF_TYPE("package_identifier", NAME_IDENTIFIER, NODE_TEXT, NONE, ASTNodeFlags::IS_CONSTRUCT)
 DEF_TYPE("import_declaration", EXTERNAL_IMPORT | SemanticRefinements::Import::MODULE, NONE, NONE, ASTNodeFlags::IS_CONSTRUCT)
 DEF_TYPE("import_spec", EXTERNAL_IMPORT | SemanticRefinements::Import::MODULE, NODE_TEXT, NONE, ASTNodeFlags::IS_CONSTRUCT)

--- a/src/sql_macros/tree_navigation.sql
+++ b/src/sql_macros/tree_navigation.sql
@@ -64,6 +64,7 @@ CREATE OR REPLACE MACRO ast_definitions(ast_table) AS TABLE
         semantic_type
     FROM query_table(ast_table)
     WHERE is_definition(semantic_type)
+      AND is_construct(flags)
       AND name IS NOT NULL AND name != ''
     ORDER BY file_path, start_line;
 
@@ -184,14 +185,14 @@ CREATE OR REPLACE MACRO ast_class_members(ast_table, class_node_id) AS TABLE
               AND a.node_id <= c.node_id + c.descendant_count
         ),
         -- Find all named definition nodes within the class
-        -- Excludes syntactic tokens like 'class'/'def' keywords where type=name
+        -- Excludes syntactic tokens like 'class'/'def' keywords via flag check
         all_defs AS (
             SELECT node_id, descendant_count, name, type, semantic_type,
                    start_line, end_line, depth, parent_id, peek, file_path, language
             FROM descendants
             WHERE is_definition(semantic_type)
+              AND is_construct(flags)
               AND name IS NOT NULL AND name != ''
-              AND type != name  -- Filter out keyword tokens (e.g., 'class' with name='class')
         )
     -- Return definitions that are NOT nested inside other definitions
     -- (i.e., direct members of the class, not locals inside methods)

--- a/test/sql/bugs/definition_noise.test
+++ b/test/sql/bugs/definition_noise.test
@@ -1,0 +1,78 @@
+# name: test/sql/bugs/definition_noise.test
+# description: Test that definition queries return clean results without noise (#25, #26)
+# group: [bugs]
+
+require sitting_duck
+
+# =============================================================================
+# Bug #26: Go package_clause should extract "main" as name
+# =============================================================================
+
+# The package_clause node should extract "main" via package_identifier child
+query IT
+SELECT name, semantic_type FROM read_ast('test/data/go/simple.go')
+WHERE type = 'package_clause';
+----
+main	DEFINITION_MODULE
+
+# There should be exactly 1 named DEFINITION_MODULE entry (the package)
+# The source_file node is also DEFINITION_MODULE but has no name
+query I
+SELECT COUNT(*) FROM read_ast('test/data/go/simple.go')
+WHERE semantic_type = 'DEFINITION_MODULE' AND name IS NOT NULL AND name != '';
+----
+1
+
+# ast_definitions() should return exactly one module definition for Go
+statement ok
+CREATE TEMP TABLE go_ast AS SELECT * FROM read_ast('test/data/go/simple.go');
+
+query II
+SELECT name, definition_type FROM ast_definitions('go_ast')
+WHERE definition_type = 'module';
+----
+main	module
+
+# =============================================================================
+# Bug #25: Keyword tokens should not appear in ast_definitions()
+# =============================================================================
+
+# Rust definitions should not include keyword text like "fn", "struct", "impl"
+statement ok
+CREATE TEMP TABLE rust_ast AS SELECT * FROM read_ast('test/data/rust/simple.rs');
+
+query I
+SELECT COUNT(*) FROM ast_definitions('rust_ast')
+WHERE name IN ('fn', 'struct', 'impl', 'let', 'pub', 'mod', 'use', 'enum', 'trait');
+----
+0
+
+# Go definitions should not include keyword text
+query I
+SELECT COUNT(*) FROM ast_definitions('go_ast')
+WHERE name IN ('func', 'var', 'const', 'type', 'package', 'import');
+----
+0
+
+# JS definitions should not include "program" root node
+statement ok
+CREATE TEMP TABLE js_ast AS SELECT * FROM read_ast('test/data/javascript/simple.js');
+
+query I
+SELECT COUNT(*) FROM ast_definitions('js_ast')
+WHERE name = 'program';
+----
+0
+
+# =============================================================================
+# Verify ast_definitions() returns only meaningful definitions
+# =============================================================================
+
+# Go definitions should be clean: package and functions only
+query II
+SELECT name, definition_type FROM ast_definitions('go_ast')
+ORDER BY start_line;
+----
+main	module
+Hello	function
+main	function


### PR DESCRIPTION
## Summary
- **#26**: Fix Go `package_clause` name extraction — switch from `FIND_IDENTIFIER` to `CUSTOM` strategy so the adapter correctly finds `package_identifier` children instead of searching for non-existent `identifier` children
- **#25**: Add `is_construct(flags)` filter to `ast_definitions()` and `ast_class_members()` macros to exclude keyword tokens (`fn`, `struct`, `class`, etc.) that leak into definition queries
- Replace ad-hoc `type != name` filter in `ast_class_members()` with proper `is_construct(flags)` flag check

## Test plan
- [x] New reproducer test `test/sql/bugs/definition_noise.test` covers both bugs
- [x] Go language support tests pass
- [x] Tree navigation macro tests pass (Python/Java class members unchanged)
- [x] Full test suite passes (67 tests, 2667 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)