### PR TITLE
Fix Bash semantic extraction: names and redirect types (#32)

### DIFF
--- a/src/language_adapter.cpp
+++ b/src/language_adapter.cpp
@@ -317,6 +317,12 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 		if (result.empty()) {
 			result = FindChildByType(node, content, "setter"); // Ruby setter methods (def name=)
 		}
+		if (result.empty()) {
+			result = FindChildByType(node, content, "variable_name"); // Bash vars, PHP params/properties
+		}
+		if (result.empty()) {
+			result = FindChildByType(node, content, "word"); // Bash function names
+		}
 		return result;
 	}
 	case ExtractionStrategy::FIND_PROPERTY:

--- a/src/language_adapter.cpp
+++ b/src/language_adapter.cpp
@@ -317,6 +317,12 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 		if (result.empty()) {
 			result = FindChildByType(node, content, "setter"); // Ruby setter methods (def name=)
 		}
+		if (result.empty()) {
+			result = FindChildByType(node, content, "variable_name"); // Bash, PHP
+		}
+		if (result.empty()) {
+			result = FindChildByType(node, content, "word"); // Bash
+		}
 		return result;
 	}
 	case ExtractionStrategy::FIND_PROPERTY:

--- a/src/language_adapters/kotlin_adapter.cpp
+++ b/src/language_adapters/kotlin_adapter.cpp
@@ -63,6 +63,19 @@ string KotlinAdapter::ExtractNodeName(TSNode node, const string &content) const 
 		if (config->name_strategy == ExtractionStrategy::CUSTOM) {
 			// Kotlin-specific custom extraction
 			string node_type = string(node_type_str);
+			if (node_type == "property_declaration") {
+				// Kotlin wraps property names in variable_declaration → simple_identifier
+				string identifier = FindChildByType(node, content, "simple_identifier");
+				if (!identifier.empty()) {
+					return identifier;
+				}
+				// Search inside variable_declaration child
+				TSNode var_decl = FindChildByTypeNode(node, "variable_declaration");
+				if (!ts_node_is_null(var_decl)) {
+					return FindChildByType(var_decl, content, "simple_identifier");
+				}
+				return FindChildByType(node, content, "identifier");
+			}
 			if (node_type.find("declaration") != string::npos || node_type.find("definition") != string::npos) {
 				// Try simple_identifier first (Kotlin-specific)
 				string identifier = FindChildByType(node, content, "simple_identifier");
@@ -79,6 +92,19 @@ string KotlinAdapter::ExtractNodeName(TSNode node, const string &content) const 
 
 	// Fallback: try to find identifier child for common declaration types
 	string node_type = string(node_type_str);
+	if (node_type == "property_declaration") {
+		// Kotlin wraps property names in variable_declaration → simple_identifier
+		string identifier = FindChildByType(node, content, "simple_identifier");
+		if (!identifier.empty()) {
+			return identifier;
+		}
+		// Search inside variable_declaration child
+		TSNode var_decl = FindChildByTypeNode(node, "variable_declaration");
+		if (!ts_node_is_null(var_decl)) {
+			return FindChildByType(var_decl, content, "simple_identifier");
+		}
+		return FindChildByType(node, content, "identifier");
+	}
 	if (node_type.find("declaration") != string::npos || node_type.find("definition") != string::npos) {
 		// Try simple_identifier first (Kotlin-specific)
 		string identifier = FindChildByType(node, content, "simple_identifier");

--- a/src/language_adapters/kotlin_adapter.cpp
+++ b/src/language_adapters/kotlin_adapter.cpp
@@ -92,19 +92,6 @@ string KotlinAdapter::ExtractNodeName(TSNode node, const string &content) const 
 
 	// Fallback: try to find identifier child for common declaration types
 	string node_type = string(node_type_str);
-	if (node_type == "property_declaration") {
-		// Kotlin wraps property names in variable_declaration → simple_identifier
-		string identifier = FindChildByType(node, content, "simple_identifier");
-		if (!identifier.empty()) {
-			return identifier;
-		}
-		// Search inside variable_declaration child
-		TSNode var_decl = FindChildByTypeNode(node, "variable_declaration");
-		if (!ts_node_is_null(var_decl)) {
-			return FindChildByType(var_decl, content, "simple_identifier");
-		}
-		return FindChildByType(node, content, "identifier");
-	}
 	if (node_type.find("declaration") != string::npos || node_type.find("definition") != string::npos) {
 		// Try simple_identifier first (Kotlin-specific)
 		string identifier = FindChildByType(node, content, "simple_identifier");

--- a/src/language_adapters/swift_adapter.cpp
+++ b/src/language_adapters/swift_adapter.cpp
@@ -103,19 +103,8 @@ string SwiftAdapter::ExtractNodeName(TSNode node, const string &content) const {
 
 	// Swift-specific fallbacks for unknown types
 	string node_type = string(node_type_str);
-	if (node_type == "function_declaration") {
+	if (node_type == "function_declaration" || node_type == "init_declaration") {
 		return FindChildByType(node, content, "simple_identifier");
-	}
-	if (node_type == "init_declaration") {
-		string identifier = FindChildByType(node, content, "simple_identifier");
-		return identifier.empty() ? "init" : identifier;
-	}
-	if (node_type == "deinit_declaration") {
-		return "deinit";
-	}
-	if (node_type == "subscript_declaration") {
-		string identifier = FindChildByType(node, content, "simple_identifier");
-		return identifier.empty() ? "subscript" : identifier;
 	}
 	if (node_type == "class_declaration" || node_type == "struct_declaration" || node_type == "enum_declaration" ||
 	    node_type == "protocol_declaration") {

--- a/src/language_adapters/swift_adapter.cpp
+++ b/src/language_adapters/swift_adapter.cpp
@@ -64,8 +64,19 @@ string SwiftAdapter::ExtractNodeName(TSNode node, const string &content) const {
 		if (config->name_strategy == ExtractionStrategy::CUSTOM) {
 			// Swift-specific custom extraction
 			string node_type = string(node_type_str);
-			if (node_type == "function_declaration" || node_type == "init_declaration") {
+			if (node_type == "function_declaration") {
 				return FindChildByType(node, content, "simple_identifier");
+			}
+			if (node_type == "init_declaration") {
+				string identifier = FindChildByType(node, content, "simple_identifier");
+				return identifier.empty() ? "init" : identifier;
+			}
+			if (node_type == "deinit_declaration") {
+				return "deinit";
+			}
+			if (node_type == "subscript_declaration") {
+				string identifier = FindChildByType(node, content, "simple_identifier");
+				return identifier.empty() ? "subscript" : identifier;
 			}
 			if (node_type == "class_declaration" || node_type == "struct_declaration" ||
 			    node_type == "enum_declaration" || node_type == "protocol_declaration") {
@@ -92,8 +103,19 @@ string SwiftAdapter::ExtractNodeName(TSNode node, const string &content) const {
 
 	// Swift-specific fallbacks for unknown types
 	string node_type = string(node_type_str);
-	if (node_type == "function_declaration" || node_type == "init_declaration") {
+	if (node_type == "function_declaration") {
 		return FindChildByType(node, content, "simple_identifier");
+	}
+	if (node_type == "init_declaration") {
+		string identifier = FindChildByType(node, content, "simple_identifier");
+		return identifier.empty() ? "init" : identifier;
+	}
+	if (node_type == "deinit_declaration") {
+		return "deinit";
+	}
+	if (node_type == "subscript_declaration") {
+		string identifier = FindChildByType(node, content, "simple_identifier");
+		return identifier.empty() ? "subscript" : identifier;
 	}
 	if (node_type == "class_declaration" || node_type == "struct_declaration" || node_type == "enum_declaration" ||
 	    node_type == "protocol_declaration") {

--- a/src/language_configs/bash_types.def
+++ b/src/language_configs/bash_types.def
@@ -108,7 +108,7 @@ DEF_TYPE("function_definition", DEFINITION_FUNCTION, FIND_IDENTIFIER, FUNCTION_W
 DEF_TYPE("variable_assignment", DEFINITION_VARIABLE, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
 
 /// @brief Declaration command - `declare`, `local`, `readonly`, `typeset`, `export`
-DEF_TYPE("declaration_command", DEFINITION_VARIABLE, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
+DEF_TYPE("declaration_command", DEFINITION_VARIABLE, CUSTOM, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
 
 /// @brief Unset command - removes variable or function definition
 DEF_TYPE("unset_command", DEFINITION_VARIABLE, FIND_IDENTIFIER, NONE, 0)
@@ -385,13 +385,13 @@ DEF_TYPE("special_variable_name", NAME_IDENTIFIER, NODE_TEXT, NONE, 0)
  */
 
 /// @brief File redirect - `>`, `<`, `>>`, `2>`, etc.
-DEF_TYPE("file_redirect", EXTERNAL_IMPORT, NODE_TEXT, NONE, 0)
+DEF_TYPE("file_redirect", EXECUTION_STATEMENT, NONE, NONE, 0)
 
 /// @brief Here document - `<<EOF ... EOF`
-DEF_TYPE("heredoc_redirect", EXTERNAL_IMPORT, NODE_TEXT, NONE, 0)
+DEF_TYPE("heredoc_redirect", EXECUTION_STATEMENT, NONE, NONE, 0)
 
 /// @brief Here string - `<<<string`
-DEF_TYPE("herestring_redirect", EXTERNAL_IMPORT, NODE_TEXT, NONE, 0)
+DEF_TYPE("herestring_redirect", EXECUTION_STATEMENT, NONE, NONE, 0)
 
 /** @} */ // end bash_redirections
 

--- a/src/language_configs/kotlin_types.def
+++ b/src/language_configs/kotlin_types.def
@@ -145,7 +145,7 @@ DEF_TYPE("anonymous_initializer", DEFINITION_FUNCTION | SemanticRefinements::Fun
  */
 
 /// @brief Property declaration - `val`/`var` in class
-DEF_TYPE("property_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::FIELD, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, 0)
+DEF_TYPE("property_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::FIELD, CUSTOM, VARIABLE_WITH_TYPE, 0)
 
 /// @brief Variable declaration - local `val`/`var`
 DEF_TYPE("variable_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, 0)

--- a/src/language_configs/swift_types.def
+++ b/src/language_configs/swift_types.def
@@ -169,7 +169,7 @@ DEF_TYPE("extension_declaration", DEFINITION_CLASS | SemanticRefinements::Class:
  */
 
 /// @brief Property declaration - class/struct property
-DEF_TYPE("property_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::FIELD, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
+DEF_TYPE("property_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::FIELD, CUSTOM, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
 
 /// @brief Variable declaration - local or global `let`/`var`
 DEF_TYPE("variable_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)

--- a/src/language_configs/zig_types.def
+++ b/src/language_configs/zig_types.def
@@ -110,19 +110,19 @@ DEF_TYPE("parameter", DEFINITION_VARIABLE | SemanticRefinements::Variable::PARAM
  */
 
 /// @brief Struct declaration - `const S = struct { }`
-DEF_TYPE("struct_declaration", DEFINITION_CLASS | SemanticRefinements::Class::REGULAR, FIND_IDENTIFIER, NONE, 0)
+DEF_TYPE("struct_declaration", DEFINITION_CLASS | SemanticRefinements::Class::REGULAR, CUSTOM, NONE, 0)
 
 /// @brief Enum declaration - `const E = enum { }`
-DEF_TYPE("enum_declaration", DEFINITION_CLASS | SemanticRefinements::Class::ENUM, FIND_IDENTIFIER, NONE, 0)
+DEF_TYPE("enum_declaration", DEFINITION_CLASS | SemanticRefinements::Class::ENUM, CUSTOM, NONE, 0)
 
 /// @brief Union declaration - `const U = union { }`
-DEF_TYPE("union_declaration", DEFINITION_CLASS | SemanticRefinements::Class::REGULAR, FIND_IDENTIFIER, NONE, 0)
+DEF_TYPE("union_declaration", DEFINITION_CLASS | SemanticRefinements::Class::REGULAR, CUSTOM, NONE, 0)
 
 /// @brief Opaque declaration - for C interop
-DEF_TYPE("opaque_declaration", DEFINITION_CLASS | SemanticRefinements::Class::ABSTRACT, FIND_IDENTIFIER, NONE, 0)
+DEF_TYPE("opaque_declaration", DEFINITION_CLASS | SemanticRefinements::Class::ABSTRACT, CUSTOM, NONE, 0)
 
 /// @brief Error set declaration - `const E = error { }`
-DEF_TYPE("error_set_declaration", DEFINITION_CLASS | SemanticRefinements::Class::ENUM, FIND_IDENTIFIER, NONE, 0)
+DEF_TYPE("error_set_declaration", DEFINITION_CLASS | SemanticRefinements::Class::ENUM, CUSTOM, NONE, 0)
 
 /** @} */ // end zig_types
 
@@ -149,7 +149,7 @@ DEF_TYPE("variable_declaration", DEFINITION_VARIABLE | SemanticRefinements::Vari
 DEF_TYPE("comptime_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::IMMUTABLE, FIND_IDENTIFIER, NONE, 0)
 
 /// @brief Test declaration - `test "name" { }`
-DEF_TYPE("test_declaration", DEFINITION_FUNCTION | SemanticRefinements::Function::REGULAR, FIND_IDENTIFIER, NONE, 0)
+DEF_TYPE("test_declaration", DEFINITION_FUNCTION | SemanticRefinements::Function::REGULAR, CUSTOM, NONE, 0)
 
 /// @brief Using namespace declaration - `usingnamespace @import("...")`
 DEF_TYPE("using_namespace_declaration", EXTERNAL_IMPORT | SemanticRefinements::Import::MODULE, NONE, NONE, 0)

--- a/test/data/hcl/simple.tf
+++ b/test/data/hcl/simple.tf
@@ -1,0 +1,130 @@
+# Simple Terraform/HCL test file demonstrating various constructs
+
+# Variable declarations
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "tags" {
+  description = "Resource tags"
+  type        = map(string)
+  default = {
+    Environment = "dev"
+    Team        = "platform"
+  }
+}
+
+# Local values
+locals {
+  common_tags = merge(var.tags, {
+    ManagedBy = "terraform"
+  })
+
+  instance_name = "web-${var.region}"
+}
+
+# Provider configuration
+provider "aws" {
+  region = var.region
+}
+
+# Data source
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+# Resource definitions
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name = "main-vpc"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = merge(local.common_tags, {
+    Name = "public-subnet-${count.index}"
+  })
+}
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(local.common_tags, {
+    Name = local.instance_name
+  })
+}
+
+# Output values
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.web.id
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+# Module reference
+module "security_group" {
+  source = "./modules/sg"
+
+  vpc_id = aws_vpc.main.id
+  name   = "web-sg"
+
+  ingress_rules = [
+    {
+      port        = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    },
+    {
+      port        = 443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
+}
+
+# Terraform backend configuration
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "my-terraform-state"
+    key    = "prod/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/test/data/lua/simple.lua
+++ b/test/data/lua/simple.lua
@@ -1,0 +1,114 @@
+-- Simple Lua test file demonstrating various language constructs
+
+-- Module table
+local M = {}
+
+-- Local variable declarations
+local name = "Lua"
+local version = 5.4
+local active = true
+
+-- Global function declaration
+function greet(who)
+    print("Hello, " .. who .. "!")
+end
+
+-- Local function declaration
+local function factorial(n)
+    if n <= 1 then
+        return 1
+    end
+    return n * factorial(n - 1)
+end
+
+-- Module function (dot syntax)
+function M.create(name, value)
+    return { name = name, value = value }
+end
+
+-- Method function (colon syntax)
+function M:init(config)
+    self.config = config
+    return self
+end
+
+-- Anonymous function assigned to variable
+local transform = function(x)
+    return x * 2
+end
+
+-- Table constructor with fields
+local config = {
+    host = "localhost",
+    port = 8080,
+    debug = false,
+}
+
+-- Class-like pattern using metatables
+local Animal = {}
+Animal.__index = Animal
+
+function Animal.new(name, sound)
+    local self = setmetatable({}, Animal)
+    self.name = name
+    self.sound = sound
+    return self
+end
+
+function Animal:speak()
+    print(self.name .. " says " .. self.sound)
+end
+
+-- Control flow
+local function process(items)
+    local results = {}
+    for i, item in ipairs(items) do
+        if item > 0 then
+            results[#results + 1] = item * 2
+        elseif item == 0 then
+            results[#results + 1] = 0
+        else
+            results[#results + 1] = -item
+        end
+    end
+    return results
+end
+
+-- Numeric for loop
+for i = 1, 10 do
+    -- counting
+end
+
+-- While loop
+local count = 0
+while count < 5 do
+    count = count + 1
+end
+
+-- Repeat-until loop
+repeat
+    count = count - 1
+until count == 0
+
+-- Coroutine
+local co = coroutine.create(function(a, b)
+    coroutine.yield(a + b)
+    return a * b
+end)
+
+-- Multiple return values
+local function divmod(a, b)
+    return math.floor(a / b), a % b
+end
+
+-- Varargs
+local function sum(...)
+    local total = 0
+    for _, v in ipairs({...}) do
+        total = total + v
+    end
+    return total
+end
+
+-- Return module
+return M

--- a/test/sql/audit/name_extraction_audit.test
+++ b/test/sql/audit/name_extraction_audit.test
@@ -1,0 +1,254 @@
+# name: test/sql/audit/name_extraction_audit.test
+# description: Comprehensive audit of name extraction across all languages
+# group: [sitting_duck_audit]
+
+require sitting_duck
+
+# Export all definitions and imports across all languages to CSV for analysis
+statement ok
+COPY (
+  SELECT 'python' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/python/simple.py')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'python_imports' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/python/imports.py')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'python_decorators' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/python/decorators.py')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'python_inheritance' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/python/inheritance.py')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'javascript' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/javascript/simple.js')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'javascript_imports' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/javascript/imports.js')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'typescript' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/javascript/typed_example.ts', 'typescript')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'typescript_imports' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/javascript/imports.ts', 'typescript')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'go' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/go/simple.go')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'go_visibility' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/go/visibility.go')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'rust' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/rust/simple.rs')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'rust_imports' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/rust/imports.rs')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'c' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/c/imports.c')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'cpp' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/cpp/simple.cpp')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'cpp_imports' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/cpp/imports.cpp')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'csharp' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/csharp/simple.cs')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'kotlin' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/kotlin/simple.kt')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'swift' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/swift/simple.swift')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'dart' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/dart/sample.dart')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'dart_imports' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/dart/imports.dart')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'ruby' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/ruby/simple.rb')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'php' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/php/test.php')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'php_imports' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/php/imports.php')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'bash' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/bash/simple.sh')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'r' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/r/simple.r')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'zig' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/zig/sample.zig')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'lua' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/lua/simple.lua')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'hcl' AS lang, type, semantic_type, name, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/hcl/simple.tf')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+) TO 'workspace/design/audit-reports/all_definitions.csv' WITH (HEADER, DELIMITER ',');
+
+# Export root nodes
+statement ok
+COPY (
+  SELECT 'python' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/python/simple.py') WHERE depth = 0
+  UNION ALL
+  SELECT 'javascript' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/javascript/simple.js') WHERE depth = 0
+  UNION ALL
+  SELECT 'go' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/go/simple.go') WHERE depth = 0
+  UNION ALL
+  SELECT 'rust' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/rust/simple.rs') WHERE depth = 0
+  UNION ALL
+  SELECT 'c' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/c/imports.c') WHERE depth = 0
+  UNION ALL
+  SELECT 'cpp' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/cpp/simple.cpp') WHERE depth = 0
+  UNION ALL
+  SELECT 'csharp' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/csharp/simple.cs') WHERE depth = 0
+  UNION ALL
+  SELECT 'kotlin' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/kotlin/simple.kt') WHERE depth = 0
+  UNION ALL
+  SELECT 'swift' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/swift/simple.swift') WHERE depth = 0
+  UNION ALL
+  SELECT 'dart' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/dart/sample.dart') WHERE depth = 0
+  UNION ALL
+  SELECT 'ruby' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/ruby/simple.rb') WHERE depth = 0
+  UNION ALL
+  SELECT 'php' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/php/test.php') WHERE depth = 0
+  UNION ALL
+  SELECT 'bash' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/bash/simple.sh') WHERE depth = 0
+  UNION ALL
+  SELECT 'r' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/r/simple.r') WHERE depth = 0
+  UNION ALL
+  SELECT 'zig' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/zig/sample.zig') WHERE depth = 0
+  UNION ALL
+  SELECT 'lua' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/lua/simple.lua') WHERE depth = 0
+  UNION ALL
+  SELECT 'hcl' AS lang, type, semantic_type, name, depth
+  FROM read_ast('test/data/hcl/simple.tf') WHERE depth = 0
+) TO 'workspace/design/audit-reports/root_nodes.csv' WITH (HEADER, DELIMITER ',');
+
+# Export keyword-named definitions (potential noise)
+statement ok
+COPY (
+  SELECT 'python' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/python/simple.py')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('def', 'class', 'lambda', 'function', 'import', 'from')
+  UNION ALL
+  SELECT 'javascript' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/javascript/simple.js')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('function', 'class', 'const', 'let', 'var', 'import', 'export')
+  UNION ALL
+  SELECT 'go' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/go/simple.go')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('func', 'var', 'const', 'type', 'package', 'import')
+  UNION ALL
+  SELECT 'rust' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/rust/simple.rs')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('fn', 'struct', 'impl', 'enum', 'trait', 'mod', 'use', 'let', 'pub')
+  UNION ALL
+  SELECT 'c' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/c/imports.c')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('struct', 'enum', 'typedef', 'int', 'void', 'char')
+  UNION ALL
+  SELECT 'cpp' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/cpp/simple.cpp')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('struct', 'class', 'enum', 'namespace', 'void', 'int')
+  UNION ALL
+  SELECT 'csharp' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/csharp/simple.cs')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('class', 'struct', 'interface', 'enum', 'namespace', 'void', 'int')
+  UNION ALL
+  SELECT 'kotlin' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/kotlin/simple.kt')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('fun', 'class', 'val', 'var', 'object')
+  UNION ALL
+  SELECT 'swift' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/swift/simple.swift')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('func', 'class', 'struct', 'enum', 'protocol', 'var', 'let')
+  UNION ALL
+  SELECT 'ruby' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/ruby/simple.rb')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('def', 'class', 'module', 'end')
+  UNION ALL
+  SELECT 'php' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/php/test.php')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('function', 'class', 'namespace', 'public', 'private', 'protected')
+  UNION ALL
+  SELECT 'bash' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/bash/simple.sh')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('function', 'local', 'export', 'declare')
+  UNION ALL
+  SELECT 'r' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/r/simple.r')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('function', 'library', 'require')
+  UNION ALL
+  SELECT 'zig' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/zig/sample.zig')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('fn', 'const', 'var', 'pub')
+  UNION ALL
+  SELECT 'dart' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/dart/sample.dart')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('class', 'void', 'var', 'final', 'const', 'int', 'String')
+  UNION ALL
+  SELECT 'lua' AS lang, type, semantic_type, name, LEFT(peek, 60) AS peek
+  FROM read_ast('test/data/lua/simple.lua')
+  WHERE semantic_type LIKE 'DEFINITION%' AND name IN ('function', 'local', 'end')
+) TO 'workspace/design/audit-reports/keyword_definitions.csv' WITH (HEADER, DELIMITER ',');
+
+# Export child node analysis for Go import_spec
+statement ok
+COPY (
+  SELECT 'go_import_children' AS analysis, a.type AS parent_type, b.type AS child_type, b.name AS child_name, LEFT(b.peek, 60) AS child_peek
+  FROM read_ast('test/data/go/simple.go') a
+  JOIN read_ast('test/data/go/simple.go') b ON b.parent_id = a.node_id
+  WHERE a.type = 'import_spec'
+  ORDER BY a.node_id, b.node_id
+) TO 'workspace/design/audit-reports/go_import_children.csv' WITH (HEADER, DELIMITER ',');

--- a/test/sql/audit/name_extraction_flags.test
+++ b/test/sql/audit/name_extraction_flags.test
@@ -1,0 +1,167 @@
+# name: test/sql/audit/name_extraction_flags.test
+# description: Audit flags and keyword filtering
+# group: [sitting_duck_audit]
+
+require sitting_duck
+
+# Export definitions WITH flags to see if keywords have IS_SYNTAX_ONLY set
+statement ok
+COPY (
+  SELECT 'rust' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/rust/simple.rs')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'kotlin' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/kotlin/simple.kt')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'swift' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/swift/simple.swift')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'bash' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/bash/simple.sh')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'zig' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/zig/sample.zig')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'lua' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/lua/simple.lua')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'go' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/go/simple.go')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'python' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/python/simple.py')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'javascript' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/javascript/simple.js')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'c' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/c/imports.c')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'cpp' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/cpp/simple.cpp')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'csharp' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/csharp/simple.cs')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'ruby' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/ruby/simple.rb')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'php' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/php/test.php')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'dart' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/dart/sample.dart')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'r' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/r/simple.r')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+  UNION ALL
+  SELECT 'hcl' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/hcl/simple.tf')
+  WHERE semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%'
+) TO 'workspace/design/audit-reports/definitions_with_flags.csv' WITH (HEADER, DELIMITER ',');
+
+# Now check: which definitions survive is_construct filtering?
+# is_construct should filter out IS_SYNTAX_ONLY (flag & 0x01 == 0)
+statement ok
+COPY (
+  SELECT 'rust' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/rust/simple.rs')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'kotlin' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/kotlin/simple.kt')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'swift' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/swift/simple.swift')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'bash' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/bash/simple.sh')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'zig' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/zig/sample.zig')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'lua' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/lua/simple.lua')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'go' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/go/simple.go')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'python' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/python/simple.py')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'javascript' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/javascript/simple.js')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'c' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/c/imports.c')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'cpp' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/cpp/simple.cpp')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'csharp' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/csharp/simple.cs')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'ruby' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/ruby/simple.rb')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'php' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/php/test.php')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'dart' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/dart/sample.dart')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'r' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/r/simple.r')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+  UNION ALL
+  SELECT 'hcl' AS lang, type, semantic_type, name, flags, LEFT(peek, 80) AS peek
+  FROM read_ast('test/data/hcl/simple.tf')
+  WHERE (semantic_type LIKE 'DEFINITION%' OR semantic_type LIKE 'EXTERNAL%')
+    AND (flags & 1) = 0
+) TO 'workspace/design/audit-reports/filtered_definitions.csv' WITH (HEADER, DELIMITER ',');

--- a/test/sql/languages/bash_language_support.test
+++ b/test/sql/languages/bash_language_support.test
@@ -128,3 +128,82 @@ SELECT COUNT(*) FROM read_ast('test/data/bash/simple.sh', 'bash')
 WHERE type IN ('array', 'subscript');
 ----
 14
+
+# Test 14: Function definition name extraction
+# =============================================
+# Verifies that all 5 function names are correctly extracted
+
+query IT
+SELECT name, type FROM read_ast('test/data/bash/simple.sh', 'bash')
+WHERE type = 'function_definition'
+ORDER BY start_line;
+----
+show_usage	function_definition
+process_file	function_definition
+run_system_checks	function_definition
+analyze_files	function_definition
+main	function_definition
+
+# Test 15: Variable assignment name extraction
+# =============================================
+# Verifies that variable_assignment nodes have their variable names extracted
+
+query I
+SELECT COUNT(*) FROM read_ast('test/data/bash/simple.sh', 'bash')
+WHERE type = 'variable_assignment' AND name != '';
+----
+27
+
+# Test 16: Declaration command name extraction
+# =============================================
+# Verifies that declare/local/readonly commands extract the variable name,
+# handling both nested variable_assignment and bare declarations with flags
+
+query IT
+SELECT name, type FROM read_ast('test/data/bash/simple.sh', 'bash')
+WHERE type = 'declaration_command'
+ORDER BY start_line;
+----
+FILES_PROCESSED	declaration_command
+CONFIG_MAP	declaration_command
+file_path	declaration_command
+backup_dir	declaration_command
+counter	declaration_command
+file_size	declaration_command
+line_count	declaration_command
+filename	declaration_command
+extension	declaration_command
+basename	declaration_command
+system_ok	declaration_command
+git_version	declaration_command
+disk_usage	declaration_command
+pattern	declaration_command
+files	declaration_command
+verbose	declaration_command
+config_file	declaration_command
+input_files	declaration_command
+
+# Test 17: Redirect semantic types
+# =================================
+# Redirects should be EXECUTION_STATEMENT, not EXTERNAL_IMPORT
+
+query IT
+SELECT DISTINCT semantic_type, type FROM read_ast('test/data/bash/simple.sh', 'bash')
+WHERE type IN ('file_redirect', 'heredoc_redirect')
+ORDER BY type;
+----
+EXECUTION_STATEMENT	file_redirect
+EXECUTION_STATEMENT	heredoc_redirect
+
+# Test 18: Minimal empty names for definition nodes
+# ==================================================
+# Nearly all definition nodes should have names extracted.
+# The one remaining case is `counter=$((counter + 1))` where the
+# variable_assignment contains an arithmetic expansion without a
+# variable_name child node.
+
+query I
+SELECT COUNT(*) FROM read_ast('test/data/bash/simple.sh', 'bash')
+WHERE semantic_type LIKE 'DEFINITION%' AND type NOT IN ('program') AND name = '';
+----
+1

--- a/test/sql/languages/zig_language_support.test
+++ b/test/sql/languages/zig_language_support.test
@@ -171,3 +171,55 @@ WHERE type = 'comptime_statement';
 ----
 1
 
+# Test 25: Struct name extraction
+query I
+SELECT name FROM read_ast('test/data/zig/sample.zig')
+WHERE type = 'struct_declaration' AND name != ''
+ORDER BY name;
+----
+Point
+
+# Test 26: Enum name extraction
+query I
+SELECT name FROM read_ast('test/data/zig/sample.zig')
+WHERE type = 'enum_declaration' AND name != '';
+----
+Color
+
+# Test 27: Union name extraction
+query I
+SELECT name FROM read_ast('test/data/zig/sample.zig')
+WHERE type = 'union_declaration' AND name != '';
+----
+Shape
+
+# Test 28: Error set name extraction
+query I
+SELECT name FROM read_ast('test/data/zig/sample.zig')
+WHERE type = 'error_set_declaration' AND name != '';
+----
+FileError
+
+# Test 29: Test declaration name extraction
+query I
+SELECT name FROM read_ast('test/data/zig/sample.zig')
+WHERE type = 'test_declaration' AND name != ''
+ORDER BY name;
+----
+basic test
+point operations
+
+# Test 30: Function name extraction still works
+query I
+SELECT name FROM read_ast('test/data/zig/sample.zig')
+WHERE type = 'function_declaration'
+ORDER BY name;
+----
+add
+area
+asyncOperation
+distanceFromOrigin
+main
+swap
+toRGB
+

--- a/test/sql/name_extraction/bash_php_find_identifier.test
+++ b/test/sql/name_extraction/bash_php_find_identifier.test
@@ -1,0 +1,101 @@
+# name: test/sql/name_extraction/bash_php_find_identifier.test
+# description: Test FIND_IDENTIFIER extracts variable_name and word child types (#28)
+# group: [name_extraction]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# FIND_IDENTIFIER fix: variable_name and word child node types
+# =============================================================================
+#
+# The FIND_IDENTIFIER extraction strategy was missing two tree-sitter node
+# types used by Bash and PHP grammars:
+#   - variable_name: Bash variable assignments, PHP parameters
+#   - word: Bash function names
+#
+# This caused definition nodes to produce NULL/empty names.
+#
+# Issue: https://github.com/teaguesterling/sitting_duck/issues/28
+# =============================================================================
+
+# =============================================================================
+# BASH: function_definition (uses "word" child type)
+# =============================================================================
+
+# Test: All 5 bash function definitions now have non-NULL names
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/bash/simple.sh', context := 'native')
+WHERE type = 'function_definition' AND name IS NOT NULL AND name != '';
+----
+5
+
+# Test: Specific bash function names are extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/bash/simple.sh', context := 'native')
+WHERE type = 'function_definition'
+ORDER BY start_line;
+----
+function_definition	show_usage
+function_definition	process_file
+function_definition	run_system_checks
+function_definition	analyze_files
+function_definition	main
+
+# =============================================================================
+# BASH: variable_assignment (uses "variable_name" child type)
+# =============================================================================
+
+# Test: 27 of 28 bash variable assignments have names
+# (1 uses subscript syntax: CONFIG_MAP["$basename"]="$file_size" where
+#  variable_name is nested inside a subscript node, not a direct child)
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/bash/simple.sh', context := 'native')
+WHERE type = 'variable_assignment' AND name IS NOT NULL AND name != '';
+----
+27
+
+# Test: Global variable names are extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/bash/simple.sh', context := 'native')
+WHERE type = 'variable_assignment' AND depth = 1
+ORDER BY start_line;
+----
+variable_assignment	SCRIPT_NAME
+variable_assignment	VERSION
+variable_assignment	DEBUG
+
+# =============================================================================
+# PHP: simple_parameter (uses "variable_name" child type)
+# =============================================================================
+
+# Test: All 9 PHP simple_parameter nodes now have non-NULL names
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'simple_parameter' AND name IS NOT NULL AND name != '';
+----
+9
+
+# Test: PHP parameter names are extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'simple_parameter'
+ORDER BY start_line, name;
+----
+simple_parameter	$name
+simple_parameter	$input
+simple_parameter	$items
+simple_parameter	$item
+simple_parameter	$data
+simple_parameter	$message
+simple_parameter	$input
+simple_parameter	$a
+simple_parameter	$b

--- a/tracker/bugs/013-find-identifier-missing-types.md
+++ b/tracker/bugs/013-find-identifier-missing-types.md
@@ -1,0 +1,49 @@
+# FIND_IDENTIFIER Missing variable_name and word Child Types
+
+**Status:** Resolved
+**Priority:** Medium
+**GitHub Issue:** #28
+
+## Problem
+
+The `FIND_IDENTIFIER` extraction strategy in `ExtractByStrategy()` searches a fixed list of child node types to extract names from AST definition nodes. However, two tree-sitter node types were missing from this list:
+
+- **`variable_name`**: Used by Bash (variable assignments) and PHP (parameters)
+- **`word`**: Used by Bash (function names)
+
+## Affected Node Types
+
+| Language | Node Type | Fixed | Count | Example |
+|----------|-----------|-------|-------|---------|
+| Bash | `function_definition` | Yes | 5 | `function show_usage() {}` → `show_usage` |
+| Bash | `variable_assignment` | 27/28 | 27 | `SCRIPT_NAME="simple.sh"` → `SCRIPT_NAME` |
+| PHP | `simple_parameter` | Yes | 9 | `string $name` → `$name` |
+| PHP | `property_declaration` | No | 3 | Needs deeper fix (see Known Remaining) |
+
+## Known Remaining
+
+- **Bash subscript assignments** (1 instance): `CONFIG_MAP["$basename"]="$file_size"` — the `variable_name` is nested inside a `subscript` node, not a direct child of `variable_assignment`. `FindChildByType` only searches direct children.
+- **PHP `property_declaration`** (3 instances): `private string $name;` — the `variable_name` is nested inside a `property_element` child, not a direct child of `property_declaration`. Fixing this requires either a recursive search or a custom extraction strategy.
+
+## Fix
+
+Added two `FindChildByType` lookups to the `FIND_IDENTIFIER` case in `src/language_adapter.cpp`, after the existing identifier type checks:
+
+```cpp
+if (result.empty()) {
+    result = FindChildByType(node, content, "variable_name");
+}
+if (result.empty()) {
+    result = FindChildByType(node, content, "word");
+}
+```
+
+No changes to `*_types.def` or `*_adapter.cpp` files were needed since these node types were already configured to use `FIND_IDENTIFIER`.
+
+## Test Coverage
+
+- `test/sql/name_extraction/bash_php_find_identifier.test`: Verifies name extraction for Bash function_definition, variable_assignment, and PHP simple_parameter
+
+## Discovery
+
+Identified by the name extraction audit (master-report.md, Issue 1 / Phase 1 Quick Win).

--- a/workspace/design/audit-reports/master-report.md
+++ b/workspace/design/audit-reports/master-report.md
@@ -1,0 +1,324 @@
+# Name Extraction Audit -- Master Report
+
+**Date:** 2026-02-27
+**Scope:** All 17 languages with test data, plus TypeScript (shared JS config)
+**Total definition nodes audited:** ~600 (post `is_construct` filtering)
+
+---
+
+## Executive Summary
+
+The name extraction system is fundamentally sound. Keyword filtering works correctly (269 keyword-named definitions reduced to 4 legitimate survivors), root nodes are properly handled, and many languages have good extraction coverage. However, there are **~220 definition nodes producing NULL names** that should have names, spread across 14 languages. The root causes fall into three categories:
+
+1. **FIND_IDENTIFIER strategy cannot find identifiers** because tree-sitter child node types do not match the generic lookup list (affects Swift properties, Bash variables, Dart locals, Kotlin properties, Lua variables, HCL blocks/objects, C# variables, PHP parameters).
+2. **FIND_IDENTIFIER searches only immediate children** but the identifier is nested deeper in the tree (affects C++ `function_definition` via `function_declarator`, Bash `declaration_command` where the variable_name is inside a nested `variable_assignment`).
+3. **CUSTOM strategy has incomplete handling** for certain node types (Swift `init_declaration`/`deinit_declaration` missing from custom switch, HCL `block` with no labels like `locals {}`).
+4. **Over-extraction** in Bash: `heredoc_redirect` and `file_redirect` use NODE_TEXT which dumps the entire redirect content as the name.
+
+## Methodology
+
+1. Query results from `read_ast()` across all test data files, filtering for DEFINITION_* semantic types
+2. Post-filter through `is_construct()` to match what users see
+3. Cross-reference NULL-named definitions against:
+   - `*_types.def` configs (extraction strategy configured)
+   - `*_adapter.cpp` custom logic (CUSTOM strategy handlers)
+   - `language_adapter.cpp` generic `ExtractByStrategy()` (FIND_IDENTIFIER fallback chain)
+4. Identify root cause per node type by tracing the extraction path
+
+---
+
+## Findings by Severity
+
+### Critical: Definitions with NULL Names
+
+#### Swift (96 NULL-named definitions, 82 properly named)
+
+| Node Type | Semantic Type | Strategy | Count | Root Cause | Suggested Fix |
+|-----------|--------------|----------|-------|------------|---------------|
+| `property_declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 75 | Swift properties use `pattern` child for the variable name (e.g., `var x: Int`), not `identifier` or `simple_identifier`. FIND_IDENTIFIER searches `simple_identifier` and `identifier` but the actual name is inside a `pattern` node. The custom handler in the adapter (line 74) checks for `property_declaration` but only under the CUSTOM branch -- however the config says FIND_IDENTIFIER, not CUSTOM. | Change strategy to CUSTOM, or add `pattern` handling to FIND_IDENTIFIER, or add custom extraction for pattern-based name lookup in the adapter. |
+| `init_declaration` | DEFINITION_FUNCTION | CUSTOM | 8 | The CUSTOM handler at line 67 searches for `simple_identifier`, but Swift `init` declarations do not have a `simple_identifier` child -- the name is the keyword `init` itself. Convention should return `"init"`. | Return literal `"init"` when node type is `init_declaration` and no `simple_identifier` is found. |
+| `deinit_declaration` | DEFINITION_FUNCTION | CUSTOM | 0-1 | Same as `init` -- should return `"deinit"`. | Return literal `"deinit"` for `deinit_declaration`. |
+| `subscript_declaration` | DEFINITION_FUNCTION | CUSTOM | 0-1 | Should return `"subscript"` as the conventional name. | Return literal `"subscript"` for `subscript_declaration`. |
+
+**Root Cause Analysis (Swift `property_declaration`):** The config at line 172 uses `FIND_IDENTIFIER`, which in `ExtractByStrategy()` tries child types in order: `identifier`, `property_identifier`, `field_identifier`, `qualified_identifier`, `name`, `simple_identifier`, `type_identifier`. However, Swift's tree-sitter grammar wraps the property name inside a `pattern` node, not any of these types. The adapter has dead code at line 74 that handles `property_declaration` under the CUSTOM branch, but the config says FIND_IDENTIFIER, so that code is never reached.
+
+**Proposed Fix:** Change `property_declaration` strategy from `FIND_IDENTIFIER` to `CUSTOM` in `swift_types.def`. This activates the existing adapter code at line 74. Alternatively, the CUSTOM handler needs to be updated to look deeper into `pattern` children for a `simple_identifier`.
+
+---
+
+#### Bash (51 NULL-named definitions, 15 properly named)
+
+| Node Type | Semantic Type | Strategy | Count | Root Cause | Suggested Fix |
+|-----------|--------------|----------|-------|------------|---------------|
+| `variable_assignment` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 28 | Bash variable assignments use `variable_name` child, not `identifier`. FIND_IDENTIFIER searches for `identifier` first, but Bash's tree-sitter grammar uses `variable_name` as the child type. The adapter fallback (line 73-83) handles this correctly, but only when `config` is NULL (unknown type). Since the config IS found, it uses `ExtractByStrategy` which fails. | Add `variable_name` to the FIND_IDENTIFIER fallback chain, OR change strategy to CUSTOM and implement handler. |
+| `declaration_command` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 18 | `declare -a FILES_PROCESSED` -- the variable name is inside a nested `variable_assignment` child, not a direct `identifier` child. FIND_IDENTIFIER only searches immediate children. | Needs CUSTOM strategy that looks inside child `variable_assignment` for `variable_name`, or recurses one level. |
+| `function_definition` | DEFINITION_FUNCTION | FIND_IDENTIFIER | 5 | Bash function names use `word` child type (e.g., `function name {}`). FIND_IDENTIFIER does not search for `word`. The adapter fallback at line 69-72 handles this correctly for unconfigured types, but since there IS a config, the fallback is never reached. | Add `word` to FIND_IDENTIFIER chain, or change to CUSTOM. |
+
+**Over-extraction (Bash):**
+
+| Node Type | Semantic Type | Strategy | Count | Issue |
+|-----------|--------------|----------|-------|-------|
+| `heredoc_redirect` | EXTERNAL_IMPORT | NODE_TEXT | 1 | Returns entire heredoc content as name: `"<< EOF\nUsage: $0..."`. Should extract just the delimiter or be set to NONE. |
+| `file_redirect` | EXTERNAL_IMPORT | NODE_TEXT | 1 | Returns redirect syntax as name: `'< "$file_path"'`. Should extract the file path or be set to NONE. |
+
+**Semantic Type Issue:** `heredoc_redirect` and `file_redirect` are classified as `EXTERNAL_IMPORT`, which is semantically incorrect. These are I/O operations, not imports. Should be `EXECUTION_STATEMENT` or similar.
+
+---
+
+#### Dart (45 NULL-named definitions, 88 properly named)
+
+| Node Type | Semantic Type | Strategy | Count | Root Cause | Suggested Fix |
+|-----------|--------------|----------|-------|------------|---------------|
+| `local_variable_declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 23 | Dart local variables wrap the name in a nested structure. `final dx = x - other.x;` has tree structure where `identifier` is not an immediate child of `local_variable_declaration`. | Needs investigation of Dart tree-sitter grammar structure; likely requires CUSTOM or deeper traversal. |
+| `method_signature` | DEFINITION_FUNCTION | FIND_IDENTIFIER | 12 | `factory Point.fromMap(...)` -- the name may be in a `constructor_signature` or `method_signature` wrapper, and FIND_IDENTIFIER cannot find it at the immediate child level. | Needs CUSTOM extraction for Dart method signatures. |
+| `declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 5 | Generic `declaration` node where identifier is nested. | Investigate Dart grammar tree structure. |
+| `formal_parameter` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 5 | Parameters where `identifier` is not immediate child. | Check if `simple_identifier` or `name` is the right child type. |
+| `record_field` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 4 | Dart 3.0+ record fields. | Needs investigation of record grammar. |
+
+---
+
+#### Kotlin (15 NULL-named definitions, 29 properly named)
+
+| Node Type | Semantic Type | Strategy | Count | Root Cause | Suggested Fix |
+|-----------|--------------|----------|-------|------------|---------------|
+| `property_declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 12 | FIND_IDENTIFIER searches for `identifier`, `simple_identifier` etc. but Kotlin `property_declaration` wraps the name in a `variable_declaration` child which then contains `simple_identifier`. The search is only one level deep. | Change to CUSTOM (the existing custom handler at line 66 matches `*declaration*` patterns and would handle this) or recursively search. |
+| `primary_constructor` | DEFINITION_FUNCTION | NONE | 3 | Strategy is explicitly NONE. The constructor has no independent name, but the parent class name could be used. | Arguably correct -- constructor name IS the class name. Consider returning parent class name, or leave as legitimate NULL. |
+
+**Note:** The Kotlin adapter's CUSTOM handler (line 66) uses `node_type.find("declaration")` which would match `property_declaration`, but the config uses `FIND_IDENTIFIER` not `CUSTOM`, so the custom handler is never reached. Changing the strategy would fix this.
+
+---
+
+#### Lua (12 NULL-named definitions, 13 properly named)
+
+| Node Type | Semantic Type | Strategy | Count | Root Cause | Suggested Fix |
+|-----------|--------------|----------|-------|------------|---------------|
+| `variable_declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 6 | Lua global variable declarations (`M = {}`) have the identifier inside a `variable_list` child, not as a direct child. FIND_IDENTIFIER only checks immediate children. | Add CUSTOM handling or recursive search. |
+| `local_variable_declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 6 | Same issue: `local M = {}` wraps identifier in a nested structure. | Same fix needed. |
+
+---
+
+#### C++ (11 NULL-named definitions, 46 properly named)
+
+| Node Type | Semantic Type | Strategy | Count | Root Cause | Suggested Fix |
+|-----------|--------------|----------|-------|------------|---------------|
+| `function_definition` | DEFINITION_FUNCTION | FIND_QUALIFIED_IDENTIFIER | 6 | The FIND_QUALIFIED_IDENTIFIER strategy calls `ExtractQualifiedIdentifierName()` which looks for `function_declarator` children. Likely failing for certain function patterns (templated, operator overloads, or destructor definitions). | Investigate which specific C++ functions fail. The existing `ExtractCppCustomName` has good logic -- consider routing through CUSTOM. |
+| `declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 5 | C++ `declaration` nodes can have deeply nested structures (e.g., `const auto& x = expr;` where identifier is inside an `init_declarator` inside a `declarator`). FIND_IDENTIFIER only checks immediate children. | The FIND_IN_DECLARATOR strategy exists but is not used for `declaration`. Consider switching. |
+
+---
+
+#### HCL (18 NULL-named definitions, 51 properly named)
+
+| Node Type | Semantic Type | Strategy | Count | Root Cause | Suggested Fix |
+|-----------|--------------|----------|-------|------------|---------------|
+| `object_elem` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 14 | HCL `object_elem` uses an `expression` child for the key, which wraps a `variable_expr` which wraps an `identifier`. Three levels deep -- FIND_IDENTIFIER only checks one. | Needs CUSTOM extraction or multi-level search. |
+| `block` | DEFINITION_CLASS | CUSTOM | 4 | Blocks like `locals {}` have no labels -- the CUSTOM handler correctly returns empty string for unlabeled blocks. This is partially legitimate (no label = no name), but could return the block type (`locals`, `terraform`, etc.) as a fallback. | Consider returning the block type identifier when no labels exist. |
+
+---
+
+#### Other Languages (lower count)
+
+| Language | Node Type | Semantic Type | Strategy | Count | Root Cause |
+|----------|-----------|--------------|----------|-------|------------|
+| C# | `variable_declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 8 | C# `variable_declaration` nests the name inside a `variable_declarator` child. Same depth issue. |
+| C# | `using_directive` | EXTERNAL_IMPORT | FIND_IDENTIFIER | 3 | Using directives use `qualified_name` or `name` child, not bare `identifier`. |
+| PHP | `simple_parameter` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 8 | PHP parameters use `variable_name` (with `$` prefix) child, not `identifier`. FIND_IDENTIFIER searches `name` (which PHP uses for class/function names) but `variable_name` for variables. |
+| PHP | `property_declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 4 | Same issue: PHP property names are `variable_name` nodes, not `identifier`. |
+| JS | `lexical_declaration` | DEFINITION_VARIABLE | FIND_IDENTIFIER | 7 | `const calc = new Calculator();` -- the name `calc` is inside a `variable_declarator` child, not a direct `identifier` child. |
+| Zig | `struct_declaration` | DEFINITION_CLASS | FIND_IDENTIFIER | 2 | Zig uses `const S = struct {}` pattern. The name `S` is in the parent `variable_declaration`, not inside `struct_declaration` itself. |
+| Zig | `test_declaration` | DEFINITION_FUNCTION | FIND_IDENTIFIER | 2 | `test "name" {}` -- the name is a `string` child, not an `identifier`. |
+| Zig | `enum_declaration` | DEFINITION_CLASS | FIND_IDENTIFIER | 1 | Same as struct: name is in parent variable_declaration. |
+| Zig | `union_declaration` | DEFINITION_CLASS | FIND_IDENTIFIER | 1 | Same pattern. |
+
+---
+
+### Low: Over-Extracted Names
+
+Only 2 cases found, both in Bash:
+
+1. **`heredoc_redirect`** with `NODE_TEXT` strategy: Returns entire heredoc content including multi-line body
+2. **`file_redirect`** with `NODE_TEXT` strategy: Returns redirect operator plus filename
+
+Both should either use `NONE` or extract only the specific file/delimiter token.
+
+Additionally, both are semantically misclassified as `EXTERNAL_IMPORT` when they are actually I/O operations.
+
+---
+
+### Informational: Legitimate NULL Names
+
+The following produce NULL names by design (anonymous/unnamed constructs):
+
+| Language | Node Type | Count | Reason |
+|----------|-----------|-------|--------|
+| Swift | `lambda_literal` | 13 | Anonymous closures `{ params in body }` |
+| Kotlin | `lambda_literal`, `anonymous_function` | 3+ | Anonymous lambdas and functions |
+| JS | `arrow_function` | 3+ | Anonymous arrow functions `() => {}` |
+| JS | `function_expression` | 2+ | Anonymous function expressions |
+| C# | `lambda_expression` | 2+ | Anonymous lambdas `(x) => x * 2` |
+| Lua | `function_definition` | 2+ | Anonymous function values |
+| Kotlin | `primary_constructor` | 3 | Constructor name is implicitly the class name |
+
+These are correctly producing empty names via `FIND_ASSIGNMENT_TARGET` (which returns empty when not in an assignment context) or via `NONE` strategy.
+
+---
+
+### Informational: Working Correctly
+
+**Keyword filtering:** 269 keyword-typed definition nodes in raw data, only 4 pass `is_construct()` filtering. All 4 are legitimate:
+- HCL `type` attribute (a valid HCL attribute named "type")
+- Lua `init` method (a legitimate method name that happens to be a keyword in other contexts)
+
+**Root nodes:** All 17 languages produce root nodes with `DEFINITION_MODULE` semantic type and empty names, which is correct behavior. R uses `ORGANIZATION_CONTAINER` instead -- minor inconsistency but not a bug.
+
+**Languages with strong extraction:**
+- Dart: 88 properly named definitions
+- Swift: 82 properly named definitions
+- HCL: 51 properly named definitions
+- C++: 46 properly named definitions
+- Zig: 46 properly named definitions
+- C#: 39 properly named definitions
+- Rust: 32 properly named definitions
+- Kotlin: 29 properly named definitions
+
+---
+
+## Root Cause Analysis: Systematic Patterns
+
+### Pattern 1: FIND_IDENTIFIER Depth Limitation (Most Common)
+
+`FIND_IDENTIFIER` only searches **immediate children** via `FindChildByType()`. Many tree-sitter grammars wrap identifiers inside intermediate nodes:
+
+```
+variable_declaration          <-- FIND_IDENTIFIER searches here
+  variable_declarator         <-- but identifier is here
+    identifier "myVar"        <-- actual name
+```
+
+**Affected:** JS `lexical_declaration`, C# `variable_declaration`, Kotlin `property_declaration`, Lua `variable_declaration`/`local_variable_declaration`, HCL `object_elem`, C++ `declaration`
+
+**Potential Fix:** Create a `FIND_IDENTIFIER_RECURSIVE` strategy or add common intermediate node traversal to `FIND_IDENTIFIER`.
+
+### Pattern 2: Language-Specific Child Type Names
+
+Different tree-sitter grammars use different node type names for identifiers:
+
+| Grammar | Identifier Node Type |
+|---------|---------------------|
+| Most languages | `identifier` |
+| Swift | `simple_identifier`, `pattern` |
+| Bash | `variable_name`, `word` |
+| PHP | `variable_name`, `name` |
+| Kotlin | `simple_identifier` |
+| Zig | `identifier` (but names are in parent) |
+
+`FIND_IDENTIFIER` covers `identifier`, `simple_identifier`, `name`, `property_identifier`, `field_identifier`, `qualified_identifier`, `type_identifier`, `operator`, `constant`, `setter`. Missing: `variable_name`, `word`, `pattern`.
+
+**Potential Fix:** Add `variable_name`, `word` to `FIND_IDENTIFIER`. For `pattern`, consider adding or using CUSTOM.
+
+### Pattern 3: Names in Parent Nodes (Zig-specific)
+
+Zig types (`struct_declaration`, `enum_declaration`, `union_declaration`) are assigned as values: `const MyStruct = struct {}`. The name `MyStruct` is in the parent `variable_declaration`, not in `struct_declaration` itself. `FIND_IDENTIFIER` looks inside the struct, not above it.
+
+**Potential Fix:** Use `FIND_ASSIGNMENT_TARGET` strategy for these Zig types, or create a CUSTOM handler that looks at the parent node.
+
+### Pattern 4: Dead Custom Code
+
+Several adapters have custom extraction code that is unreachable because the config uses a generic strategy instead of CUSTOM:
+
+- **Swift adapter** lines 74-75: Handles `property_declaration` and `variable_declaration` with `FindChildByType(node, content, "pattern")` -- but config says `FIND_IDENTIFIER`
+- **Bash adapter** lines 69-83: Handles `function_definition` (word), `variable_assignment` (variable_name) -- but config says `FIND_IDENTIFIER`
+- **Kotlin adapter** lines 66-74: Matches any `*declaration*` pattern -- but config says `FIND_IDENTIFIER`
+
+---
+
+## Suggested GitHub Issues
+
+### Issue 1: Fix FIND_IDENTIFIER to support additional child types
+**Priority:** High
+**Scope:** `src/language_adapter.cpp` `ExtractByStrategy()`
+**Estimate:** Small change
+
+Add `variable_name` and `word` to the `FIND_IDENTIFIER` fallback chain. This directly fixes:
+- Bash `variable_assignment` (28 instances)
+- Bash `function_definition` (5 instances)
+- PHP `simple_parameter` (8 instances)
+- PHP `property_declaration` (4 instances)
+
+### Issue 2: Activate dead custom extraction code in Swift, Bash, Kotlin adapters
+**Priority:** High
+**Scope:** `swift_types.def`, `kotlin_types.def`
+**Estimate:** Small config change + testing
+
+Change extraction strategy from `FIND_IDENTIFIER` to `CUSTOM` for:
+- Swift `property_declaration` (75 instances) -- existing custom code handles this
+- Kotlin `property_declaration` (12 instances) -- existing custom code handles this
+
+For Swift `init_declaration` (8 instances), add `return "init"` fallback when `simple_identifier` is not found in the CUSTOM handler.
+
+### Issue 3: Handle nested identifier patterns (depth > 1)
+**Priority:** Medium
+**Scope:** Multiple languages
+**Estimate:** Medium effort
+
+Create a `FIND_IDENTIFIER_DEEP` strategy or enhance FIND_IDENTIFIER to optionally search common intermediate wrapper nodes (`variable_declarator`, `init_declarator`, `variable_list`, `variable_assignment`). This fixes:
+- JS `lexical_declaration` (7 instances)
+- C# `variable_declaration` (8 instances)
+- Lua `variable_declaration` / `local_variable_declaration` (12 instances)
+- HCL `object_elem` (14 instances)
+- Bash `declaration_command` (18 instances)
+- Dart `local_variable_declaration` (23 instances)
+- C++ `declaration` (5 instances)
+
+### Issue 4: Fix Zig type definitions to extract names from parent
+**Priority:** Medium
+**Scope:** `zig_types.def`
+**Estimate:** Small
+
+Zig `struct_declaration`, `enum_declaration`, `union_declaration` should use `FIND_ASSIGNMENT_TARGET` instead of `FIND_IDENTIFIER`, since names are assigned via `const Name = struct {}`.
+
+Also fix `test_declaration` -- its name is a string literal child, not an identifier. Needs CUSTOM handling.
+
+### Issue 5: Fix Bash redirect semantic types and over-extraction
+**Priority:** Low
+**Scope:** `bash_types.def`
+**Estimate:** Small
+
+- Change `heredoc_redirect` and `file_redirect` from `EXTERNAL_IMPORT` to `EXECUTION_STATEMENT` or `COMPUTATION_CALL`
+- Change their extraction strategy from `NODE_TEXT` to `NONE` (or extract just the delimiter/path)
+
+---
+
+## Remediation Plan
+
+### Phase 1: Quick Wins (fixes ~120 NULL names)
+1. **Add `variable_name` and `word` to FIND_IDENTIFIER** in `language_adapter.cpp`
+2. **Switch Swift `property_declaration` to CUSTOM** in `swift_types.def`
+3. **Add `init`/`deinit`/`subscript` literal name fallbacks** in `swift_adapter.cpp`
+4. **Switch Zig type declarations to FIND_ASSIGNMENT_TARGET** in `zig_types.def`
+5. **Fix Bash redirect semantics and over-extraction** in `bash_types.def`
+
+### Phase 2: Depth Enhancement (fixes ~80 more NULL names)
+1. **Implement FIND_IDENTIFIER_DEEP or enhance FIND_IDENTIFIER** with common intermediate node traversal
+2. **Apply to:** JS `lexical_declaration`, C# `variable_declaration`, Lua variables, HCL `object_elem`, Bash `declaration_command`, Dart `local_variable_declaration`, C++ `declaration`
+
+### Phase 3: Language-Specific Custom Handlers (remaining ~20)
+1. **Dart method_signature, formal_parameter, record_field** -- investigate grammar structure, add CUSTOM handlers
+2. **HCL labelless blocks** -- decide whether to return block type as name
+3. **C++ complex function definitions** -- investigate which patterns fail FIND_QUALIFIED_IDENTIFIER
+4. **C# using_directive** -- may need to search for `qualified_name` in addition to current search set
+
+---
+
+## Appendix: Extraction Strategy Reference
+
+| Strategy | Behavior | Used By |
+|----------|----------|---------|
+| `NONE` | Returns empty string | Root nodes, anonymous constructs |
+| `NODE_TEXT` | Returns full text of node | Literals, keywords |
+| `FIND_IDENTIFIER` | Searches immediate children for common identifier types | Most definition nodes |
+| `FIND_QUALIFIED_IDENTIFIER` | Looks for qualified names (C++ `Ns::Name`) | C++ function_definition |
+| `FIND_IN_DECLARATOR` | Looks inside declarator children | C/C++ specific |
+| `FIND_ASSIGNMENT_TARGET` | Looks at parent for assignment LHS | Lambdas, anonymous functions |
+| `FIND_CALL_TARGET` | Extracts function/method name from call | Call expressions |
+| `FIND_PROPERTY` | Searches for property_identifier child | Property access |
+| `CUSTOM` | Routes to adapter-specific `ExtractNodeName` | Language-specific patterns |


### PR DESCRIPTION
## Summary

- **Add `variable_name` and `word` to the generic `FIND_IDENTIFIER` chain**, fixing name extraction for `function_definition` (5 names), `variable_assignment` (27 names), and also benefiting PHP `simple_parameter`/`property_declaration`
- **Switch `declaration_command` to `CUSTOM` strategy** with a 3-level fallback to handle nested variable names (e.g., `declare -a FILES_PROCESSED` where the name is 2 levels deep)
- **Reclassify redirects** (`file_redirect`, `heredoc_redirect`, `herestring_redirect`) from `EXTERNAL_IMPORT` to `EXECUTION_STATEMENT` — redirections are I/O operations, not imports
- **Remove dead fallback code** in `bash_adapter.cpp` that was never reached because configs are always found
- **Add 5 new tests** verifying function names, declaration names, variable assignment names, redirect semantic types, and remaining edge cases

Addresses the Bash findings from the name extraction audit (51 NULL-name definitions, 2 mis-typed redirects).

## Test plan

- [x] All 138 tests pass (5450 assertions), zero regressions
- [x] Function definitions: all 5 names extracted (`show_usage`, `process_file`, `run_system_checks`, `analyze_files`, `main`)
- [x] Declaration commands: all 18 names extracted, including `declare -a`/`-A` with flag-skipping
- [x] Variable assignments: 27 of 28 have non-empty names (1 edge case: arithmetic reassignment)
- [x] Redirects: `EXECUTION_STATEMENT` semantic type, no name extraction
- [x] No regressions in PHP or other languages from FIND_IDENTIFIER chain changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)