### PR TITLE
Fix FIND_IDENTIFIER to search through intermediate wrapper nodes

### DIFF
--- a/src/include/language_adapter.hpp
+++ b/src/include/language_adapter.hpp
@@ -92,6 +92,10 @@ protected:
 	string ExtractNameFromQualifiedNode(TSNode qualified_node, const string &content) const;
 	string ExtractNameFromDeclarator(TSNode node, const string &content) const;
 	string ExtractFunctionNameFromText(TSNode node, const string &content) const;
+
+	// FIND_IDENTIFIER helpers for searching through wrapper nodes
+	string FindIdentifierInChildren(TSNode node, const string &content) const;
+	string FindIdentifierInWrappers(TSNode node, const string &content, int depth) const;
 };
 
 // Python language adapter

--- a/src/language_adapter.cpp
+++ b/src/language_adapter.cpp
@@ -273,6 +273,87 @@ string LanguageAdapter::ExtractFunctionNameFromText(TSNode node, const string &c
 	return function_name;
 }
 
+string LanguageAdapter::FindIdentifierInChildren(TSNode node, const string &content) const {
+	// Try common identifier node types across languages
+	string result = FindChildByType(node, content, "identifier");
+	if (result.empty()) {
+		result = FindChildByType(node, content, "property_identifier"); // JS methods
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "field_identifier"); // Go methods
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "qualified_identifier"); // C++
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "name"); // PHP
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "simple_identifier"); // Swift, Kotlin
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "type_identifier"); // Swift types
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "operator"); // Ruby operator methods (def +, def <<, etc.)
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "constant"); // Ruby uppercase method names (def F, def M, etc.)
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "setter"); // Ruby setter methods (def name=)
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "variable_name"); // Bash vars, PHP params/properties
+	}
+	if (result.empty()) {
+		result = FindChildByType(node, content, "word"); // Bash function names
+	}
+	return result;
+}
+
+string LanguageAdapter::FindIdentifierInWrappers(TSNode node, const string &content, int depth) const {
+	if (depth <= 0) {
+		return "";
+	}
+
+	// Known intermediate wrapper types that may contain identifiers at a deeper level
+	static const vector<string> wrapper_types = {
+	    "variable_declarator",              // JS, C#, TypeScript
+	    "variable_list",                    // Lua (inside assignment_statement)
+	    "assignment_statement",             // Lua (inside variable_declaration)
+	    "init_declarator",                  // C++
+	    "initialized_variable_definition",  // Dart (inside local_variable_declaration)
+	    "expression",                       // HCL (object_elem key expressions)
+	    "variable_expr",                    // HCL (inside expression)
+	};
+
+	uint32_t child_count = ts_node_child_count(node);
+	for (uint32_t i = 0; i < child_count; i++) {
+		TSNode child = ts_node_child(node, i);
+		const char *child_type = ts_node_type(child);
+
+		for (const string &wrapper : wrapper_types) {
+			if (wrapper == child_type) {
+				// Found a wrapper — search for identifier types in its children
+				string result = FindIdentifierInChildren(child, content);
+				if (!result.empty()) {
+					return result;
+				}
+				// Recurse into the wrapper's children looking for more wrappers
+				if (depth > 1) {
+					result = FindIdentifierInWrappers(child, content, depth - 1);
+					if (!result.empty()) {
+						return result;
+					}
+				}
+				break; // Only match one wrapper type per child node
+			}
+		}
+	}
+	return "";
+}
+
 string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, ExtractionStrategy strategy) const {
 	switch (strategy) {
 	case ExtractionStrategy::NONE:
@@ -288,40 +369,9 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 		return "";
 	}
 	case ExtractionStrategy::FIND_IDENTIFIER: {
-		// Try common identifier node types across languages
-		string result = FindChildByType(node, content, "identifier");
+		string result = FindIdentifierInChildren(node, content);
 		if (result.empty()) {
-			result = FindChildByType(node, content, "property_identifier"); // JS methods
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "field_identifier"); // Go methods
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "qualified_identifier"); // C++
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "name"); // PHP
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "simple_identifier"); // Swift, Kotlin
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "type_identifier"); // Swift types
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "operator"); // Ruby operator methods (def +, def <<, etc.)
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "constant"); // Ruby uppercase method names (def F, def M, etc.)
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "setter"); // Ruby setter methods (def name=)
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "variable_name"); // Bash vars, PHP params/properties
-		}
-		if (result.empty()) {
-			result = FindChildByType(node, content, "word"); // Bash function names
+			result = FindIdentifierInWrappers(node, content, 2);
 		}
 		return result;
 	}

--- a/src/language_adapter.cpp
+++ b/src/language_adapter.cpp
@@ -317,7 +317,11 @@ string LanguageAdapter::FindIdentifierInWrappers(TSNode node, const string &cont
 		return "";
 	}
 
-	// Known intermediate wrapper types that may contain identifiers at a deeper level
+	// Known intermediate wrapper types that may contain identifiers at a deeper level.
+	// NOTE: "expression" is intentionally generic — it's currently only reached via HCL's
+	// object_elem pattern (object_elem -> expression -> variable_expr -> identifier).
+	// The depth limit and identifier-type filter constrain what gets matched, but if
+	// false positives appear in other languages, consider qualifying it further.
 	static const vector<string> wrapper_types = {
 	    "variable_declarator",              // JS, C#, TypeScript
 	    "variable_list",                    // Lua (inside assignment_statement)

--- a/test/sql/name_extraction/find_identifier_wrappers.test
+++ b/test/sql/name_extraction/find_identifier_wrappers.test
@@ -1,0 +1,209 @@
+# name: test/sql/name_extraction/find_identifier_wrappers.test
+# description: Test FIND_IDENTIFIER searches through intermediate wrapper nodes (#30)
+# group: [name_extraction]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# FIND_IDENTIFIER wrapper traversal fix
+# =============================================================================
+#
+# Many tree-sitter grammars wrap identifiers inside intermediate structural
+# nodes (declarators, lists, expressions). The FIND_IDENTIFIER strategy now
+# searches through known wrapper types when the identifier is not a direct child.
+#
+# Issue: https://github.com/teaguesterling/sitting_duck/issues/30
+# =============================================================================
+
+# =============================================================================
+# JAVASCRIPT: lexical_declaration (wrapper: variable_declarator)
+# =============================================================================
+
+# Test: All 7 JS lexical_declaration nodes have non-NULL names
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/javascript/simple.js', context := 'native')
+WHERE type = 'lexical_declaration' AND name IS NOT NULL AND name != '';
+----
+7
+
+# Test: Specific JS variable names extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/javascript/simple.js', context := 'native')
+WHERE type = 'lexical_declaration'
+ORDER BY start_line;
+----
+lexical_declaration	calc
+lexical_declaration	sum
+lexical_declaration	multiply
+lexical_declaration	person
+lexical_declaration	numbers
+lexical_declaration	doubled
+lexical_declaration	response
+
+# =============================================================================
+# C#: variable_declaration (wrapper: variable_declarator)
+# =============================================================================
+
+# Test: All 8 C# variable_declaration nodes have non-NULL names
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/csharp/simple.cs', context := 'native')
+WHERE type = 'variable_declaration' AND name IS NOT NULL AND name != '';
+----
+8
+
+# Test: Specific C# variable names extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/csharp/simple.cs', context := 'native')
+WHERE type = 'variable_declaration'
+ORDER BY start_line;
+----
+variable_declaration	_items
+variable_declaration	calc
+variable_declaration	numbers
+variable_declaration	evens
+variable_declaration	result
+variable_declaration	nullable
+variable_declaration	length
+variable_declaration	person
+
+# =============================================================================
+# LUA: variable_declaration (wrappers: assignment_statement -> variable_list)
+# =============================================================================
+
+# Test: All 12 Lua variable_declaration nodes have non-NULL names
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'variable_declaration' AND name IS NOT NULL AND name != '';
+----
+12
+
+# Test: Specific Lua variable names extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'variable_declaration'
+ORDER BY start_line;
+----
+variable_declaration	M
+variable_declaration	name
+variable_declaration	version
+variable_declaration	active
+variable_declaration	transform
+variable_declaration	config
+variable_declaration	Animal
+variable_declaration	self
+variable_declaration	results
+variable_declaration	count
+variable_declaration	co
+variable_declaration	total
+
+# =============================================================================
+# HCL: object_elem (wrappers: expression -> variable_expr)
+# =============================================================================
+
+# Test: All 14 HCL object_elem nodes have non-NULL names
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/hcl/simple.tf', context := 'native')
+WHERE type = 'object_elem' AND name IS NOT NULL AND name != '';
+----
+14
+
+# Test: Specific HCL object element names extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/hcl/simple.tf', context := 'native')
+WHERE type = 'object_elem'
+ORDER BY start_line;
+----
+object_elem	Environment
+object_elem	Team
+object_elem	ManagedBy
+object_elem	Name
+object_elem	Name
+object_elem	Name
+object_elem	port
+object_elem	protocol
+object_elem	cidr_blocks
+object_elem	port
+object_elem	protocol
+object_elem	cidr_blocks
+object_elem	source
+object_elem	version
+
+# =============================================================================
+# DART: local_variable_declaration (wrapper: initialized_variable_definition)
+# =============================================================================
+
+# Test: 21 of 23 Dart local_variable_declaration nodes have non-NULL names
+# (2 use destructuring patterns without simple identifiers)
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'local_variable_declaration' AND name IS NOT NULL AND name != '';
+----
+21
+
+# Test: Specific Dart variable names extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'local_variable_declaration' AND name IS NOT NULL AND name != ''
+ORDER BY start_line;
+----
+local_variable_declaration	dx
+local_variable_declaration	dy
+local_variable_declaration	message
+local_variable_declaration	pi
+local_variable_declaration	maxSize
+local_variable_declaration	lateVar
+local_variable_declaration	nullableString
+local_variable_declaration	nonNullable
+local_variable_declaration	i
+local_variable_declaration	numbers
+local_variable_declaration	counter
+local_variable_declaration	colorName
+local_variable_declaration	point
+local_variable_declaration	list
+local_variable_declaration	listLiteral
+local_variable_declaration	setLiteral
+local_variable_declaration	mapLiteral
+local_variable_declaration	combined
+local_variable_declaration	record
+local_variable_declaration	i
+local_variable_declaration	k
+
+# =============================================================================
+# C++: declaration (wrapper: init_declarator)
+# =============================================================================
+
+# Test: All 7 C++ declaration nodes have non-NULL names
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/cpp/simple.cpp', context := 'native')
+WHERE type = 'declaration' AND name IS NOT NULL AND name != '';
+----
+7
+
+# Test: Specific C++ variable names extracted correctly
+query TT
+SELECT type, name
+FROM read_ast('test/data/cpp/simple.cpp', context := 'native')
+WHERE type = 'declaration'
+ORDER BY start_line;
+----
+declaration	calc
+declaration	sum
+declaration	numbers
+declaration	maxInt
+declaration	maxDouble
+declaration	multiply
+declaration	product


### PR DESCRIPTION
## Summary
- Enhanced the `FIND_IDENTIFIER` extraction strategy to search through known intermediate wrapper node types when the identifier is not a direct child of the node
- Extracted the identifier search chain into `FindIdentifierInChildren()` and added `FindIdentifierInWrappers()` with depth-limited (max 2) recursive traversal through wrapper types: `variable_declarator` (JS/C#/TS), `variable_list`/`assignment_statement` (Lua), `init_declarator` (C++), `initialized_variable_definition` (Dart), `expression`/`variable_expr` (HCL)
- Fixes ~69 definition nodes that previously produced NULL names across 6 languages (JS: 7, C#: 8, Lua: 12, HCL: 14, Dart: 21, C++: 7)

Closes #30

## Test plan
- [x] New test file `find_identifier_wrappers.test` with 145 assertions covering all 6 affected languages
- [x] Existing `bash_php_find_identifier.test` passes (no regressions)
- [x] Full test suite passes: 71 test cases, 2921 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)