### PR TITLE
Fix anonymous function name inference for Dart (#41)

### DIFF
--- a/src/language_adapter.cpp
+++ b/src/language_adapter.cpp
@@ -397,16 +397,13 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 			    parent_type == "init_declarator" ||               // C++: auto name = lambda
 			    parent_type == "assignment" ||                    // Python: x = lambda
 			    parent_type == "named_expression" ||              // Python: (x := lambda)
+			    parent_type == "initialized_variable_definition" || // Dart: var name = () => ...
 			    parent_type.find("declarator") != string::npos) { // Other declarator patterns
 
-				// Look for the first child which should be the identifier
-				TSNode first_child = ts_node_child(parent, 0);
-				if (!ts_node_is_null(first_child)) {
-					string first_child_type = ts_node_type(first_child);
-					if (first_child_type == "identifier") {
-						return ExtractNodeText(first_child, content);
-					}
-				}
+				// Find identifier among parent's children
+				// In most languages (JS, Python, C++) the identifier is the first child,
+				// but in Dart initialized_variable_definition the type annotation comes first
+				return FindChildByType(parent, content, "identifier");
 			}
 		}
 		return "";

--- a/src/language_configs/dart_types.def
+++ b/src/language_configs/dart_types.def
@@ -137,13 +137,13 @@ DEF_TYPE("function_signature", DEFINITION_FUNCTION | SemanticRefinements::Functi
 DEF_TYPE("function_body", ORGANIZATION_BLOCK | SemanticRefinements::Organization::SEQUENTIAL, NONE, NONE, 0)
 
 /// @brief Function expression - anonymous function
-DEF_TYPE("function_expression", DEFINITION_FUNCTION | SemanticRefinements::Function::LAMBDA, NONE, ARROW_FUNCTION, 0)
+DEF_TYPE("function_expression", DEFINITION_FUNCTION | SemanticRefinements::Function::LAMBDA, FIND_ASSIGNMENT_TARGET, ARROW_FUNCTION, 0)
 
 /// @brief Function expression body
 DEF_TYPE("function_expression_body", ORGANIZATION_BLOCK | SemanticRefinements::Organization::SEQUENTIAL, NONE, NONE, 0)
 
 /// @brief Lambda expression - `(x) => expr`
-DEF_TYPE("lambda_expression", DEFINITION_FUNCTION | SemanticRefinements::Function::LAMBDA, NONE, ARROW_FUNCTION, 0)
+DEF_TYPE("lambda_expression", DEFINITION_FUNCTION | SemanticRefinements::Function::LAMBDA, FIND_ASSIGNMENT_TARGET, ARROW_FUNCTION, 0)
 
 /// @brief Method signature - class method declaration
 DEF_TYPE("method_signature", DEFINITION_FUNCTION | SemanticRefinements::Function::REGULAR, FIND_IDENTIFIER, FUNCTION_WITH_PARAMS, ASTNodeFlags::IS_DECLARATION_ONLY)

--- a/test/data/dart/anonymous_functions.dart
+++ b/test/data/dart/anonymous_functions.dart
@@ -1,0 +1,23 @@
+// Dart anonymous function assignment examples for testing FIND_ASSIGNMENT_TARGET
+
+void main() {
+  // Function expression assigned to variable
+  var greet = (String name) {
+    return 'Hello, $name!';
+  };
+
+  // Lambda expression assigned to variable
+  var square = (int x) => x * x;
+
+  // Function expression with final
+  final add = (int a, int b) {
+    return a + b;
+  };
+
+  // Lambda expression with type annotation
+  int Function(int) doubler = (x) => x * 2;
+
+  // Anonymous function used inline (no name expected)
+  var items = [3, 1, 2];
+  items.sort((a, b) => a.compareTo(b));
+}

--- a/test/data/python/lambdas.py
+++ b/test/data/python/lambdas.py
@@ -1,0 +1,16 @@
+# Python lambda assignment examples for testing FIND_ASSIGNMENT_TARGET
+
+# Simple lambda assigned to variable
+square = lambda x: x * x
+
+# Lambda with multiple parameters
+add = lambda x, y: x + y
+
+# Lambda with default parameter
+greet = lambda name="World": f"Hello, {name}!"
+
+# Lambda assigned with walrus operator
+result = (filtered := lambda xs: [x for x in xs if x > 0])
+
+# Lambda not assigned (used inline) - should have no name
+sorted_items = sorted([3, 1, 2], key=lambda x: x)

--- a/test/sql/name_extraction/find_assignment_target.test
+++ b/test/sql/name_extraction/find_assignment_target.test
@@ -1,0 +1,77 @@
+# name: test/sql/name_extraction/find_assignment_target.test
+# description: Test FIND_ASSIGNMENT_TARGET infers names for anonymous functions (#41)
+# group: [name_extraction]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# FIND_ASSIGNMENT_TARGET: Anonymous function name inference
+# =============================================================================
+#
+# Anonymous functions (lambdas, arrow functions, function expressions) should
+# infer their name from the assignment context, e.g.:
+#   var greet = (name) { ... };    →  name = "greet"
+#   square = lambda x: x * x      →  name = "square"
+#
+# Issue: https://github.com/teaguesterling/sitting_duck/issues/41
+# =============================================================================
+
+# =============================================================================
+# PYTHON: lambda name inference (verify existing behavior)
+# =============================================================================
+
+# Test: Python lambdas assigned to variables get names
+# (lambda nodes appear twice due to IS_KEYWORD_IF_LEAF — expression + keyword)
+query TT
+SELECT type, name
+FROM read_ast('test/data/python/lambdas.py', context := 'native')
+WHERE type = 'lambda' AND name IS NOT NULL AND name != ''
+ORDER BY start_line;
+----
+lambda	square
+lambda	add
+lambda	greet
+lambda	filtered
+
+# Test: Python lambda used inline (as argument) has no inferred name
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/python/lambdas.py', context := 'native')
+WHERE type = 'lambda' AND start_line = 16 AND (name IS NULL OR name = '');
+----
+2
+
+# =============================================================================
+# DART: function_expression name inference (new fix)
+# =============================================================================
+
+# Test: Dart function expressions assigned to variables get names
+query TT
+SELECT type, name
+FROM read_ast('test/data/dart/anonymous_functions.dart', context := 'native')
+WHERE type = 'function_expression' AND name IS NOT NULL AND name != ''
+ORDER BY start_line;
+----
+function_expression	greet
+function_expression	square
+function_expression	add
+function_expression	doubler
+
+# Test: Dart function expression used inline (sort callback) has no name
+query TI
+SELECT type, start_line
+FROM read_ast('test/data/dart/anonymous_functions.dart', context := 'native')
+WHERE type = 'function_expression' AND (name IS NULL OR name = '');
+----
+function_expression	22
+
+# Test: Total count of Dart function_expression nodes
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/dart/anonymous_functions.dart', context := 'native')
+WHERE type = 'function_expression';
+----
+5


### PR DESCRIPTION
## Summary
- Dart `function_expression` and `lambda_expression` nodes now infer names from assignment context (e.g., `var greet = (name) { ... }` → name = "greet")
- Added `initialized_variable_definition` to `FIND_ASSIGNMENT_TARGET` parent type matching
- Fixed identifier lookup to search all parent children (not just first child), handling Dart's type-annotation-before-identifier pattern

## Changes
- `src/language_configs/dart_types.def`: `function_expression` and `lambda_expression` name extraction `NONE` → `FIND_ASSIGNMENT_TARGET`
- `src/language_adapter.cpp`: Added `initialized_variable_definition` to parent type check; replaced first-child-only identifier lookup with `FindChildByType` to handle Dart's tree structure where type annotations precede the identifier
- `test/data/dart/anonymous_functions.dart`: Dart test data with assigned and inline anonymous functions
- `test/data/python/lambdas.py`: Python test data with assigned and inline lambdas
- `test/sql/name_extraction/find_assignment_target.test`: Tests for Python lambda and Dart function_expression name inference

## Test plan
- [x] Build succeeds
- [x] All existing name extraction tests pass (184 assertions)
- [x] New test passes (21 new assertions)
- [x] Full test suite: only pre-existing failures in `glob_array_support.test` and `multi_file_edge_cases.test`
- [x] Assigned anonymous functions get names: `greet`, `square`, `add`, `doubler`
- [x] Inline anonymous functions correctly get no name

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)