### PR TITLE
Fix native extractors for Java, Swift, and PHP

### DIFF
--- a/src/include/css_native_extractors.hpp
+++ b/src/include/css_native_extractors.hpp
@@ -20,7 +20,9 @@ class CSSAdapter;
 
 template <NativeExtractionStrategy Strategy>
 struct CSSNativeExtractor {
-	static NativeContext Extract(TSNode node, const string &content);
+	static NativeContext Extract(TSNode node, const string &content) {
+		return NativeContext();
+	}
 };
 
 //==============================================================================

--- a/src/include/function_call_extractor.hpp
+++ b/src/include/function_call_extractor.hpp
@@ -260,18 +260,28 @@ private:
 		// The full call expression (obj.method) goes in qualified_name instead
 
 		uint32_t child_count = ts_node_child_count(node);
+		string object_part;
+		string method_name;
 
 		for (uint32_t i = 0; i < child_count; i++) {
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			// Extract qualified call target from first matching child -> qualified_name
+			// Extract qualified call target from first matching child
 			if (i == 0 && context.qualified_name.empty()) {
 				for (const char *name_type : types.function_name_types) {
 					if (strcmp(child_type, name_type) == 0) {
-						context.qualified_name = ExtractNodeText(child, content);
+						object_part = ExtractNodeText(child, content);
+						context.qualified_name = object_part;
 						break;
 					}
+				}
+			} else if (!object_part.empty() && method_name.empty()) {
+				// Java method_invocation pattern: object.method(args)
+				// The method name is a separate identifier sibling after the object
+				if (strcmp(child_type, "identifier") == 0 || strcmp(child_type, "simple_identifier") == 0) {
+					method_name = ExtractNodeText(child, content);
+					context.qualified_name = object_part + "." + method_name;
 				}
 			}
 
@@ -280,8 +290,6 @@ private:
 				context.parameters = ExtractCallArguments(child, content, types);
 			}
 		}
-
-		// No fallback for qualified_name - empty is fine if we couldn't extract it
 
 		return context;
 	}

--- a/src/include/html_native_extractors.hpp
+++ b/src/include/html_native_extractors.hpp
@@ -20,7 +20,9 @@ class HTMLAdapter;
 
 template <NativeExtractionStrategy Strategy>
 struct HTMLNativeExtractor {
-	static NativeContext Extract(TSNode node, const string &content);
+	static NativeContext Extract(TSNode node, const string &content) {
+		return NativeContext();
+	}
 };
 
 //==============================================================================

--- a/src/include/java_native_extractors.hpp
+++ b/src/include/java_native_extractors.hpp
@@ -10,6 +10,15 @@ namespace duckdb {
 // Java-Specific Native Context Extractors
 //==============================================================================
 
+// Helper to check if a node type is a Java type node (return type, parameter type, etc.)
+// Covers all Java tree-sitter type nodes: reference types, primitives, generics, arrays
+inline bool IsJavaTypeNode(const char *child_type) {
+	return strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "primitive_type") == 0 ||
+	       strcmp(child_type, "integral_type") == 0 || strcmp(child_type, "floating_point_type") == 0 ||
+	       strcmp(child_type, "boolean_type") == 0 || strcmp(child_type, "generic_type") == 0 ||
+	       strcmp(child_type, "array_type") == 0 || strcmp(child_type, "void_type") == 0;
+}
+
 // Base template for Java extractors - default returns empty context
 template <NativeExtractionStrategy Strategy>
 struct JavaNativeExtractor {
@@ -49,9 +58,7 @@ private:
 			const char *child_type = ts_node_type(child);
 
 			// Look for any return type (primitive types like int, or reference types like String)
-			if (strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "primitive_type") == 0 ||
-			    strcmp(child_type, "generic_type") == 0 || strcmp(child_type, "array_type") == 0 ||
-			    strcmp(child_type, "void_type") == 0) {
+			if (IsJavaTypeNode(child_type)) {
 				uint32_t start = ts_node_start_byte(child);
 				uint32_t end = ts_node_end_byte(child);
 				if (start < content.length() && end <= content.length() && end > start) {
@@ -70,9 +77,7 @@ private:
 				const char *child_type = ts_node_type(child);
 
 				// Look for any return type in parent
-				if (strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "primitive_type") == 0 ||
-				    strcmp(child_type, "generic_type") == 0 || strcmp(child_type, "array_type") == 0 ||
-				    strcmp(child_type, "void_type") == 0) {
+				if (IsJavaTypeNode(child_type)) {
 					uint32_t start = ts_node_start_byte(child);
 					uint32_t end = ts_node_end_byte(child);
 					if (start < content.length() && end <= content.length() && end > start) {
@@ -141,8 +146,7 @@ private:
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "primitive_type") == 0 ||
-			    strcmp(child_type, "generic_type") == 0 || strcmp(child_type, "array_type") == 0) {
+			if (IsJavaTypeNode(child_type)) {
 				// Parameter type
 				uint32_t start = ts_node_start_byte(child);
 				uint32_t end = ts_node_end_byte(child);
@@ -178,8 +182,7 @@ private:
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "primitive_type") == 0 ||
-			    strcmp(child_type, "generic_type") == 0) {
+			if (IsJavaTypeNode(child_type)) {
 				// Varargs type (without the ...)
 				uint32_t start = ts_node_start_byte(child);
 				uint32_t end = ts_node_end_byte(child);
@@ -712,14 +715,13 @@ struct JavaNativeExtractor<NativeExtractionStrategy::VARIABLE_WITH_TYPE> {
 
 private:
 	static string ExtractJavaVariableType(TSNode node, const string &content) {
-		// Look for type in variable declarator
+		// Look for type in variable declarator or field declaration
 		uint32_t child_count = ts_node_child_count(node);
 		for (uint32_t i = 0; i < child_count; i++) {
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "primitive_type") == 0 ||
-			    strcmp(child_type, "generic_type") == 0 || strcmp(child_type, "array_type") == 0) {
+			if (IsJavaTypeNode(child_type)) {
 				uint32_t start = ts_node_start_byte(child);
 				uint32_t end = ts_node_end_byte(child);
 				if (start < content.length() && end <= content.length()) {
@@ -832,8 +834,7 @@ private:
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "primitive_type") == 0 ||
-			    strcmp(child_type, "generic_type") == 0 || strcmp(child_type, "array_type") == 0) {
+			if (IsJavaTypeNode(child_type)) {
 				return ExtractNodeText(child, content);
 			}
 		}
@@ -994,6 +995,19 @@ private:
 		}
 
 		return "";
+	}
+};
+
+// Specialization for CONSTRUCTOR_DEFINITION (Java constructors)
+// Constructors are like methods but have no return type
+template <>
+struct JavaNativeExtractor<NativeExtractionStrategy::CONSTRUCTOR_DEFINITION> {
+	static NativeContext Extract(TSNode node, const string &content) {
+		// Reuse FUNCTION_WITH_PARAMS for parameter and modifier extraction
+		// Constructors have no return type, so signature_type stays empty
+		auto context = JavaNativeExtractor<NativeExtractionStrategy::FUNCTION_WITH_PARAMS>::Extract(node, content);
+		context.signature_type = ""; // Constructors have no return type
+		return context;
 	}
 };
 

--- a/src/include/native_context_extraction.hpp
+++ b/src/include/native_context_extraction.hpp
@@ -255,6 +255,9 @@ NativeContext ExtractNativeContextTemplated(TSNode node, const string &content, 
 	case NativeExtractionStrategy::FUNCTION_CALL:
 		return NativeExtractionTraits<AdapterType>::template ExtractorType<
 		    NativeExtractionStrategy::FUNCTION_CALL>::Extract(node, content);
+	case NativeExtractionStrategy::CONSTRUCTOR_DEFINITION:
+		return NativeExtractionTraits<AdapterType>::template ExtractorType<
+		    NativeExtractionStrategy::CONSTRUCTOR_DEFINITION>::Extract(node, content);
 	case NativeExtractionStrategy::CUSTOM:
 		return NativeExtractionTraits<AdapterType>::template ExtractorType<NativeExtractionStrategy::CUSTOM>::Extract(
 		    node, content);

--- a/src/include/php_native_extractors.hpp
+++ b/src/include/php_native_extractors.hpp
@@ -249,21 +249,19 @@ public:
 	static vector<string> ExtractPHPModifiers(TSNode node, const string &content) {
 		vector<string> modifiers;
 
-		// Check for function modifiers
-		TSNode parent = ts_node_parent(node);
-		if (!ts_node_is_null(parent)) {
-			uint32_t parent_count = ts_node_child_count(parent);
-			for (uint32_t i = 0; i < parent_count; i++) {
-				TSNode sibling = ts_node_child(parent, i);
-				const char *sibling_type = ts_node_type(sibling);
+		// PHP AST: visibility_modifier, static_modifier, etc. are direct children
+		// of method_declaration/function_definition
+		uint32_t child_count = ts_node_child_count(node);
+		for (uint32_t i = 0; i < child_count; i++) {
+			TSNode child = ts_node_child(node, i);
+			const char *child_type = ts_node_type(child);
 
-				if (strcmp(sibling_type, "visibility_modifier") == 0 || strcmp(sibling_type, "static_modifier") == 0 ||
-				    strcmp(sibling_type, "abstract_modifier") == 0 || strcmp(sibling_type, "final_modifier") == 0) {
-					uint32_t start = ts_node_start_byte(sibling);
-					uint32_t end = ts_node_end_byte(sibling);
-					if (start < content.length() && end <= content.length()) {
-						modifiers.push_back(content.substr(start, end - start));
-					}
+			if (strcmp(child_type, "visibility_modifier") == 0 || strcmp(child_type, "static_modifier") == 0 ||
+			    strcmp(child_type, "abstract_modifier") == 0 || strcmp(child_type, "final_modifier") == 0) {
+				uint32_t start = ts_node_start_byte(child);
+				uint32_t end = ts_node_end_byte(child);
+				if (start < content.length() && end <= content.length()) {
+					modifiers.push_back(content.substr(start, end - start));
 				}
 			}
 		}

--- a/src/include/sql_native_extractors.hpp
+++ b/src/include/sql_native_extractors.hpp
@@ -20,7 +20,9 @@ class SQLAdapter;
 
 template <NativeExtractionStrategy Strategy>
 struct SQLNativeExtractor {
-	static NativeContext Extract(TSNode node, const string &content);
+	static NativeContext Extract(TSNode node, const string &content) {
+		return NativeContext();
+	}
 };
 
 //==============================================================================

--- a/src/include/swift_native_extractors.hpp
+++ b/src/include/swift_native_extractors.hpp
@@ -42,31 +42,19 @@ struct SwiftNativeExtractor<NativeExtractionStrategy::FUNCTION_WITH_PARAMS> {
 
 public:
 	static string ExtractSwiftReturnType(TSNode node, const string &content) {
-		// Look for return type after -> in function signature
+		// Swift AST: return type appears after "->" as a direct child (user_type, optional_type, etc.)
 		uint32_t child_count = ts_node_child_count(node);
+		bool found_arrow = false;
 		for (uint32_t i = 0; i < child_count; i++) {
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "type_annotation") == 0) {
-				// Find type after ->
-				uint32_t type_child_count = ts_node_child_count(child);
-				for (uint32_t j = 0; j < type_child_count; j++) {
-					TSNode type_child = ts_node_child(child, j);
-					const char *type_child_type = ts_node_type(type_child);
+			if (strcmp(child_type, "->") == 0) {
+				found_arrow = true;
+				continue;
+			}
 
-					if (strcmp(type_child_type, "type_identifier") == 0 ||
-					    strcmp(type_child_type, "optional_type") == 0 || strcmp(type_child_type, "array_type") == 0 ||
-					    strcmp(type_child_type, "dictionary_type") == 0 || strcmp(type_child_type, "tuple_type") == 0) {
-						uint32_t start = ts_node_start_byte(type_child);
-						uint32_t end = ts_node_end_byte(type_child);
-						if (start < content.length() && end <= content.length()) {
-							return content.substr(start, end - start);
-						}
-					}
-				}
-			} else if (strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "optional_type") == 0) {
-				// Direct return type annotation
+			if (found_arrow && IsSwiftTypeNode(child_type)) {
 				uint32_t start = ts_node_start_byte(child);
 				uint32_t end = ts_node_end_byte(child);
 				if (start < content.length() && end <= content.length()) {
@@ -77,52 +65,37 @@ public:
 		return ""; // Void or inferred return type
 	}
 
+	static bool IsSwiftTypeNode(const char *type) {
+		return strcmp(type, "user_type") == 0 || strcmp(type, "type_identifier") == 0 ||
+		       strcmp(type, "optional_type") == 0 || strcmp(type, "array_type") == 0 ||
+		       strcmp(type, "dictionary_type") == 0 || strcmp(type, "tuple_type") == 0 ||
+		       strcmp(type, "function_type") == 0;
+	}
+
 	static vector<ParameterInfo> ExtractSwiftParameters(TSNode node, const string &content) {
 		vector<ParameterInfo> params;
 
-		// Find parameter_list or function_value_parameters node
+		// Swift AST: parameters are direct children of function_declaration/init_declaration
+		// (no wrapper node like parameter_list)
 		uint32_t child_count = ts_node_child_count(node);
 		for (uint32_t i = 0; i < child_count; i++) {
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "parameter_list") == 0 || strcmp(child_type, "function_value_parameters") == 0) {
-				params = ExtractSwiftParametersDirect(child, content);
-				break;
+			if (strcmp(child_type, "parameter") == 0) {
+				ParameterInfo param = ExtractSwiftParameter(child, content);
+				if (!param.name.empty()) {
+					params.push_back(param);
+				}
+			} else if (strcmp(child_type, "variadic_parameter") == 0) {
+				ParameterInfo param = ExtractSwiftVariadicParameter(child, content);
+				if (!param.name.empty()) {
+					params.push_back(param);
+				}
 			}
 		}
 
 		return params;
-	}
-
-	static vector<ParameterInfo> ExtractSwiftParametersDirect(TSNode params_node, const string &content) {
-		vector<ParameterInfo> parameters;
-
-		uint32_t child_count = ts_node_child_count(params_node);
-
-		for (uint32_t i = 0; i < child_count; i++) {
-			TSNode child = ts_node_child(params_node, i);
-			const char *child_type = ts_node_type(child);
-
-			ParameterInfo param;
-			bool is_valid_param = false;
-
-			if (strcmp(child_type, "parameter") == 0) {
-				// Standard parameter: label name: Type or name: Type = default
-				param = ExtractSwiftParameter(child, content);
-				is_valid_param = !param.name.empty();
-			} else if (strcmp(child_type, "variadic_parameter") == 0) {
-				// Variadic parameter: args: Type...
-				param = ExtractSwiftVariadicParameter(child, content);
-				is_valid_param = !param.name.empty();
-			}
-
-			if (is_valid_param) {
-				parameters.push_back(param);
-			}
-		}
-
-		return parameters;
 	}
 
 	static ParameterInfo ExtractSwiftParameter(TSNode node, const string &content) {
@@ -136,7 +109,7 @@ public:
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "identifier") == 0) {
+			if (strcmp(child_type, "simple_identifier") == 0) {
 				// Could be external name or internal name
 				uint32_t start = ts_node_start_byte(child);
 				uint32_t end = ts_node_end_byte(child);
@@ -148,8 +121,18 @@ public:
 						internal_name = name;
 					}
 				}
+			} else if (strcmp(child_type, "user_type") == 0 || strcmp(child_type, "type_identifier") == 0 ||
+			           strcmp(child_type, "optional_type") == 0 || strcmp(child_type, "array_type") == 0 ||
+			           strcmp(child_type, "dictionary_type") == 0 || strcmp(child_type, "tuple_type") == 0 ||
+			           strcmp(child_type, "function_type") == 0) {
+				// Parameter type (direct child, not wrapped in type_annotation)
+				uint32_t start = ts_node_start_byte(child);
+				uint32_t end = ts_node_end_byte(child);
+				if (start < content.length() && end <= content.length()) {
+					param.type = content.substr(start, end - start);
+				}
 			} else if (strcmp(child_type, "type_annotation") == 0) {
-				// Parameter type
+				// Fallback: some versions may use type_annotation
 				param.type = ExtractSwiftTypeAnnotation(child, content);
 			} else if (strcmp(child_type, "default_parameter_clause") == 0) {
 				// Default value
@@ -184,11 +167,17 @@ public:
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "identifier") == 0) {
+			if (strcmp(child_type, "simple_identifier") == 0) {
 				uint32_t start = ts_node_start_byte(child);
 				uint32_t end = ts_node_end_byte(child);
 				if (start < content.length() && end <= content.length()) {
 					param.name = content.substr(start, end - start);
+				}
+			} else if (IsSwiftTypeNode(child_type)) {
+				uint32_t start = ts_node_start_byte(child);
+				uint32_t end = ts_node_end_byte(child);
+				if (start < content.length() && end <= content.length()) {
+					param.type = content.substr(start, end - start) + "...";
 				}
 			} else if (strcmp(child_type, "type_annotation") == 0) {
 				param.type = ExtractSwiftTypeAnnotation(child, content) + "...";
@@ -205,9 +194,7 @@ public:
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "type_identifier") == 0 || strcmp(child_type, "optional_type") == 0 ||
-			    strcmp(child_type, "array_type") == 0 || strcmp(child_type, "dictionary_type") == 0 ||
-			    strcmp(child_type, "tuple_type") == 0 || strcmp(child_type, "function_type") == 0) {
+			if (IsSwiftTypeNode(child_type)) {
 				uint32_t start = ts_node_start_byte(child);
 				uint32_t end = ts_node_end_byte(child);
 				if (start < content.length() && end <= content.length()) {
@@ -222,23 +209,34 @@ public:
 	static vector<string> ExtractSwiftModifiers(TSNode node, const string &content) {
 		vector<string> modifiers;
 
-		// Check for function modifiers
-		TSNode parent = ts_node_parent(node);
-		if (!ts_node_is_null(parent)) {
-			uint32_t parent_count = ts_node_child_count(parent);
-			for (uint32_t i = 0; i < parent_count; i++) {
-				TSNode sibling = ts_node_child(parent, i);
-				const char *sibling_type = ts_node_type(sibling);
+		// Swift AST: modifiers are in a "modifiers" child node of the function_declaration
+		// modifiers > {mutation_modifier, member_modifier, property_modifier, etc.} > keyword
+		uint32_t child_count = ts_node_child_count(node);
+		for (uint32_t i = 0; i < child_count; i++) {
+			TSNode child = ts_node_child(node, i);
+			const char *child_type = ts_node_type(child);
 
-				if (strcmp(sibling_type, "access_level_modifier") == 0 ||
-				    strcmp(sibling_type, "member_modifier") == 0 || strcmp(sibling_type, "mutation_modifier") == 0 ||
-				    strcmp(sibling_type, "override_modifier") == 0) {
-					uint32_t start = ts_node_start_byte(sibling);
-					uint32_t end = ts_node_end_byte(sibling);
-					if (start < content.length() && end <= content.length()) {
-						modifiers.push_back(content.substr(start, end - start));
+			if (strcmp(child_type, "modifiers") == 0) {
+				uint32_t mod_count = ts_node_child_count(child);
+				for (uint32_t j = 0; j < mod_count; j++) {
+					TSNode mod = ts_node_child(child, j);
+					const char *mod_type = ts_node_type(mod);
+
+					if (strcmp(mod_type, "mutation_modifier") == 0 ||
+					    strcmp(mod_type, "member_modifier") == 0 ||
+					    strcmp(mod_type, "property_modifier") == 0 ||
+					    strcmp(mod_type, "access_level_modifier") == 0 ||
+					    strcmp(mod_type, "inheritance_modifier") == 0 ||
+					    strcmp(mod_type, "attribute") == 0) {
+						// Extract the text of the modifier (e.g., "mutating", "override", "static")
+						uint32_t start = ts_node_start_byte(mod);
+						uint32_t end = ts_node_end_byte(mod);
+						if (start < content.length() && end <= content.length()) {
+							modifiers.push_back(content.substr(start, end - start));
+						}
 					}
 				}
+				break;
 			}
 		}
 
@@ -274,8 +272,9 @@ public:
 			const char *child_type = ts_node_type(child);
 
 			if (strcmp(child_type, "closure_parameters") == 0) {
+				// Extract parameters from closure_parameters node (same structure as function params)
 				params =
-				    SwiftNativeExtractor<NativeExtractionStrategy::FUNCTION_WITH_PARAMS>::ExtractSwiftParametersDirect(
+				    SwiftNativeExtractor<NativeExtractionStrategy::FUNCTION_WITH_PARAMS>::ExtractSwiftParameters(
 				        child, content);
 				break;
 			}
@@ -491,42 +490,38 @@ public:
 	static vector<string> ExtractSwiftVariableModifiers(TSNode node, const string &content) {
 		vector<string> modifiers;
 
-		// Check for variable declaration modifiers
+		// Swift AST: property_declaration children include modifiers, value_binding_pattern, etc.
 		uint32_t child_count = ts_node_child_count(node);
 		for (uint32_t i = 0; i < child_count; i++) {
 			TSNode child = ts_node_child(node, i);
 			const char *child_type = ts_node_type(child);
 
-			if (strcmp(child_type, "access_level_modifier") == 0 || strcmp(child_type, "member_modifier") == 0 ||
-			    strcmp(child_type, "ownership_modifier") == 0) {
-				uint32_t start = ts_node_start_byte(child);
-				uint32_t end = ts_node_end_byte(child);
-				if (start < content.length() && end <= content.length()) {
-					modifiers.push_back(content.substr(start, end - start));
+			if (strcmp(child_type, "modifiers") == 0) {
+				// Extract modifiers from wrapper (same as function modifiers)
+				uint32_t mod_count = ts_node_child_count(child);
+				for (uint32_t j = 0; j < mod_count; j++) {
+					TSNode mod = ts_node_child(child, j);
+					const char *mod_type = ts_node_type(mod);
+					if (strcmp(mod_type, "access_level_modifier") == 0 ||
+					    strcmp(mod_type, "member_modifier") == 0 ||
+					    strcmp(mod_type, "property_modifier") == 0 ||
+					    strcmp(mod_type, "ownership_modifier") == 0 ||
+					    strcmp(mod_type, "attribute") == 0) {
+						uint32_t start = ts_node_start_byte(mod);
+						uint32_t end = ts_node_end_byte(mod);
+						if (start < content.length() && end <= content.length()) {
+							modifiers.push_back(content.substr(start, end - start));
+						}
+					}
 				}
-			} else if (strcmp(child_type, "attribute") == 0) {
-				// @objc, @IBOutlet, etc.
-				uint32_t start = ts_node_start_byte(child);
-				uint32_t end = ts_node_end_byte(child);
-				if (start < content.length() && end <= content.length()) {
-					modifiers.push_back(content.substr(start, end - start));
-				}
-			}
-		}
-
-		// Check if this is var or let
-		TSNode parent = ts_node_parent(node);
-		if (!ts_node_is_null(parent)) {
-			const char *parent_type = ts_node_type(parent);
-			if (strcmp(parent_type, "property_declaration") == 0) {
-				// Check for var/let keyword
-				uint32_t parent_count = ts_node_child_count(parent);
-				for (uint32_t i = 0; i < parent_count; i++) {
-					TSNode sibling = ts_node_child(parent, i);
-					const char *sibling_type = ts_node_type(sibling);
-
-					if (strcmp(sibling_type, "var") == 0 || strcmp(sibling_type, "let") == 0) {
-						modifiers.push_back(sibling_type);
+			} else if (strcmp(child_type, "value_binding_pattern") == 0) {
+				// Extract var/let from value_binding_pattern child
+				uint32_t vbp_count = ts_node_child_count(child);
+				for (uint32_t j = 0; j < vbp_count; j++) {
+					TSNode vbp_child = ts_node_child(child, j);
+					const char *vbp_type = ts_node_type(vbp_child);
+					if (strcmp(vbp_type, "var") == 0 || strcmp(vbp_type, "let") == 0) {
+						modifiers.push_back(vbp_type);
 						break;
 					}
 				}
@@ -577,6 +572,19 @@ public:
 		modifiers.insert(modifiers.end(), regular_modifiers.begin(), regular_modifiers.end());
 
 		return modifiers;
+	}
+};
+
+// Specialization for CONSTRUCTOR_DEFINITION (Swift init declarations)
+// Constructors are like functions but have no return type
+template <>
+struct SwiftNativeExtractor<NativeExtractionStrategy::CONSTRUCTOR_DEFINITION> {
+	static NativeContext Extract(TSNode node, const string &content) {
+		// Reuse FUNCTION_WITH_PARAMS for parameter and modifier extraction
+		auto context =
+		    SwiftNativeExtractor<NativeExtractionStrategy::FUNCTION_WITH_PARAMS>::Extract(node, content);
+		context.signature_type = ""; // Constructors have no return type
+		return context;
 	}
 };
 

--- a/src/language_adapter.cpp
+++ b/src/language_adapter.cpp
@@ -134,7 +134,8 @@ string LanguageAdapter::ExtractNameFromDeclarator(TSNode node, const string &con
 	vector<string> declarator_patterns = {
 	    "function_declarator", "method_declarator", "declarator",
 	    "procedure_declarator", // Pascal-like languages
-	    "init_declarator"       // C++ initializing declarators
+	    "init_declarator",      // C++ initializing declarators
+	    "variable_declarator"   // Java field/variable declarations
 	};
 
 	// Wrapper types that may contain the actual declarator (e.g., for pointer/array return types)
@@ -432,7 +433,23 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 		string first_child_type = ts_node_type(first_child);
 
 		// Simple function call: first child is identifier
+		// But in Java method_invocation, the first identifier is the object, not the method.
+		// Check if there's a later identifier sibling (before argument_list) which would be the method name.
 		if (first_child_type == "identifier") {
+			uint32_t node_child_count = ts_node_child_count(node);
+			for (uint32_t i = 1; i < node_child_count; i++) {
+				TSNode sibling = ts_node_child(node, i);
+				string sibling_type = ts_node_type(sibling);
+				// Stop at argument containers
+				if (sibling_type == "argument_list" || sibling_type == "arguments") {
+					break;
+				}
+				if (sibling_type == "identifier" || sibling_type == "property_identifier" ||
+				    sibling_type == "field_identifier" || sibling_type == "simple_identifier") {
+					return ExtractNodeText(sibling, content);
+				}
+			}
+			// No later identifier found — this IS the function name (Python, etc.)
 			return ExtractNodeText(first_child, content);
 		}
 
@@ -443,7 +460,23 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 		    first_child_type == "field_expression" || first_child_type == "selector_expression" ||
 		    first_child_type == "field_access" || first_child_type == "scoped_identifier" ||
 		    first_child_type == "qualified_identifier") {
-			// Find the last identifier child (the method/function name)
+
+			// Java method_invocation has a special structure: the method name is a sibling
+			// of field_access, not inside it. E.g., System.out.println():
+			//   method_invocation -> field_access("System.out"), ".", identifier("println"), argument_list
+			// Check for an identifier sibling after the first child (the object expression)
+			uint32_t node_child_count = ts_node_child_count(node);
+			for (uint32_t i = 1; i < node_child_count; i++) {
+				TSNode sibling = ts_node_child(node, i);
+				string sibling_type = ts_node_type(sibling);
+				if (sibling_type == "identifier" || sibling_type == "property_identifier" ||
+				    sibling_type == "field_identifier" || sibling_type == "simple_identifier") {
+					return ExtractNodeText(sibling, content);
+				}
+			}
+
+			// Fallback: find the last identifier inside the first child
+			// (Python attribute, JS member_expression, etc.)
 			uint32_t child_count = ts_node_child_count(first_child);
 			for (int i = child_count - 1; i >= 0; i--) {
 				TSNode child = ts_node_child(first_child, i);

--- a/src/language_configs/bash_types.def
+++ b/src/language_configs/bash_types.def
@@ -81,7 +81,7 @@ DEF_TYPE("program", DEFINITION_MODULE, NONE, NONE, ASTNodeFlags::IS_CONSTRUCT)
  */
 
 /// @brief Function definition - both POSIX `name()` and Bash `function name` styles
-DEF_TYPE("function_definition", DEFINITION_FUNCTION, FIND_IDENTIFIER, FUNCTION_WITH_PARAMS, ASTNodeFlags::IS_CONSTRUCT)
+DEF_TYPE("function_definition", DEFINITION_FUNCTION | SemanticRefinements::Function::REGULAR, FIND_IDENTIFIER, FUNCTION_WITH_PARAMS, ASTNodeFlags::IS_CONSTRUCT)
 
 /** @} */ // end bash_functions
 
@@ -105,13 +105,13 @@ DEF_TYPE("function_definition", DEFINITION_FUNCTION, FIND_IDENTIFIER, FUNCTION_W
  */
 
 /// @brief Variable assignment - `name=value` or `name+=value`
-DEF_TYPE("variable_assignment", DEFINITION_VARIABLE, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
+DEF_TYPE("variable_assignment", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
 
 /// @brief Declaration command - `declare`, `local`, `readonly`, `typeset`, `export`
-DEF_TYPE("declaration_command", DEFINITION_VARIABLE, CUSTOM, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
+DEF_TYPE("declaration_command", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, CUSTOM, VARIABLE_WITH_TYPE, ASTNodeFlags::IS_CONSTRUCT)
 
 /// @brief Unset command - removes variable or function definition
-DEF_TYPE("unset_command", DEFINITION_VARIABLE, FIND_IDENTIFIER, NONE, 0)
+DEF_TYPE("unset_command", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, FIND_IDENTIFIER, NONE, 0)
 
 /** @} */ // end bash_variables
 
@@ -148,10 +148,10 @@ DEF_TYPE("simple_command", EXECUTION_STATEMENT, FIND_IDENTIFIER, NONE, 0)
 DEF_TYPE("pipeline", EXECUTION_STATEMENT, NONE, NONE, 0)
 
 /// @brief Command substitution - `$(cmd)` captures command output as string
-DEF_TYPE("command_substitution", COMPUTATION_CALL, NONE, NONE, 0)
+DEF_TYPE("command_substitution", COMPUTATION_CALL | SemanticRefinements::Call::FUNCTION, NONE, NONE, 0)
 
 /// @brief Process substitution - `<(cmd)` or `>(cmd)` provides file descriptor
-DEF_TYPE("process_substitution", COMPUTATION_CALL, NONE, NONE, 0)
+DEF_TYPE("process_substitution", COMPUTATION_CALL | SemanticRefinements::Call::FUNCTION, NONE, NONE, 0)
 
 /** @} */ // end bash_commands
 
@@ -178,40 +178,40 @@ DEF_TYPE("process_substitution", COMPUTATION_CALL, NONE, NONE, 0)
  */
 
 /// @brief If statement - `if cmd; then ...; fi`
-DEF_TYPE("if_statement", FLOW_CONDITIONAL, NONE, NONE, 0)
+DEF_TYPE("if_statement", FLOW_CONDITIONAL | SemanticRefinements::Conditional::BINARY, NONE, NONE, 0)
 
 /// @brief Case statement - pattern matching `case $var in pattern) ...; esac`
-DEF_TYPE("case_statement", FLOW_CONDITIONAL, NONE, NONE, 0)
+DEF_TYPE("case_statement", FLOW_CONDITIONAL | SemanticRefinements::Conditional::MULTIWAY, NONE, NONE, 0)
 
 /// @brief While loop - `while cmd; do ...; done`
-DEF_TYPE("while_statement", FLOW_LOOP, NONE, NONE, 0)
+DEF_TYPE("while_statement", FLOW_LOOP | SemanticRefinements::Loop::CONDITIONAL, NONE, NONE, 0)
 
 /// @brief For loop - `for var in list; do ...; done`
-DEF_TYPE("for_statement", FLOW_LOOP, NONE, NONE, 0)
+DEF_TYPE("for_statement", FLOW_LOOP | SemanticRefinements::Loop::ITERATOR, NONE, NONE, 0)
 
 /// @brief C-style for loop - `for ((i=0; i<n; i++)); do ...; done`
-DEF_TYPE("c_style_for_statement", FLOW_LOOP, NONE, NONE, 0)
+DEF_TYPE("c_style_for_statement", FLOW_LOOP | SemanticRefinements::Loop::COUNTER, NONE, NONE, 0)
 
 /// @brief Break statement - exit from enclosing loop
-DEF_TYPE("break_statement", FLOW_JUMP, NONE, NONE, 0)
+DEF_TYPE("break_statement", FLOW_JUMP | SemanticRefinements::Jump::BREAK, NONE, NONE, 0)
 
 /// @brief Continue statement - skip to next loop iteration
-DEF_TYPE("continue_statement", FLOW_JUMP, NONE, NONE, 0)
+DEF_TYPE("continue_statement", FLOW_JUMP | SemanticRefinements::Jump::CONTINUE, NONE, NONE, 0)
 
 /// @brief Return statement - exit function with status code
-DEF_TYPE("return_statement", FLOW_JUMP, NONE, NONE, 0)
+DEF_TYPE("return_statement", FLOW_JUMP | SemanticRefinements::Jump::RETURN, NONE, NONE, 0)
 
 /// @brief Exit statement - terminate script with status code
-DEF_TYPE("exit_statement", FLOW_JUMP, NONE, NONE, 0)
+DEF_TYPE("exit_statement", FLOW_JUMP | SemanticRefinements::Jump::RETURN, NONE, NONE, 0)
 
 /// @brief Else clause - alternative branch in if statement
-DEF_TYPE("else_clause", FLOW_CONDITIONAL, NONE, NONE, 0)
+DEF_TYPE("else_clause", FLOW_CONDITIONAL | SemanticRefinements::Conditional::BINARY, NONE, NONE, 0)
 
 /// @brief Elif clause - chained conditional in if statement
-DEF_TYPE("elif_clause", FLOW_CONDITIONAL, NONE, NONE, 0)
+DEF_TYPE("elif_clause", FLOW_CONDITIONAL | SemanticRefinements::Conditional::BINARY, NONE, NONE, 0)
 
 /// @brief Case item - individual pattern match in case statement
-DEF_TYPE("case_item", FLOW_CONDITIONAL, NONE, NONE, 0)
+DEF_TYPE("case_item", FLOW_CONDITIONAL | SemanticRefinements::Conditional::MULTIWAY, NONE, NONE, 0)
 
 /** @} */ // end bash_control
 
@@ -279,17 +279,17 @@ DEF_TYPE("brace_expression", COMPUTATION_EXPRESSION, NONE, NONE, 0)
  * @{
  */
 
-/// @brief Double-quoted string - allows expansion inside
-DEF_TYPE("string", LITERAL_STRING, NODE_TEXT, NONE, 0)
+/// @brief Double-quoted string - allows expansion inside (template-like)
+DEF_TYPE("string", LITERAL_STRING | SemanticRefinements::String::TEMPLATE, NODE_TEXT, NONE, 0)
 
 /// @brief Single-quoted string - literal, no expansion
-DEF_TYPE("raw_string", LITERAL_STRING, NODE_TEXT, NONE, 0)
+DEF_TYPE("raw_string", LITERAL_STRING | SemanticRefinements::String::RAW, NODE_TEXT, NONE, 0)
 
 /// @brief ANSI-C quoted string - `$'...'` with escape sequences
-DEF_TYPE("ansii_c_string", LITERAL_STRING, NODE_TEXT, NONE, 0)
+DEF_TYPE("ansii_c_string", LITERAL_STRING | SemanticRefinements::String::LITERAL, NODE_TEXT, NONE, 0)
 
 /// @brief String concatenation - adjacent strings combined
-DEF_TYPE("concatenation", LITERAL_STRING, NODE_TEXT, NONE, 0)
+DEF_TYPE("concatenation", LITERAL_STRING | SemanticRefinements::String::LITERAL, NODE_TEXT, NONE, 0)
 
 /** @} */ // end bash_strings
 
@@ -315,10 +315,10 @@ DEF_TYPE("concatenation", LITERAL_STRING, NODE_TEXT, NONE, 0)
  */
 
 /// @brief Numeric literal - integers for arithmetic context
-DEF_TYPE("number", LITERAL_NUMBER, NODE_TEXT, NONE, 0)
+DEF_TYPE("number", LITERAL_NUMBER | SemanticRefinements::Number::INTEGER, NODE_TEXT, NONE, 0)
 
 /// @brief Array literal - `(elem1 elem2 elem3)`
-DEF_TYPE("array", LITERAL_STRUCTURED, NONE, NONE, 0)
+DEF_TYPE("array", LITERAL_STRUCTURED | SemanticRefinements::Structured::SEQUENCE, NONE, NONE, 0)
 
 /** @} */ // end bash_literals
 
@@ -431,13 +431,13 @@ DEF_TYPE("comment", METADATA_COMMENT, NODE_TEXT, NONE, ASTNodeFlags::IS_CONSTRUC
  */
 
 /// @brief Subshell - commands in `()` run in child process
-DEF_TYPE("subshell", ORGANIZATION_BLOCK, NONE, NONE, 0)
+DEF_TYPE("subshell", ORGANIZATION_BLOCK | SemanticRefinements::Organization::SEQUENTIAL, NONE, NONE, 0)
 
 /// @brief Compound statement - command group in `{}`
-DEF_TYPE("compound_statement", ORGANIZATION_BLOCK, NONE, NONE, 0)
+DEF_TYPE("compound_statement", ORGANIZATION_BLOCK | SemanticRefinements::Organization::SEQUENTIAL, NONE, NONE, 0)
 
 /// @brief Do group - loop body between `do` and `done`
-DEF_TYPE("do_group", ORGANIZATION_BLOCK, NONE, NONE, 0)
+DEF_TYPE("do_group", ORGANIZATION_BLOCK | SemanticRefinements::Organization::SEQUENTIAL, NONE, NONE, 0)
 
 /** @} */ // end bash_blocks
 
@@ -472,13 +472,13 @@ DEF_TYPE("do_group", ORGANIZATION_BLOCK, NONE, NONE, 0)
 DEF_TYPE("test_command", COMPUTATION_EXPRESSION, NONE, NONE, 0)
 
 /// @brief Binary expression - two-operand test (e.g., `$a -eq $b`)
-DEF_TYPE("binary_expression", OPERATOR_COMPARISON, NONE, NONE, 0)
+DEF_TYPE("binary_expression", OPERATOR_COMPARISON | SemanticRefinements::Comparison::RELATIONAL, NONE, NONE, 0)
 
 /// @brief Unary expression - single-operand test (e.g., `-f file`)
-DEF_TYPE("unary_expression", OPERATOR_LOGICAL, NONE, NONE, 0)
+DEF_TYPE("unary_expression", OPERATOR_ARITHMETIC | SemanticRefinements::Arithmetic::UNARY, NONE, NONE, 0)
 
 /// @brief Postfix expression - increment/decrement in arithmetic
-DEF_TYPE("postfix_expression", OPERATOR_ARITHMETIC, NONE, NONE, 0)
+DEF_TYPE("postfix_expression", OPERATOR_ARITHMETIC | SemanticRefinements::Arithmetic::UNARY, NONE, NONE, 0)
 
 /// @brief Parenthesized expression - grouped expression `(expr)`
 DEF_TYPE("parenthesized_expression", COMPUTATION_EXPRESSION, NONE, NONE, 0)
@@ -513,7 +513,7 @@ DEF_TYPE("||", OPERATOR_LOGICAL, NODE_TEXT, NONE, 0)
 DEF_TYPE("|", PARSER_PUNCTUATION, NODE_TEXT, NONE, 0)
 
 /// @brief Background operator - run command asynchronously
-DEF_TYPE("&", OPERATOR_ARITHMETIC, NODE_TEXT, NONE, 0)
+DEF_TYPE("&", EXECUTION_STATEMENT, NODE_TEXT, NONE, 0)
 
 /// @brief Semicolon - command separator
 DEF_TYPE(";", PARSER_PUNCTUATION, NODE_TEXT, NONE, 0)
@@ -636,16 +636,16 @@ DEF_TYPE("exit", FLOW_JUMP, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
  * @{
  */
 /// @brief local keyword - function-scoped variable
-DEF_TYPE("local", DEFINITION_VARIABLE, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
+DEF_TYPE("local", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
 
 /// @brief declare keyword - variable declaration with attributes
-DEF_TYPE("declare", DEFINITION_VARIABLE, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
+DEF_TYPE("declare", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
 
 /// @brief readonly keyword - immutable variable declaration
-DEF_TYPE("readonly", DEFINITION_VARIABLE, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
+DEF_TYPE("readonly", DEFINITION_VARIABLE | SemanticRefinements::Variable::IMMUTABLE, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
 
 /// @brief export keyword - export variable to environment
-DEF_TYPE("export", DEFINITION_VARIABLE, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
+DEF_TYPE("export", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, NODE_TEXT, NONE, ASTNodeFlags::IS_KEYWORD)
 /** @} */
 
 /** @} */ // end bash_keywords

--- a/src/language_configs/java_types.def
+++ b/src/language_configs/java_types.def
@@ -142,8 +142,8 @@ DEF_TYPE("lambda_expression", DEFINITION_FUNCTION | SemanticRefinements::Functio
  * - `enum_constant`: Enum values (FIELD refinement)
  * @{
  */
-DEF_TYPE("field_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::FIELD, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, 0)
-DEF_TYPE("local_variable_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, 0)
+DEF_TYPE("field_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::FIELD, FIND_IN_DECLARATOR, VARIABLE_WITH_TYPE, 0)
+DEF_TYPE("local_variable_declaration", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, FIND_IN_DECLARATOR, VARIABLE_WITH_TYPE, 0)
 DEF_TYPE("variable_declarator", DEFINITION_VARIABLE | SemanticRefinements::Variable::MUTABLE, FIND_IDENTIFIER, VARIABLE_WITH_TYPE, 0)
 DEF_TYPE("formal_parameter", DEFINITION_VARIABLE | SemanticRefinements::Variable::PARAMETER, FIND_IDENTIFIER, NONE, 0)
 DEF_TYPE("spread_parameter", DEFINITION_VARIABLE | SemanticRefinements::Variable::PARAMETER, FIND_IDENTIFIER, NONE, 0)

--- a/test/sql/languages/bash_refinements.test
+++ b/test/sql/languages/bash_refinements.test
@@ -1,0 +1,381 @@
+# name: test/sql/languages/bash_refinements.test
+# description: Test Bash semantic refinements
+# group: [languages]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# Bash Refinement Tests
+# =============================================================================
+#
+# Tests that semantic refinements are correctly applied to Bash code.
+# Refinements are 2-bit values in the lower bits of semantic_type that provide
+# finer-grained classification within each semantic category.
+# =============================================================================
+
+# =============================================================================
+# FUNCTION REFINEMENTS
+# =============================================================================
+
+# Test: Function definition should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'function_definition'
+LIMIT 1;
+----
+function_definition	DEFINITION_FUNCTION
+
+# Test: function keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'function'
+LIMIT 1;
+----
+function	DEFINITION_FUNCTION
+
+# =============================================================================
+# VARIABLE REFINEMENTS
+# =============================================================================
+
+# Test: Variable assignment should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'variable_assignment'
+LIMIT 1;
+----
+variable_assignment	DEFINITION_VARIABLE
+
+# Test: Declaration command should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'declaration_command'
+LIMIT 1;
+----
+declaration_command	DEFINITION_VARIABLE
+
+# Test: local keyword should be DEFINITION_VARIABLE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'local'
+LIMIT 1;
+----
+local	DEFINITION_VARIABLE
+
+# Test: declare keyword should be DEFINITION_VARIABLE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'declare'
+LIMIT 1;
+----
+declare	DEFINITION_VARIABLE
+
+
+# =============================================================================
+# CONTROL FLOW - CONDITIONALS
+# =============================================================================
+
+# Test: If statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'if_statement'
+LIMIT 1;
+----
+if_statement	FLOW_CONDITIONAL
+
+# Test: Case statement should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'case_statement'
+LIMIT 1;
+----
+case_statement	FLOW_CONDITIONAL
+
+# Test: Case item should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'case_item'
+LIMIT 1;
+----
+case_item	FLOW_CONDITIONAL
+
+# Test: Elif clause should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'elif_clause'
+LIMIT 1;
+----
+elif_clause	FLOW_CONDITIONAL
+
+# Test: Else clause should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'else_clause'
+LIMIT 1;
+----
+else_clause	FLOW_CONDITIONAL
+
+# Test: if keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'if'
+LIMIT 1;
+----
+if	FLOW_CONDITIONAL
+
+# Test: case keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'case'
+LIMIT 1;
+----
+case	FLOW_CONDITIONAL
+
+# =============================================================================
+# CONTROL FLOW - LOOPS
+# =============================================================================
+
+# Test: While loop should be FLOW_LOOP (with CONDITIONAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'while_statement'
+LIMIT 1;
+----
+while_statement	FLOW_LOOP
+
+# Test: For loop should be FLOW_LOOP (with ITERATOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'for_statement'
+LIMIT 1;
+----
+for_statement	FLOW_LOOP
+
+# Test: for keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'for'
+LIMIT 1;
+----
+for	FLOW_LOOP
+
+# Test: while keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'while'
+LIMIT 1;
+----
+while	FLOW_LOOP
+
+# Test: do keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'do'
+LIMIT 1;
+----
+do	FLOW_LOOP
+
+# Test: done keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'done'
+LIMIT 1;
+----
+done	FLOW_LOOP
+
+# =============================================================================
+# JUMP STATEMENTS
+# =============================================================================
+
+# =============================================================================
+# STRING REFINEMENTS
+# =============================================================================
+
+# Test: Double-quoted strings should be LITERAL_STRING (with TEMPLATE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'string'
+LIMIT 1;
+----
+string	LITERAL_STRING
+
+# Test: Single-quoted strings should be LITERAL_STRING (with RAW refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'raw_string'
+LIMIT 1;
+----
+raw_string	LITERAL_STRING
+
+# =============================================================================
+# NUMBER AND STRUCTURED LITERAL REFINEMENTS
+# =============================================================================
+
+# Test: Number literal should be LITERAL_NUMBER (with INTEGER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'number'
+LIMIT 1;
+----
+number	LITERAL_NUMBER
+
+# =============================================================================
+# COMMAND AND CALL REFINEMENTS
+# =============================================================================
+
+# Test: Command substitution should be COMPUTATION_CALL (with FUNCTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'command_substitution'
+LIMIT 1;
+----
+command_substitution	COMPUTATION_CALL
+
+
+# =============================================================================
+# ORGANIZATION REFINEMENTS
+# =============================================================================
+
+# Test: Compound statement should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'compound_statement'
+LIMIT 1;
+----
+compound_statement	ORGANIZATION_BLOCK
+
+# Test: Do group should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'do_group'
+LIMIT 1;
+----
+do_group	ORGANIZATION_BLOCK
+
+# Test: Subshell should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'subshell'
+LIMIT 1;
+----
+subshell	ORGANIZATION_BLOCK
+
+# =============================================================================
+# OPERATOR REFINEMENTS
+# =============================================================================
+
+# Test: && operator should be OPERATOR_LOGICAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = '&&'
+LIMIT 1;
+----
+&&	OPERATOR_LOGICAL
+
+# Test: || operator should be OPERATOR_LOGICAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = '||'
+LIMIT 1;
+----
+||	OPERATOR_LOGICAL
+
+# =============================================================================
+# IDENTIFIER AND EXPANSION REFINEMENTS
+# =============================================================================
+
+# Test: Variable name should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'variable_name'
+LIMIT 1;
+----
+variable_name	NAME_IDENTIFIER
+
+# Test: Simple expansion should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'simple_expansion'
+LIMIT 1;
+----
+simple_expansion	COMPUTATION_ACCESS
+
+# Test: Complex expansion should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'expansion'
+LIMIT 1;
+----
+expansion	COMPUTATION_ACCESS
+
+# =============================================================================
+# MODULE REFINEMENTS
+# =============================================================================
+
+# Test: Program root should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'program'
+LIMIT 1;
+----
+program	DEFINITION_MODULE
+
+# =============================================================================
+# COMMENT REFINEMENTS
+# =============================================================================
+
+# Test: Comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'comment'
+LIMIT 1;
+----
+comment	METADATA_COMMENT
+
+# =============================================================================
+# TEST EXPRESSION REFINEMENTS
+# =============================================================================
+
+# Test: Test command should be COMPUTATION_EXPRESSION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/bash/simple.sh')
+WHERE type = 'test_command'
+LIMIT 1;
+----
+test_command	COMPUTATION_EXPRESSION

--- a/test/sql/languages/c_refinements.test
+++ b/test/sql/languages/c_refinements.test
@@ -1,0 +1,881 @@
+# name: test/sql/languages/c_refinements.test
+# description: Test C semantic refinements
+# group: [languages]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# C Refinement Tests
+# =============================================================================
+#
+# Tests that semantic refinements are correctly applied to C code.
+# Refinements are 2-bit values in the lower bits of semantic_type that provide
+# finer-grained classification within each semantic category.
+# =============================================================================
+
+# =============================================================================
+# TRANSLATION UNIT
+# =============================================================================
+
+# Test: Translation unit should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'translation_unit'
+LIMIT 1;
+----
+translation_unit	DEFINITION_MODULE
+
+# =============================================================================
+# FUNCTION REFINEMENTS
+# =============================================================================
+
+# Test: Function definition should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'function_definition'
+LIMIT 1;
+----
+function_definition	DEFINITION_FUNCTION
+
+# Test: Function-like macro should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'preproc_function_def'
+LIMIT 1;
+----
+preproc_function_def	DEFINITION_FUNCTION
+
+# =============================================================================
+# VARIABLE REFINEMENTS
+# =============================================================================
+
+# Test: Declaration should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'declaration'
+LIMIT 1;
+----
+declaration	DEFINITION_VARIABLE
+
+# Test: Parameter declaration should be DEFINITION_VARIABLE (with PARAMETER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'parameter_declaration'
+LIMIT 1;
+----
+parameter_declaration	DEFINITION_VARIABLE
+
+# Test: Field declaration should be DEFINITION_VARIABLE (with FIELD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'field_declaration'
+LIMIT 1;
+----
+field_declaration	DEFINITION_VARIABLE
+
+# Test: Enumerator should be DEFINITION_VARIABLE (with FIELD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'enumerator'
+LIMIT 1;
+----
+enumerator	DEFINITION_VARIABLE
+
+# Test: Object-like macro should be DEFINITION_VARIABLE (with IMMUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'preproc_def'
+LIMIT 1;
+----
+preproc_def	DEFINITION_VARIABLE
+
+# Test: Init declarator should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'init_declarator'
+LIMIT 1;
+----
+init_declarator	DEFINITION_VARIABLE
+
+# =============================================================================
+# CLASS/TYPE DEFINITION REFINEMENTS
+# =============================================================================
+
+# Test: Struct specifier should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'struct_specifier'
+LIMIT 1;
+----
+struct_specifier	DEFINITION_CLASS
+
+# Test: Enum specifier should be DEFINITION_CLASS (with ENUM refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'enum_specifier'
+LIMIT 1;
+----
+enum_specifier	DEFINITION_CLASS
+
+# =============================================================================
+# IMPORT REFINEMENTS
+# =============================================================================
+
+# Test: Preproc include should be EXTERNAL_IMPORT (with MODULE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'preproc_include'
+LIMIT 1;
+----
+preproc_include	EXTERNAL_IMPORT
+
+# Test: System library string should be EXTERNAL_IMPORT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'system_lib_string'
+LIMIT 1;
+----
+system_lib_string	EXTERNAL_IMPORT
+
+# =============================================================================
+# CONTROL FLOW REFINEMENTS
+# =============================================================================
+
+# Test: If statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'if_statement'
+LIMIT 1;
+----
+if_statement	FLOW_CONDITIONAL
+
+# Test: Switch statement should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'switch_statement'
+LIMIT 1;
+----
+switch_statement	FLOW_CONDITIONAL
+
+# Test: Case statement should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'case_statement'
+LIMIT 1;
+----
+case_statement	FLOW_CONDITIONAL
+
+# Test: Conditional/ternary expression should be FLOW_CONDITIONAL (with TERNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'conditional_expression'
+LIMIT 1;
+----
+conditional_expression	FLOW_CONDITIONAL
+
+# Test: if keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'if'
+LIMIT 1;
+----
+if	FLOW_CONDITIONAL
+
+# Test: switch keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'switch'
+LIMIT 1;
+----
+switch	FLOW_CONDITIONAL
+
+# Test: case keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'case'
+LIMIT 1;
+----
+case	FLOW_CONDITIONAL
+
+# Test: default keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'default'
+LIMIT 1;
+----
+default	FLOW_CONDITIONAL
+
+# Test: Preprocessor ifdef should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'preproc_ifdef'
+LIMIT 1;
+----
+preproc_ifdef	FLOW_CONDITIONAL
+
+# =============================================================================
+# LOOP REFINEMENTS
+# =============================================================================
+
+# Test: For statement should be FLOW_LOOP (with COUNTER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'for_statement'
+LIMIT 1;
+----
+for_statement	FLOW_LOOP
+
+# Test: While statement should be FLOW_LOOP (with CONDITIONAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'while_statement'
+LIMIT 1;
+----
+while_statement	FLOW_LOOP
+
+# Test: for keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'for'
+LIMIT 1;
+----
+for	FLOW_LOOP
+
+# Test: while keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'while'
+LIMIT 1;
+----
+while	FLOW_LOOP
+
+# =============================================================================
+# JUMP REFINEMENTS
+# =============================================================================
+
+# Test: Return statement should be FLOW_JUMP (with RETURN refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'return_statement'
+LIMIT 1;
+----
+return_statement	FLOW_JUMP
+
+# Test: Break statement should be FLOW_JUMP (with BREAK refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'break_statement'
+LIMIT 1;
+----
+break_statement	FLOW_JUMP
+
+# Test: return keyword should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'return'
+LIMIT 1;
+----
+return	FLOW_JUMP
+
+# Test: break keyword should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'break'
+LIMIT 1;
+----
+break	FLOW_JUMP
+
+# =============================================================================
+# CALL REFINEMENTS
+# =============================================================================
+
+# Test: Call expression should be COMPUTATION_CALL (with FUNCTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'call_expression'
+LIMIT 1;
+----
+call_expression	COMPUTATION_CALL
+
+# Test: Field expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'field_expression'
+LIMIT 1;
+----
+field_expression	COMPUTATION_ACCESS
+
+# Test: Subscript expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'subscript_expression'
+LIMIT 1;
+----
+subscript_expression	COMPUTATION_ACCESS
+
+# Test: Pointer member access (->) should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '->'
+LIMIT 1;
+----
+->	COMPUTATION_ACCESS
+
+# Test: Cast expression should be COMPUTATION_EXPRESSION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'cast_expression'
+LIMIT 1;
+----
+cast_expression	COMPUTATION_EXPRESSION
+
+# =============================================================================
+# OPERATOR REFINEMENTS
+# =============================================================================
+
+# Test: Assignment expression should be OPERATOR_ASSIGNMENT (with SIMPLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'assignment_expression'
+LIMIT 1;
+----
+assignment_expression	OPERATOR_ASSIGNMENT
+
+# Test: = operator should be OPERATOR_ASSIGNMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '='
+LIMIT 1;
+----
+=	OPERATOR_ASSIGNMENT
+
+# Test: |= compound assignment should be OPERATOR_ASSIGNMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '|='
+LIMIT 1;
+----
+|=	OPERATOR_ASSIGNMENT
+
+# Test: &= compound assignment should be OPERATOR_ASSIGNMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '&='
+LIMIT 1;
+----
+&=	OPERATOR_ASSIGNMENT
+
+# Test: Binary expression should be OPERATOR_ARITHMETIC (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'binary_expression'
+LIMIT 1;
+----
+binary_expression	OPERATOR_ARITHMETIC
+
+# Test: Unary expression should be OPERATOR_ARITHMETIC (with UNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'unary_expression'
+LIMIT 1;
+----
+unary_expression	OPERATOR_ARITHMETIC
+
+# Test: Update expression should be OPERATOR_ARITHMETIC (with UNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'update_expression'
+LIMIT 1;
+----
+update_expression	OPERATOR_ARITHMETIC
+
+# Test: Sizeof expression should be OPERATOR_ARITHMETIC (with UNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'sizeof_expression'
+LIMIT 1;
+----
+sizeof_expression	OPERATOR_ARITHMETIC
+
+# Test: == operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '=='
+LIMIT 1;
+----
+==	OPERATOR_COMPARISON
+
+# Test: != operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '!='
+LIMIT 1;
+----
+!=	OPERATOR_COMPARISON
+
+# Test: < operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '<'
+LIMIT 1;
+----
+<	OPERATOR_COMPARISON
+
+# Test: > operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '>'
+LIMIT 1;
+----
+>	OPERATOR_COMPARISON
+
+# Test: + operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '+'
+LIMIT 1;
+----
++	OPERATOR_ARITHMETIC
+
+# Test: * operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '*'
+LIMIT 1;
+----
+*	OPERATOR_ARITHMETIC
+
+# Test: / operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '/'
+LIMIT 1;
+----
+/	OPERATOR_ARITHMETIC
+
+# Test: % operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '%'
+LIMIT 1;
+----
+%	OPERATOR_ARITHMETIC
+
+# Test: ++ operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '++'
+LIMIT 1;
+----
+++	OPERATOR_ARITHMETIC
+
+# Test: -- operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '--'
+LIMIT 1;
+----
+--	OPERATOR_ARITHMETIC
+
+# Test: << operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '<<'
+LIMIT 1;
+----
+<<	OPERATOR_ARITHMETIC
+
+# Test: ~ operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '~'
+LIMIT 1;
+----
+~	OPERATOR_ARITHMETIC
+
+# =============================================================================
+# LITERAL REFINEMENTS
+# =============================================================================
+
+# Test: Number literal should be LITERAL_NUMBER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'number_literal'
+LIMIT 1;
+----
+number_literal	LITERAL_NUMBER
+
+# Test: String literal should be LITERAL_STRING (with LITERAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'string_literal'
+LIMIT 1;
+----
+string_literal	LITERAL_STRING
+
+# Test: NULL should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'NULL'
+LIMIT 1;
+----
+NULL	LITERAL_ATOMIC
+
+# Test: true should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'true'
+LIMIT 1;
+----
+true	LITERAL_ATOMIC
+
+# Test: false should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'false'
+LIMIT 1;
+----
+false	LITERAL_ATOMIC
+
+# Test: Initializer list should be LITERAL_STRUCTURED (with SEQUENCE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'initializer_list'
+LIMIT 1;
+----
+initializer_list	LITERAL_STRUCTURED
+
+# =============================================================================
+# IDENTIFIER REFINEMENTS
+# =============================================================================
+
+# Test: Identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'identifier'
+LIMIT 1;
+----
+identifier	NAME_IDENTIFIER
+
+# Test: Field identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'field_identifier'
+LIMIT 1;
+----
+field_identifier	NAME_IDENTIFIER
+
+# =============================================================================
+# TYPE SYSTEM
+# =============================================================================
+
+# Test: Primitive type should be TYPE_PRIMITIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'primitive_type'
+LIMIT 1;
+----
+primitive_type	TYPE_PRIMITIVE
+
+# Test: Type identifier should be TYPE_REFERENCE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'type_identifier'
+LIMIT 1;
+----
+type_identifier	TYPE_REFERENCE
+
+# Test: Pointer declarator should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'pointer_declarator'
+LIMIT 1;
+----
+pointer_declarator	TYPE_COMPOSITE
+
+# Test: Array declarator should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'array_declarator'
+LIMIT 1;
+----
+array_declarator	TYPE_COMPOSITE
+
+# Test: Function declarator should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'function_declarator'
+LIMIT 1;
+----
+function_declarator	TYPE_COMPOSITE
+
+# =============================================================================
+# STRUCTURAL ELEMENTS
+# =============================================================================
+
+# Test: Compound statement should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'compound_statement'
+LIMIT 1;
+----
+compound_statement	ORGANIZATION_BLOCK
+
+# Test: Parameter list should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'parameter_list'
+LIMIT 1;
+----
+parameter_list	ORGANIZATION_LIST
+
+# Test: Argument list should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'argument_list'
+LIMIT 1;
+----
+argument_list	ORGANIZATION_LIST
+
+# Test: Field declaration list should be ORGANIZATION_LIST
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'field_declaration_list'
+LIMIT 1;
+----
+field_declaration_list	ORGANIZATION_LIST
+
+# Test: Enumerator list should be ORGANIZATION_LIST
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'enumerator_list'
+LIMIT 1;
+----
+enumerator_list	ORGANIZATION_LIST
+
+# =============================================================================
+# STATEMENTS
+# =============================================================================
+
+# Test: Expression statement should be EXECUTION_STATEMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'expression_statement'
+LIMIT 1;
+----
+expression_statement	EXECUTION_STATEMENT
+
+# =============================================================================
+# PREPROCESSOR DIRECTIVES
+# =============================================================================
+
+# Test: #include directive token should be METADATA_DIRECTIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '#include'
+LIMIT 1;
+----
+#include	METADATA_DIRECTIVE
+
+# Test: #define directive token should be METADATA_DIRECTIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '#define'
+LIMIT 1;
+----
+#define	METADATA_DIRECTIVE
+
+# Test: #ifdef directive token should be METADATA_DIRECTIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '#ifdef'
+LIMIT 1;
+----
+#ifdef	METADATA_DIRECTIVE
+
+# Test: #endif directive token should be METADATA_DIRECTIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = '#endif'
+LIMIT 1;
+----
+#endif	METADATA_DIRECTIVE
+
+# =============================================================================
+# METADATA
+# =============================================================================
+
+# Test: Comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'comment'
+LIMIT 1;
+----
+comment	METADATA_COMMENT
+
+# Test: Storage class specifier should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'storage_class_specifier'
+LIMIT 1;
+----
+storage_class_specifier	METADATA_ANNOTATION
+
+# Test: Type qualifier should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'type_qualifier'
+LIMIT 1;
+----
+type_qualifier	METADATA_ANNOTATION
+
+# =============================================================================
+# KEYWORD REFINEMENTS
+# =============================================================================
+
+# Test: struct keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'struct'
+LIMIT 1;
+----
+struct	METADATA_ANNOTATION
+
+# Test: enum keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'enum'
+LIMIT 1;
+----
+enum	METADATA_ANNOTATION
+
+# Test: typedef keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'typedef'
+LIMIT 1;
+----
+typedef	METADATA_ANNOTATION
+
+# Test: static keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'static'
+LIMIT 1;
+----
+static	METADATA_ANNOTATION
+
+# Test: const keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'const'
+LIMIT 1;
+----
+const	METADATA_ANNOTATION
+
+# Test: inline keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'inline'
+LIMIT 1;
+----
+inline	METADATA_ANNOTATION
+
+# Test: sizeof keyword should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/c/test.c', context := 'native')
+WHERE type = 'sizeof'
+LIMIT 1;
+----
+sizeof	OPERATOR_ARITHMETIC

--- a/test/sql/languages/csharp_refinements.test
+++ b/test/sql/languages/csharp_refinements.test
@@ -1,0 +1,290 @@
+# name: test/sql/languages/csharp_refinements.test
+# description: Test C# semantic refinements
+# group: [languages]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# C# Refinement Tests
+# =============================================================================
+#
+# Tests that semantic refinements are correctly applied to C# code.
+# Refinements are 2-bit values in the lower bits of semantic_type that provide
+# finer-grained classification within each semantic category.
+# =============================================================================
+
+# =============================================================================
+# CLASS AND TYPE DEFINITION REFINEMENTS
+# =============================================================================
+
+# Test: Class declaration should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'class_declaration'
+LIMIT 1;
+----
+class_declaration	DEFINITION_CLASS
+
+# Test: Struct declaration should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'struct_declaration'
+LIMIT 1;
+----
+struct_declaration	DEFINITION_CLASS
+
+# Test: Interface declaration should be DEFINITION_CLASS (with ABSTRACT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'interface_declaration'
+LIMIT 1;
+----
+interface_declaration	DEFINITION_CLASS
+
+# Test: Enum declaration should be DEFINITION_CLASS (with ENUM refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'enum_declaration'
+LIMIT 1;
+----
+enum_declaration	DEFINITION_CLASS
+
+# Test: Record declaration should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'record_declaration'
+LIMIT 1;
+----
+record_declaration	DEFINITION_CLASS
+
+# =============================================================================
+# FUNCTION REFINEMENTS
+# =============================================================================
+
+# Test: Method declaration should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'method_declaration'
+LIMIT 1;
+----
+method_declaration	DEFINITION_FUNCTION
+
+# Test: Constructor declaration should be DEFINITION_FUNCTION (with CONSTRUCTOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'constructor_declaration'
+LIMIT 1;
+----
+constructor_declaration	DEFINITION_FUNCTION
+
+# Test: Lambda expression should be DEFINITION_FUNCTION (with LAMBDA refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'lambda_expression'
+LIMIT 1;
+----
+lambda_expression	DEFINITION_FUNCTION
+
+# =============================================================================
+# MODULE REFINEMENTS
+# =============================================================================
+
+# Test: Compilation unit should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'compilation_unit'
+LIMIT 1;
+----
+compilation_unit	DEFINITION_MODULE
+
+# Test: Namespace declaration should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'namespace_declaration'
+LIMIT 1;
+----
+namespace_declaration	DEFINITION_MODULE
+
+# =============================================================================
+# VARIABLE REFINEMENTS
+# =============================================================================
+
+# Test: Field declaration should be DEFINITION_VARIABLE (with FIELD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'field_declaration'
+LIMIT 1;
+----
+field_declaration	DEFINITION_VARIABLE
+
+# Test: Property declaration should be DEFINITION_VARIABLE (with FIELD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'property_declaration'
+LIMIT 1;
+----
+property_declaration	DEFINITION_VARIABLE
+
+# Test: Variable declaration should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'variable_declaration'
+LIMIT 1;
+----
+variable_declaration	DEFINITION_VARIABLE
+
+# Test: Parameter should be DEFINITION_VARIABLE (with PARAMETER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'parameter'
+LIMIT 1;
+----
+parameter	DEFINITION_VARIABLE
+
+# =============================================================================
+# IMPORT REFINEMENTS
+# =============================================================================
+
+# Test: Using directive should be EXTERNAL_IMPORT (with MODULE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'using_directive'
+LIMIT 1;
+----
+using_directive	EXTERNAL_IMPORT
+
+# =============================================================================
+# CALL REFINEMENTS
+# =============================================================================
+
+# Test: Invocation expression should be COMPUTATION_CALL (with METHOD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'invocation_expression'
+LIMIT 1;
+----
+invocation_expression	COMPUTATION_CALL
+
+# Test: Object creation expression should be COMPUTATION_CALL (with CONSTRUCTOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'object_creation_expression'
+LIMIT 1;
+----
+object_creation_expression	COMPUTATION_CALL
+
+# =============================================================================
+# CONTROL FLOW REFINEMENTS
+# =============================================================================
+
+# Test: Foreach statement should be FLOW_LOOP (with ITERATOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'foreach_statement'
+LIMIT 1;
+----
+foreach_statement	FLOW_LOOP
+
+# =============================================================================
+# JUMP REFINEMENTS
+# =============================================================================
+
+# Test: Return statement should be FLOW_JUMP (with RETURN refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'return_statement'
+LIMIT 1;
+----
+return_statement	FLOW_JUMP
+
+# =============================================================================
+# ASYNC REFINEMENTS
+# =============================================================================
+
+# Test: Await expression should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'await_expression'
+LIMIT 1;
+----
+await_expression	FLOW_SYNC
+
+# =============================================================================
+# LITERAL REFINEMENTS
+# =============================================================================
+
+# Test: Integer literal should be LITERAL_NUMBER (with INTEGER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'integer_literal'
+LIMIT 1;
+----
+integer_literal	LITERAL_NUMBER
+
+# Test: String literal should be LITERAL_STRING (with LITERAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'string_literal'
+LIMIT 1;
+----
+string_literal	LITERAL_STRING
+
+# Test: Null literal should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'null_literal'
+LIMIT 1;
+----
+null_literal	LITERAL_ATOMIC
+
+# =============================================================================
+# IDENTIFIERS
+# =============================================================================
+
+# Test: Identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'identifier'
+LIMIT 1;
+----
+identifier	NAME_IDENTIFIER
+
+# =============================================================================
+# COMMENTS
+# =============================================================================
+
+# Test: Comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/csharp/simple.cs')
+WHERE type = 'comment'
+LIMIT 1;
+----
+comment	METADATA_COMMENT

--- a/test/sql/languages/dart_refinements.test
+++ b/test/sql/languages/dart_refinements.test
@@ -1,0 +1,814 @@
+# name: test/sql/languages/dart_refinements.test
+# description: Test Dart semantic refinements
+# group: [languages]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# Dart Refinement Tests
+# =============================================================================
+#
+# Tests that semantic refinements are correctly applied to Dart code.
+# Refinements are 2-bit values in the lower bits of semantic_type that provide
+# finer-grained classification within each semantic category.
+# =============================================================================
+
+# =============================================================================
+# CLASS DEFINITION REFINEMENTS
+# =============================================================================
+
+# Test: Class definition should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'class_definition'
+LIMIT 1;
+----
+class_definition	DEFINITION_CLASS
+
+# Test: Enum declaration should be DEFINITION_CLASS (with ENUM refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'enum_declaration'
+LIMIT 1;
+----
+enum_declaration	DEFINITION_CLASS
+
+# Test: Mixin declaration should be DEFINITION_CLASS (with ABSTRACT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'mixin_declaration'
+LIMIT 1;
+----
+mixin_declaration	DEFINITION_CLASS
+
+# Test: Extension declaration should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'extension_declaration'
+LIMIT 1;
+----
+extension_declaration	DEFINITION_CLASS
+
+# Test: Type alias should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'type_alias'
+LIMIT 1;
+----
+type_alias	DEFINITION_CLASS
+
+# =============================================================================
+# FUNCTION REFINEMENTS
+# =============================================================================
+
+# Test: Function signature should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'function_signature'
+LIMIT 1;
+----
+function_signature	DEFINITION_FUNCTION
+
+# Test: Method signature should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'method_signature'
+LIMIT 1;
+----
+method_signature	DEFINITION_FUNCTION
+
+# Test: Getter signature should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'getter_signature'
+LIMIT 1;
+----
+getter_signature	DEFINITION_FUNCTION
+
+# Test: Setter signature should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'setter_signature'
+LIMIT 1;
+----
+setter_signature	DEFINITION_FUNCTION
+
+# Test: Operator signature should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'operator_signature'
+LIMIT 1;
+----
+operator_signature	DEFINITION_FUNCTION
+
+# Test: Constructor signature should be DEFINITION_FUNCTION (with CONSTRUCTOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'constructor_signature'
+LIMIT 1;
+----
+constructor_signature	DEFINITION_FUNCTION
+
+# Test: Constant constructor signature should be DEFINITION_FUNCTION (with CONSTRUCTOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'constant_constructor_signature'
+LIMIT 1;
+----
+constant_constructor_signature	DEFINITION_FUNCTION
+
+# Test: Factory constructor signature should be DEFINITION_FUNCTION (with CONSTRUCTOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'factory_constructor_signature'
+LIMIT 1;
+----
+factory_constructor_signature	DEFINITION_FUNCTION
+
+# =============================================================================
+# MODULE REFINEMENTS
+# =============================================================================
+
+# Test: Program (source file) should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'program'
+LIMIT 1;
+----
+program	DEFINITION_MODULE
+
+# =============================================================================
+# VARIABLE REFINEMENTS
+# =============================================================================
+
+# Test: Local variable declaration should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'local_variable_declaration'
+LIMIT 1;
+----
+local_variable_declaration	DEFINITION_VARIABLE
+
+# Test: Initialized variable definition should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'initialized_variable_definition'
+LIMIT 1;
+----
+initialized_variable_definition	DEFINITION_VARIABLE
+
+# Test: Formal parameter should be DEFINITION_VARIABLE (with PARAMETER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'formal_parameter'
+LIMIT 1;
+----
+formal_parameter	DEFINITION_VARIABLE
+
+# Test: Constructor param should be DEFINITION_VARIABLE (with PARAMETER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'constructor_param'
+LIMIT 1;
+----
+constructor_param	DEFINITION_VARIABLE
+
+# Test: Enum constant should be DEFINITION_VARIABLE (with FIELD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'enum_constant'
+LIMIT 1;
+----
+enum_constant	DEFINITION_VARIABLE
+
+# Test: Declaration should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'declaration'
+LIMIT 1;
+----
+declaration	DEFINITION_VARIABLE
+
+# =============================================================================
+# IMPORT REFINEMENTS
+# =============================================================================
+
+# Test: Library import should be EXTERNAL_IMPORT (with MODULE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'library_import'
+LIMIT 1;
+----
+library_import	EXTERNAL_IMPORT
+
+# Test: Import specification should be EXTERNAL_IMPORT (with MODULE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'import_specification'
+LIMIT 1;
+----
+import_specification	EXTERNAL_IMPORT
+
+# Test: Import or export should be EXTERNAL_IMPORT (with MODULE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'import_or_export'
+LIMIT 1;
+----
+import_or_export	EXTERNAL_IMPORT
+
+# =============================================================================
+# CONTROL FLOW REFINEMENTS
+# =============================================================================
+
+# Test: If statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'if_statement'
+LIMIT 1;
+----
+if_statement	FLOW_CONDITIONAL
+
+# Test: Switch expression should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'switch_expression'
+LIMIT 1;
+----
+switch_expression	FLOW_CONDITIONAL
+
+# Test: Switch expression case should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'switch_expression_case'
+LIMIT 1;
+----
+switch_expression_case	FLOW_CONDITIONAL
+
+# Test: If-null expression should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'if_null_expression'
+LIMIT 1;
+----
+if_null_expression	FLOW_CONDITIONAL
+
+# =============================================================================
+# LOOP REFINEMENTS
+# =============================================================================
+
+# Test: For statement should be FLOW_LOOP (with ITERATOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'for_statement'
+LIMIT 1;
+----
+for_statement	FLOW_LOOP
+
+# Test: While statement should be FLOW_LOOP (with CONDITIONAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'while_statement'
+LIMIT 1;
+----
+while_statement	FLOW_LOOP
+
+# Test: Do statement should be FLOW_LOOP (with CONDITIONAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'do_statement'
+LIMIT 1;
+----
+do_statement	FLOW_LOOP
+
+# =============================================================================
+# JUMP REFINEMENTS
+# =============================================================================
+
+# Test: Return statement should be FLOW_JUMP (with RETURN refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'return_statement'
+LIMIT 1;
+----
+return_statement	FLOW_JUMP
+
+# Test: Break statement should be FLOW_JUMP (with BREAK refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'break_statement'
+LIMIT 1;
+----
+break_statement	FLOW_JUMP
+
+# Test: Continue statement should be FLOW_JUMP (with CONTINUE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'continue_statement'
+LIMIT 1;
+----
+continue_statement	FLOW_JUMP
+
+# Test: break_builtin keyword should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'break_builtin'
+LIMIT 1;
+----
+break_builtin	FLOW_JUMP
+
+# =============================================================================
+# OPERATOR REFINEMENTS
+# =============================================================================
+
+# Test: Assignment expression should be OPERATOR_ASSIGNMENT (with SIMPLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'assignment_expression'
+LIMIT 1;
+----
+assignment_expression	OPERATOR_ASSIGNMENT
+
+# Test: Additive expression should be OPERATOR_ARITHMETIC (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'additive_expression'
+LIMIT 1;
+----
+additive_expression	OPERATOR_ARITHMETIC
+
+# Test: Multiplicative expression should be OPERATOR_ARITHMETIC (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'multiplicative_expression'
+LIMIT 1;
+----
+multiplicative_expression	OPERATOR_ARITHMETIC
+
+# Test: Unary expression should be OPERATOR_ARITHMETIC (with UNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'unary_expression'
+LIMIT 1;
+----
+unary_expression	OPERATOR_ARITHMETIC
+
+# Test: Postfix expression should be OPERATOR_ARITHMETIC (with UNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'postfix_expression'
+LIMIT 1;
+----
+postfix_expression	OPERATOR_ARITHMETIC
+
+# Test: Additive operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'additive_operator'
+LIMIT 1;
+----
+additive_operator	OPERATOR_ARITHMETIC
+
+# Test: Multiplicative operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'multiplicative_operator'
+LIMIT 1;
+----
+multiplicative_operator	OPERATOR_ARITHMETIC
+
+# Test: Increment operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'increment_operator'
+LIMIT 1;
+----
+increment_operator	OPERATOR_ARITHMETIC
+
+# Test: Equality expression should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'equality_expression'
+LIMIT 1;
+----
+equality_expression	OPERATOR_COMPARISON
+
+# Test: Equality operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'equality_operator'
+LIMIT 1;
+----
+equality_operator	OPERATOR_COMPARISON
+
+# Test: Relational expression should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'relational_expression'
+LIMIT 1;
+----
+relational_expression	OPERATOR_COMPARISON
+
+# Test: Relational operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'relational_operator'
+LIMIT 1;
+----
+relational_operator	OPERATOR_COMPARISON
+
+# =============================================================================
+# LITERAL REFINEMENTS
+# =============================================================================
+
+# Test: String literal should be LITERAL_STRING (with LITERAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'string_literal'
+LIMIT 1;
+----
+string_literal	LITERAL_STRING
+
+# Test: Template substitution should be LITERAL_STRING (with TEMPLATE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'template_substitution'
+LIMIT 1;
+----
+template_substitution	LITERAL_STRING
+
+# Test: URI should be LITERAL_STRING
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'uri'
+LIMIT 1;
+----
+uri	LITERAL_STRING
+
+# Test: Decimal integer literal should be LITERAL_NUMBER (with INTEGER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'decimal_integer_literal'
+LIMIT 1;
+----
+decimal_integer_literal	LITERAL_NUMBER
+
+# Test: Hex integer literal should be LITERAL_NUMBER (with INTEGER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'hex_integer_literal'
+LIMIT 1;
+----
+hex_integer_literal	LITERAL_NUMBER
+
+# Test: Decimal floating point literal should be LITERAL_NUMBER (with FLOAT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'decimal_floating_point_literal'
+LIMIT 1;
+----
+decimal_floating_point_literal	LITERAL_NUMBER
+
+# Test: Null literal should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'null_literal'
+LIMIT 1;
+----
+null_literal	LITERAL_ATOMIC
+
+# Test: List literal should be LITERAL_STRUCTURED (with SEQUENCE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'list_literal'
+LIMIT 1;
+----
+list_literal	LITERAL_STRUCTURED
+
+# Test: Set or map literal should be LITERAL_STRUCTURED (with MAPPING refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'set_or_map_literal'
+LIMIT 1;
+----
+set_or_map_literal	LITERAL_STRUCTURED
+
+# Test: Record literal should be LITERAL_STRUCTURED (with SEQUENCE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'record_literal'
+LIMIT 1;
+----
+record_literal	LITERAL_STRUCTURED
+
+# =============================================================================
+# IDENTIFIER REFINEMENTS
+# =============================================================================
+
+# Test: Identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'identifier'
+LIMIT 1;
+----
+identifier	NAME_IDENTIFIER
+
+# Test: this keyword should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'this'
+LIMIT 1;
+----
+this	NAME_IDENTIFIER
+
+# Test: Qualified identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'qualified'
+LIMIT 1;
+----
+qualified	NAME_IDENTIFIER
+
+# =============================================================================
+# ERROR HANDLING REFINEMENTS
+# =============================================================================
+
+# Test: Try statement should be ERROR_TRY
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'try_statement'
+LIMIT 1;
+----
+try_statement	ERROR_TRY
+
+# Test: Catch clause should be ERROR_CATCH
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'catch_clause'
+LIMIT 1;
+----
+catch_clause	ERROR_CATCH
+
+# Test: Finally clause should be ERROR_FINALLY
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'finally_clause'
+LIMIT 1;
+----
+finally_clause	ERROR_FINALLY
+
+# Test: Assert statement should be ERROR_THROW
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'assert_statement'
+LIMIT 1;
+----
+assert_statement	ERROR_THROW
+
+# =============================================================================
+# ASYNC REFINEMENTS
+# =============================================================================
+
+# Test: Await expression should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'await_expression'
+LIMIT 1;
+----
+await_expression	FLOW_SYNC
+
+# Test: Yield statement should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'yield_statement'
+LIMIT 1;
+----
+yield_statement	FLOW_SYNC
+
+# =============================================================================
+# METADATA REFINEMENTS
+# =============================================================================
+
+# Test: Annotation should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'annotation'
+LIMIT 1;
+----
+annotation	METADATA_ANNOTATION
+
+# Test: sealed keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'sealed'
+LIMIT 1;
+----
+sealed	METADATA_ANNOTATION
+
+# Test: final_builtin should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'final_builtin'
+LIMIT 1;
+----
+final_builtin	METADATA_ANNOTATION
+
+# Test: const_builtin should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'const_builtin'
+LIMIT 1;
+----
+const_builtin	METADATA_ANNOTATION
+
+# Test: Comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'comment'
+LIMIT 1;
+----
+comment	METADATA_COMMENT
+
+# Test: Documentation comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'documentation_comment'
+LIMIT 1;
+----
+documentation_comment	METADATA_COMMENT
+
+# =============================================================================
+# TYPE SYSTEM
+# =============================================================================
+
+# Test: Type identifier should be TYPE_REFERENCE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'type_identifier'
+LIMIT 1;
+----
+type_identifier	TYPE_REFERENCE
+
+# Test: Void type should be TYPE_PRIMITIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'void_type'
+LIMIT 1;
+----
+void_type	TYPE_PRIMITIVE
+
+# Test: Function type should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'function_type'
+LIMIT 1;
+----
+function_type	TYPE_COMPOSITE
+
+# Test: Type arguments should be TYPE_GENERIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'type_arguments'
+LIMIT 1;
+----
+type_arguments	TYPE_GENERIC
+
+# Test: Type parameters should be TYPE_GENERIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'type_parameters'
+LIMIT 1;
+----
+type_parameters	TYPE_GENERIC
+
+# =============================================================================
+# STRUCTURAL ELEMENTS
+# =============================================================================
+
+# Test: Block should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'block'
+LIMIT 1;
+----
+block	ORGANIZATION_BLOCK
+
+# Test: Formal parameter list should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'formal_parameter_list'
+LIMIT 1;
+----
+formal_parameter_list	ORGANIZATION_LIST
+
+# Test: Arguments should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'arguments'
+LIMIT 1;
+----
+arguments	ORGANIZATION_LIST
+
+# =============================================================================
+# ACCESS REFINEMENTS
+# =============================================================================
+
+# Test: Selector should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'selector'
+LIMIT 1;
+----
+selector	COMPUTATION_ACCESS
+
+# Test: Cascade section should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/dart/sample.dart')
+WHERE type = 'cascade_section'
+LIMIT 1;
+----
+cascade_section	COMPUTATION_ACCESS

--- a/test/sql/languages/lua_refinements.test
+++ b/test/sql/languages/lua_refinements.test
@@ -1,0 +1,564 @@
+# name: test/sql/languages/lua_refinements.test
+# description: Test Lua semantic refinements
+# group: [languages]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# Lua Refinement Tests
+# =============================================================================
+#
+# Tests that semantic refinements are correctly applied to Lua code.
+# Refinements are 2-bit values in the lower bits of semantic_type that provide
+# finer-grained classification within each semantic category.
+# =============================================================================
+
+# =============================================================================
+# PROGRAM STRUCTURE
+# =============================================================================
+
+# Test: Chunk (root node) should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'chunk'
+LIMIT 1;
+----
+chunk	DEFINITION_MODULE
+
+# Test: Block should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'block'
+LIMIT 1;
+----
+block	ORGANIZATION_BLOCK
+
+# =============================================================================
+# FUNCTION DEFINITIONS
+# =============================================================================
+
+# Test: Named function declaration should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'function_declaration'
+LIMIT 1;
+----
+function_declaration	DEFINITION_FUNCTION
+
+# Test: Anonymous function (function_definition) should be DEFINITION_FUNCTION (with LAMBDA refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'function_definition'
+LIMIT 1;
+----
+function_definition	DEFINITION_FUNCTION
+
+# Test: Parameters should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'parameters'
+LIMIT 1;
+----
+parameters	ORGANIZATION_LIST
+
+# Test: function keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'function'
+LIMIT 1;
+----
+function	DEFINITION_FUNCTION
+
+# =============================================================================
+# FUNCTION CALLS
+# =============================================================================
+
+# Test: Function call should be COMPUTATION_CALL (with FUNCTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'function_call'
+LIMIT 1;
+----
+function_call	COMPUTATION_CALL
+
+# Test: Method index expression should be COMPUTATION_CALL (with METHOD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'method_index_expression'
+LIMIT 1;
+----
+method_index_expression	COMPUTATION_CALL
+
+# =============================================================================
+# VARIABLE DECLARATIONS
+# =============================================================================
+
+# Test: Assignment statement should be OPERATOR_ASSIGNMENT (with SIMPLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'assignment_statement'
+LIMIT 1;
+----
+assignment_statement	OPERATOR_ASSIGNMENT
+
+# Test: Expression list should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'expression_list'
+LIMIT 1;
+----
+expression_list	ORGANIZATION_LIST
+
+# Test: local keyword should be DEFINITION_VARIABLE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'local'
+LIMIT 1;
+----
+local	DEFINITION_VARIABLE
+
+# =============================================================================
+# TABLE CONSTRUCTS
+# =============================================================================
+
+# Test: Table constructor should be LITERAL_STRUCTURED (with MAPPING refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'table_constructor'
+LIMIT 1;
+----
+table_constructor	LITERAL_STRUCTURED
+
+# Test: Field in table should be DEFINITION_VARIABLE (with FIELD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'field'
+LIMIT 1;
+----
+field	DEFINITION_VARIABLE
+
+# =============================================================================
+# IDENTIFIERS AND REFERENCES
+# =============================================================================
+
+# Test: Identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'identifier'
+LIMIT 1;
+----
+identifier	NAME_IDENTIFIER
+
+# Test: Dot index expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'dot_index_expression'
+LIMIT 1;
+----
+dot_index_expression	COMPUTATION_ACCESS
+
+# Test: Bracket index expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'bracket_index_expression'
+LIMIT 1;
+----
+bracket_index_expression	COMPUTATION_ACCESS
+
+# =============================================================================
+# LITERALS
+# =============================================================================
+
+# Test: Number literal should be LITERAL_NUMBER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'number'
+LIMIT 1;
+----
+number	LITERAL_NUMBER
+
+# Test: String literal should be LITERAL_STRING (with LITERAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'string'
+LIMIT 1;
+----
+string	LITERAL_STRING
+
+# Test: Boolean true should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'true'
+LIMIT 1;
+----
+true	LITERAL_ATOMIC
+
+# Test: Boolean false should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'false'
+LIMIT 1;
+----
+false	LITERAL_ATOMIC
+
+# =============================================================================
+# CONTROL FLOW - CONDITIONALS
+# =============================================================================
+
+# Test: If statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'if_statement'
+LIMIT 1;
+----
+if_statement	FLOW_CONDITIONAL
+
+# Test: Elseif statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'elseif_statement'
+LIMIT 1;
+----
+elseif_statement	FLOW_CONDITIONAL
+
+# Test: Else statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'else_statement'
+LIMIT 1;
+----
+else_statement	FLOW_CONDITIONAL
+
+# Test: if keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'if'
+LIMIT 1;
+----
+if	FLOW_CONDITIONAL
+
+# Test: then keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'then'
+LIMIT 1;
+----
+then	FLOW_CONDITIONAL
+
+# Test: else keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'else'
+LIMIT 1;
+----
+else	FLOW_CONDITIONAL
+
+# Test: elseif keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'elseif'
+LIMIT 1;
+----
+elseif	FLOW_CONDITIONAL
+
+# =============================================================================
+# CONTROL FLOW - LOOPS
+# =============================================================================
+
+# Test: For statement should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'for_statement'
+LIMIT 1;
+----
+for_statement	FLOW_LOOP
+
+# Test: Generic for clause should be FLOW_LOOP (with ITERATOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'for_generic_clause'
+LIMIT 1;
+----
+for_generic_clause	FLOW_LOOP
+
+# Test: Numeric for clause should be FLOW_LOOP (with COUNTER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'for_numeric_clause'
+LIMIT 1;
+----
+for_numeric_clause	FLOW_LOOP
+
+# Test: While statement should be FLOW_LOOP (with CONDITIONAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'while_statement'
+LIMIT 1;
+----
+while_statement	FLOW_LOOP
+
+# Test: Repeat statement should be FLOW_LOOP (with CONDITIONAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'repeat_statement'
+LIMIT 1;
+----
+repeat_statement	FLOW_LOOP
+
+# Test: for keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'for'
+LIMIT 1;
+----
+for	FLOW_LOOP
+
+# Test: while keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'while'
+LIMIT 1;
+----
+while	FLOW_LOOP
+
+# Test: repeat keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'repeat'
+LIMIT 1;
+----
+repeat	FLOW_LOOP
+
+# Test: until keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'until'
+LIMIT 1;
+----
+until	FLOW_LOOP
+
+# Test: in keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'in'
+LIMIT 1;
+----
+in	FLOW_LOOP
+
+# Test: do keyword should be ORGANIZATION_BLOCK
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'do'
+LIMIT 1;
+----
+do	ORGANIZATION_BLOCK
+
+# Test: end keyword should be ORGANIZATION_BLOCK
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'end'
+LIMIT 1;
+----
+end	ORGANIZATION_BLOCK
+
+# =============================================================================
+# JUMP STATEMENTS
+# =============================================================================
+
+# Test: Return statement should be FLOW_JUMP (with RETURN refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'return_statement'
+LIMIT 1;
+----
+return_statement	FLOW_JUMP
+
+# Test: return keyword should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'return'
+LIMIT 1;
+----
+return	FLOW_JUMP
+
+# =============================================================================
+# EXPRESSIONS
+# =============================================================================
+
+# Test: Binary expression should be OPERATOR_ARITHMETIC (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'binary_expression'
+LIMIT 1;
+----
+binary_expression	OPERATOR_ARITHMETIC
+
+# Test: Unary expression should be OPERATOR_ARITHMETIC (with UNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'unary_expression'
+LIMIT 1;
+----
+unary_expression	OPERATOR_ARITHMETIC
+
+# =============================================================================
+# OPERATORS
+# =============================================================================
+
+# Test: + operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '+'
+LIMIT 1;
+----
++	OPERATOR_ARITHMETIC
+
+# Test: - operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '-'
+LIMIT 1;
+----
+-	OPERATOR_ARITHMETIC
+
+# Test: * operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '*'
+LIMIT 1;
+----
+*	OPERATOR_ARITHMETIC
+
+# Test: / operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '/'
+LIMIT 1;
+----
+/	OPERATOR_ARITHMETIC
+
+# Test: % operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '%'
+LIMIT 1;
+----
+%	OPERATOR_ARITHMETIC
+
+# Test: .. (concat) operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '..'
+LIMIT 1;
+----
+..	OPERATOR_ARITHMETIC
+
+# Test: # (length) operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '#'
+LIMIT 1;
+----
+#	OPERATOR_ARITHMETIC
+
+# Test: == operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '=='
+LIMIT 1;
+----
+==	OPERATOR_COMPARISON
+
+# Test: <= operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '<='
+LIMIT 1;
+----
+<=	OPERATOR_COMPARISON
+
+# Test: > operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '>'
+LIMIT 1;
+----
+>	OPERATOR_COMPARISON
+
+# Test: = assignment operator should be OPERATOR_ASSIGNMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = '='
+LIMIT 1;
+----
+=	OPERATOR_ASSIGNMENT
+
+# =============================================================================
+# COMMENTS AND METADATA
+# =============================================================================
+
+# Test: Comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/lua/simple.lua', context := 'native')
+WHERE type = 'comment'
+LIMIT 1;
+----
+comment	METADATA_COMMENT

--- a/test/sql/languages/php_refinements.test
+++ b/test/sql/languages/php_refinements.test
@@ -1,0 +1,508 @@
+# name: test/sql/languages/php_refinements.test
+# description: Test PHP semantic refinements
+# group: [languages]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# PHP Refinement Tests
+# =============================================================================
+#
+# Tests that semantic refinements are correctly applied to PHP code.
+# Refinements are 2-bit values in the lower bits of semantic_type that provide
+# finer-grained classification within each semantic category.
+# =============================================================================
+
+# =============================================================================
+# CLASS AND INTERFACE DEFINITIONS
+# =============================================================================
+
+# Test: Class declaration should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'class_declaration'
+LIMIT 1;
+----
+class_declaration	DEFINITION_CLASS
+
+# Test: Interface declaration should be DEFINITION_CLASS (with ABSTRACT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'interface_declaration'
+LIMIT 1;
+----
+interface_declaration	DEFINITION_CLASS
+
+# Test: Trait declaration should be DEFINITION_CLASS (with ABSTRACT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'trait_declaration'
+LIMIT 1;
+----
+trait_declaration	DEFINITION_CLASS
+
+# Test: Enum declaration should be DEFINITION_CLASS (with ENUM refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'enum_declaration'
+LIMIT 1;
+----
+enum_declaration	DEFINITION_CLASS
+
+# =============================================================================
+# FUNCTION AND METHOD DEFINITIONS
+# =============================================================================
+
+# Test: Function definition should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'function_definition'
+LIMIT 1;
+----
+function_definition	DEFINITION_FUNCTION
+
+# Test: function keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'function'
+LIMIT 1;
+----
+function	DEFINITION_FUNCTION
+
+# Test: Method declaration should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'method_declaration'
+LIMIT 1;
+----
+method_declaration	DEFINITION_FUNCTION
+
+# Test: Arrow function should be DEFINITION_FUNCTION (with LAMBDA refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'arrow_function'
+LIMIT 1;
+----
+arrow_function	DEFINITION_FUNCTION
+
+# =============================================================================
+# MODULE DEFINITIONS
+# =============================================================================
+
+# Test: Program root should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'program'
+LIMIT 1;
+----
+program	DEFINITION_MODULE
+
+# Test: Namespace definition should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'namespace_definition'
+LIMIT 1;
+----
+namespace_definition	DEFINITION_MODULE
+
+# =============================================================================
+# VARIABLE DEFINITIONS
+# =============================================================================
+
+# Test: Property declaration should be DEFINITION_VARIABLE (with FIELD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'property_declaration'
+LIMIT 1;
+----
+property_declaration	DEFINITION_VARIABLE
+
+# Test: Const declaration should be DEFINITION_VARIABLE (with IMMUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'const_declaration'
+LIMIT 1;
+----
+const_declaration	DEFINITION_VARIABLE
+
+# Test: Simple parameter should be DEFINITION_VARIABLE (with PARAMETER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'simple_parameter'
+LIMIT 1;
+----
+simple_parameter	DEFINITION_VARIABLE
+
+# =============================================================================
+# IMPORT DEFINITIONS
+# =============================================================================
+
+# Test: Namespace use declaration should be EXTERNAL_IMPORT (with MODULE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'namespace_use_declaration'
+LIMIT 1;
+----
+namespace_use_declaration	EXTERNAL_IMPORT
+
+# =============================================================================
+# CALL EXPRESSIONS
+# =============================================================================
+
+# Test: Function call expression should be COMPUTATION_CALL (with FUNCTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'function_call_expression'
+LIMIT 1;
+----
+function_call_expression	COMPUTATION_CALL
+
+# Test: Method call expression should be COMPUTATION_CALL (with METHOD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'member_call_expression'
+LIMIT 1;
+----
+member_call_expression	COMPUTATION_CALL
+
+# Test: Static call expression should be COMPUTATION_CALL (with METHOD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'scoped_call_expression'
+LIMIT 1;
+----
+scoped_call_expression	COMPUTATION_CALL
+
+# Test: Object creation should be COMPUTATION_CALL (with CONSTRUCTOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'object_creation_expression'
+LIMIT 1;
+----
+object_creation_expression	COMPUTATION_CALL
+
+# Test: Member access expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'member_access_expression'
+LIMIT 1;
+----
+member_access_expression	COMPUTATION_ACCESS
+
+# Test: Subscript expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'subscript_expression'
+LIMIT 1;
+----
+subscript_expression	COMPUTATION_ACCESS
+
+# =============================================================================
+# CONTROL FLOW - CONDITIONALS
+# =============================================================================
+
+# Test: If statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'if_statement'
+LIMIT 1;
+----
+if_statement	FLOW_CONDITIONAL
+
+# Test: Match expression should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'match_expression'
+LIMIT 1;
+----
+match_expression	FLOW_CONDITIONAL
+
+# =============================================================================
+# CONTROL FLOW - LOOPS
+# =============================================================================
+
+# Test: Foreach statement should be FLOW_LOOP (with ITERATOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'foreach_statement'
+LIMIT 1;
+----
+foreach_statement	FLOW_LOOP
+
+# =============================================================================
+# CONTROL FLOW - JUMPS
+# =============================================================================
+
+# Test: Return statement should be FLOW_JUMP (with RETURN refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'return_statement'
+LIMIT 1;
+----
+return_statement	FLOW_JUMP
+
+# =============================================================================
+# EXCEPTION HANDLING
+# =============================================================================
+
+# Test: Try statement should be ERROR_TRY
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'try_statement'
+LIMIT 1;
+----
+try_statement	ERROR_TRY
+
+# Test: Catch clause should be ERROR_CATCH
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'catch_clause'
+LIMIT 1;
+----
+catch_clause	ERROR_CATCH
+
+# Test: Finally clause should be ERROR_FINALLY
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'finally_clause'
+LIMIT 1;
+----
+finally_clause	ERROR_FINALLY
+
+# =============================================================================
+# OPERATORS
+# =============================================================================
+
+# Test: Binary expression should be OPERATOR_ARITHMETIC (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'binary_expression'
+LIMIT 1;
+----
+binary_expression	OPERATOR_ARITHMETIC
+
+# Test: Unary expression should be OPERATOR_ARITHMETIC (with UNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'unary_op_expression'
+LIMIT 1;
+----
+unary_op_expression	OPERATOR_ARITHMETIC
+
+# Test: Assignment expression should be OPERATOR_ASSIGNMENT (with SIMPLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'assignment_expression'
+LIMIT 1;
+----
+assignment_expression	OPERATOR_ASSIGNMENT
+
+# =============================================================================
+# LITERALS
+# =============================================================================
+
+# Test: Integer literal should be LITERAL_NUMBER (with INTEGER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'integer'
+LIMIT 1;
+----
+integer	LITERAL_NUMBER
+
+# Test: String literal should be LITERAL_STRING (with LITERAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'string'
+LIMIT 1;
+----
+string	LITERAL_STRING
+
+# Test: Encapsed string should be LITERAL_STRING (with TEMPLATE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'encapsed_string'
+LIMIT 1;
+----
+encapsed_string	LITERAL_STRING
+
+# Test: Heredoc should be LITERAL_STRING (with RAW refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'heredoc'
+LIMIT 1;
+----
+heredoc	LITERAL_STRING
+
+# Test: Shell command expression should be LITERAL_STRING (with TEMPLATE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'shell_command_expression'
+LIMIT 1;
+----
+shell_command_expression	LITERAL_STRING
+
+# Test: Null literal should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'null'
+LIMIT 1;
+----
+null	LITERAL_ATOMIC
+
+# Test: Array creation expression should be LITERAL_STRUCTURED (with SEQUENCE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'array_creation_expression'
+LIMIT 1;
+----
+array_creation_expression	LITERAL_STRUCTURED
+
+# =============================================================================
+# IDENTIFIERS
+# =============================================================================
+
+# Test: Name should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'name'
+LIMIT 1;
+----
+name	NAME_IDENTIFIER
+
+# Test: Variable name should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'variable_name'
+LIMIT 1;
+----
+variable_name	NAME_IDENTIFIER
+
+# =============================================================================
+# TYPE SYSTEM
+# =============================================================================
+
+# Test: Named type should be TYPE_REFERENCE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'named_type'
+LIMIT 1;
+----
+named_type	TYPE_REFERENCE
+
+# Test: Primitive type should be TYPE_PRIMITIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'primitive_type'
+LIMIT 1;
+----
+primitive_type	TYPE_PRIMITIVE
+
+# Test: Optional type should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'optional_type'
+LIMIT 1;
+----
+optional_type	TYPE_COMPOSITE
+
+# =============================================================================
+# METADATA
+# =============================================================================
+
+# Test: Visibility modifier should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'visibility_modifier'
+LIMIT 1;
+----
+visibility_modifier	METADATA_ANNOTATION
+
+# Test: Static modifier should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'static_modifier'
+LIMIT 1;
+----
+static_modifier	METADATA_ANNOTATION
+
+# Test: Comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'comment'
+LIMIT 1;
+----
+comment	METADATA_COMMENT
+
+# =============================================================================
+# STATEMENTS
+# =============================================================================
+
+# Test: Echo statement should be EXECUTION_STATEMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'echo_statement'
+LIMIT 1;
+----
+echo_statement	EXECUTION_STATEMENT
+
+# =============================================================================
+# STRUCTURAL ELEMENTS
+# =============================================================================
+
+# Test: Formal parameters should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/languages/php/test.php')
+WHERE type = 'formal_parameters'
+LIMIT 1;
+----
+formal_parameters	ORGANIZATION_LIST

--- a/test/sql/languages/swift_refinements.test
+++ b/test/sql/languages/swift_refinements.test
@@ -1,0 +1,809 @@
+# name: test/sql/languages/swift_refinements.test
+# description: Test Swift semantic refinements
+# group: [languages]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# Swift Refinement Tests
+# =============================================================================
+#
+# Tests that semantic refinements are correctly applied to Swift code.
+# Refinements are 2-bit values in the lower bits of semantic_type that provide
+# finer-grained classification within each semantic category.
+# =============================================================================
+
+# =============================================================================
+# TYPE DEFINITION REFINEMENTS
+# =============================================================================
+
+# Test: Class declaration should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'class_declaration'
+LIMIT 1;
+----
+class_declaration	DEFINITION_CLASS
+
+# Test: Protocol declaration should be DEFINITION_CLASS (with ABSTRACT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'protocol_declaration'
+LIMIT 1;
+----
+protocol_declaration	DEFINITION_CLASS
+
+# Test: Associated type declaration should be DEFINITION_CLASS (with ABSTRACT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'associatedtype_declaration'
+LIMIT 1;
+----
+associatedtype_declaration	DEFINITION_CLASS
+
+# Test: class keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'class'
+LIMIT 1;
+----
+class	DEFINITION_CLASS
+
+# Test: struct keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'struct'
+LIMIT 1;
+----
+struct	DEFINITION_CLASS
+
+# Test: enum keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'enum'
+LIMIT 1;
+----
+enum	DEFINITION_CLASS
+
+# Test: protocol keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'protocol'
+LIMIT 1;
+----
+protocol	DEFINITION_CLASS
+
+# Test: extension keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'extension'
+LIMIT 1;
+----
+extension	DEFINITION_CLASS
+
+# Test: actor keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'actor'
+LIMIT 1;
+----
+actor	DEFINITION_CLASS
+
+# Test: associatedtype keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'associatedtype'
+LIMIT 1;
+----
+associatedtype	DEFINITION_CLASS
+
+# =============================================================================
+# FUNCTION REFINEMENTS
+# =============================================================================
+
+# Test: Function declarations should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'function_declaration'
+LIMIT 1;
+----
+function_declaration	DEFINITION_FUNCTION
+
+# Test: Initializer declarations should be DEFINITION_FUNCTION (with CONSTRUCTOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'init_declaration'
+LIMIT 1;
+----
+init_declaration	DEFINITION_FUNCTION
+
+# Test: Deinitializer declarations should be DEFINITION_FUNCTION (with CONSTRUCTOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'deinit_declaration'
+LIMIT 1;
+----
+deinit_declaration	DEFINITION_FUNCTION
+
+# Test: Subscript declarations should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'subscript_declaration'
+LIMIT 1;
+----
+subscript_declaration	DEFINITION_FUNCTION
+
+# Test: Lambda literals should be DEFINITION_FUNCTION (with LAMBDA refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'lambda_literal'
+LIMIT 1;
+----
+lambda_literal	DEFINITION_FUNCTION
+
+# Test: func keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'func'
+LIMIT 1;
+----
+func	DEFINITION_FUNCTION
+
+# Test: init keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'init'
+LIMIT 1;
+----
+init	DEFINITION_FUNCTION
+
+# Test: deinit keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'deinit'
+LIMIT 1;
+----
+deinit	DEFINITION_FUNCTION
+
+# Test: subscript keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'subscript'
+LIMIT 1;
+----
+subscript	DEFINITION_FUNCTION
+
+# =============================================================================
+# MODULE REFINEMENTS
+# =============================================================================
+
+# Test: Source file should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'source_file'
+LIMIT 1;
+----
+source_file	DEFINITION_MODULE
+
+# =============================================================================
+# VARIABLE REFINEMENTS
+# =============================================================================
+
+# Test: Property declarations should be DEFINITION_VARIABLE (with FIELD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'property_declaration'
+LIMIT 1;
+----
+property_declaration	DEFINITION_VARIABLE
+
+# Test: Parameter should be DEFINITION_VARIABLE (with PARAMETER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'parameter'
+LIMIT 1;
+----
+parameter	DEFINITION_VARIABLE
+
+# Test: let keyword should be DEFINITION_VARIABLE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'let'
+LIMIT 1;
+----
+let	DEFINITION_VARIABLE
+
+# Test: var keyword should be DEFINITION_VARIABLE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'var'
+LIMIT 1;
+----
+var	DEFINITION_VARIABLE
+
+# =============================================================================
+# IMPORT REFINEMENTS
+# =============================================================================
+
+# Test: Import declaration should be EXTERNAL_IMPORT (with MODULE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'import_declaration'
+LIMIT 1;
+----
+import_declaration	EXTERNAL_IMPORT
+
+# Test: import keyword should be EXTERNAL_IMPORT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'import'
+LIMIT 1;
+----
+import	EXTERNAL_IMPORT
+
+# =============================================================================
+# CALL REFINEMENTS
+# =============================================================================
+
+# Test: Call expressions should be COMPUTATION_CALL (with FUNCTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'call_expression'
+LIMIT 1;
+----
+call_expression	COMPUTATION_CALL
+
+# Test: Postfix expression should be COMPUTATION_CALL (with METHOD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'postfix_expression'
+LIMIT 1;
+----
+postfix_expression	COMPUTATION_CALL
+
+# Test: Navigation expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'navigation_expression'
+LIMIT 1;
+----
+navigation_expression	COMPUTATION_ACCESS
+
+# =============================================================================
+# CONTROL FLOW REFINEMENTS
+# =============================================================================
+
+# Test: If statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'if_statement'
+LIMIT 1;
+----
+if_statement	FLOW_CONDITIONAL
+
+# Test: Guard statement should be FLOW_CONDITIONAL (with GUARD refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'guard_statement'
+LIMIT 1;
+----
+guard_statement	FLOW_CONDITIONAL
+
+# Test: Switch statement should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'switch_statement'
+LIMIT 1;
+----
+switch_statement	FLOW_CONDITIONAL
+
+# Test: Ternary expression should be FLOW_CONDITIONAL (with TERNARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'ternary_expression'
+LIMIT 1;
+----
+ternary_expression	FLOW_CONDITIONAL
+
+# Test: if keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'if'
+LIMIT 1;
+----
+if	FLOW_CONDITIONAL
+
+# Test: guard keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'guard'
+LIMIT 1;
+----
+guard	FLOW_CONDITIONAL
+
+# Test: switch keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'switch'
+LIMIT 1;
+----
+switch	FLOW_CONDITIONAL
+
+# Test: else keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'else'
+LIMIT 1;
+----
+else	FLOW_CONDITIONAL
+
+# Test: case keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'case'
+LIMIT 1;
+----
+case	FLOW_CONDITIONAL
+
+# =============================================================================
+# LOOP REFINEMENTS
+# =============================================================================
+
+# Test: For statement should be FLOW_LOOP (with ITERATOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'for_statement'
+LIMIT 1;
+----
+for_statement	FLOW_LOOP
+
+# Test: for keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'for'
+LIMIT 1;
+----
+for	FLOW_LOOP
+
+# Test: in keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'in'
+LIMIT 1;
+----
+in	FLOW_LOOP
+
+# =============================================================================
+# JUMP REFINEMENTS
+# =============================================================================
+
+# Test: return keyword should be FLOW_JUMP (with RETURN refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'return'
+LIMIT 1;
+----
+return	FLOW_JUMP
+
+# =============================================================================
+# ASYNC/AWAIT AND CONCURRENCY
+# =============================================================================
+
+# Test: Await expression should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'await_expression'
+LIMIT 1;
+----
+await_expression	FLOW_SYNC
+
+# Test: Do statement should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'do_statement'
+LIMIT 1;
+----
+do_statement	FLOW_SYNC
+
+# Test: async keyword should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'async'
+LIMIT 1;
+----
+async	FLOW_SYNC
+
+# Test: await keyword should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'await'
+LIMIT 1;
+----
+await	FLOW_SYNC
+
+# Test: do keyword should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'do'
+LIMIT 1;
+----
+do	FLOW_SYNC
+
+# =============================================================================
+# ERROR HANDLING
+# =============================================================================
+
+# Test: Try expression should be ERROR_TRY
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'try_expression'
+LIMIT 1;
+----
+try_expression	ERROR_TRY
+
+# Test: try keyword should be ERROR_TRY
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'try'
+LIMIT 1;
+----
+try	ERROR_TRY
+
+# Test: throws keyword should be ERROR_THROW
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'throws'
+LIMIT 1;
+----
+throws	ERROR_THROW
+
+# =============================================================================
+# OPERATOR REFINEMENTS
+# =============================================================================
+
+# Test: Custom operator should be OPERATOR_ARITHMETIC (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'custom_operator'
+LIMIT 1;
+----
+custom_operator	OPERATOR_ARITHMETIC
+
+# Test: as keyword should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'as'
+LIMIT 1;
+----
+as	OPERATOR_COMPARISON
+
+# =============================================================================
+# LITERAL REFINEMENTS
+# =============================================================================
+
+# Test: Integer literal should be LITERAL_NUMBER (with INTEGER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'integer_literal'
+LIMIT 1;
+----
+integer_literal	LITERAL_NUMBER
+
+# Test: Real literal should be LITERAL_NUMBER (with FLOAT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'real_literal'
+LIMIT 1;
+----
+real_literal	LITERAL_NUMBER
+
+# Test: Boolean literal should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'boolean_literal'
+LIMIT 1;
+----
+boolean_literal	LITERAL_ATOMIC
+
+# Test: true keyword should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'true'
+LIMIT 1;
+----
+true	LITERAL_ATOMIC
+
+# Test: false keyword should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'false'
+LIMIT 1;
+----
+false	LITERAL_ATOMIC
+
+# Test: nil keyword should be LITERAL_ATOMIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'nil'
+LIMIT 1;
+----
+nil	LITERAL_ATOMIC
+
+# Test: Array literal should be LITERAL_STRUCTURED (with SEQUENCE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'array_literal'
+LIMIT 1;
+----
+array_literal	LITERAL_STRUCTURED
+
+# Test: Dictionary literal should be LITERAL_STRUCTURED (with MAPPING refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'dictionary_literal'
+LIMIT 1;
+----
+dictionary_literal	LITERAL_STRUCTURED
+
+# Test: Tuple expression should be LITERAL_STRUCTURED (with SEQUENCE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'tuple_expression'
+LIMIT 1;
+----
+tuple_expression	LITERAL_STRUCTURED
+
+# =============================================================================
+# TYPE SYSTEM
+# =============================================================================
+
+# Test: Type identifier should be TYPE_PRIMITIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'type_identifier'
+LIMIT 1;
+----
+type_identifier	TYPE_PRIMITIVE
+
+# Test: User type should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'user_type'
+LIMIT 1;
+----
+user_type	TYPE_COMPOSITE
+
+# Test: Array type should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'array_type'
+LIMIT 1;
+----
+array_type	TYPE_COMPOSITE
+
+# Test: Dictionary type should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'dictionary_type'
+LIMIT 1;
+----
+dictionary_type	TYPE_COMPOSITE
+
+# Test: Function type should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'function_type'
+LIMIT 1;
+----
+function_type	TYPE_COMPOSITE
+
+# Test: Tuple type should be TYPE_COMPOSITE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'tuple_type'
+LIMIT 1;
+----
+tuple_type	TYPE_COMPOSITE
+
+# Test: Optional type should be TYPE_REFERENCE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'optional_type'
+LIMIT 1;
+----
+optional_type	TYPE_REFERENCE
+
+# =============================================================================
+# STRUCTURAL ELEMENTS
+# =============================================================================
+
+# Test: Statements block should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'statements'
+LIMIT 1;
+----
+statements	ORGANIZATION_BLOCK
+
+# =============================================================================
+# IDENTIFIERS
+# =============================================================================
+
+# Test: Simple identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'simple_identifier'
+LIMIT 1;
+----
+simple_identifier	NAME_IDENTIFIER
+
+# Test: Identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'identifier'
+LIMIT 1;
+----
+identifier	NAME_IDENTIFIER
+
+# Test: self keyword should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'self'
+LIMIT 1;
+----
+self	NAME_IDENTIFIER
+
+# Test: super keyword should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'super'
+LIMIT 1;
+----
+super	NAME_IDENTIFIER
+
+# =============================================================================
+# METADATA AND ANNOTATIONS
+# =============================================================================
+
+# Test: Attribute should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'attribute'
+LIMIT 1;
+----
+attribute	METADATA_ANNOTATION
+
+# Test: Visibility modifier should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'visibility_modifier'
+LIMIT 1;
+----
+visibility_modifier	METADATA_ANNOTATION
+
+# Test: Mutation modifier should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'mutation_modifier'
+LIMIT 1;
+----
+mutation_modifier	METADATA_ANNOTATION
+
+# Test: Modifiers should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'modifiers'
+LIMIT 1;
+----
+modifiers	METADATA_ANNOTATION
+
+# Test: private keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'private'
+LIMIT 1;
+----
+private	METADATA_ANNOTATION
+
+# Test: static keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'static'
+LIMIT 1;
+----
+static	METADATA_ANNOTATION
+
+# =============================================================================
+# COMMENTS
+# =============================================================================
+
+# Test: Comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/swift/simple.swift')
+WHERE type = 'comment'
+LIMIT 1;
+----
+comment	METADATA_COMMENT

--- a/test/sql/languages/zig_refinements.test
+++ b/test/sql/languages/zig_refinements.test
@@ -1,0 +1,729 @@
+# name: test/sql/languages/zig_refinements.test
+# description: Test Zig semantic refinements
+# group: [languages]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# Zig Refinement Tests
+# =============================================================================
+#
+# Tests that semantic refinements are correctly applied to Zig code.
+# Refinements are 2-bit values in the lower bits of semantic_type that provide
+# finer-grained classification within each semantic category.
+# =============================================================================
+
+# =============================================================================
+# FUNCTION REFINEMENTS
+# =============================================================================
+
+# Test: Function declaration should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'function_declaration'
+LIMIT 1;
+----
+function_declaration	DEFINITION_FUNCTION
+
+# Test: Test declaration should be DEFINITION_FUNCTION (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'test_declaration'
+LIMIT 1;
+----
+test_declaration	DEFINITION_FUNCTION
+
+# Test: fn keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'fn'
+LIMIT 1;
+----
+fn	DEFINITION_FUNCTION
+
+# Test: test keyword should be DEFINITION_FUNCTION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'test'
+LIMIT 1;
+----
+test	DEFINITION_FUNCTION
+
+# =============================================================================
+# VARIABLE REFINEMENTS
+# =============================================================================
+
+# Test: Variable declaration should be DEFINITION_VARIABLE (with MUTABLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'variable_declaration'
+LIMIT 1;
+----
+variable_declaration	DEFINITION_VARIABLE
+
+# Test: Parameter should be DEFINITION_VARIABLE (with PARAMETER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'parameter'
+LIMIT 1;
+----
+parameter	DEFINITION_VARIABLE
+
+# Test: const keyword should be DEFINITION_VARIABLE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'const'
+LIMIT 1;
+----
+const	DEFINITION_VARIABLE
+
+# Test: var keyword should be DEFINITION_VARIABLE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'var'
+LIMIT 1;
+----
+var	DEFINITION_VARIABLE
+
+# =============================================================================
+# TYPE DEFINITION REFINEMENTS
+# =============================================================================
+
+# Test: Struct declaration should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'struct_declaration'
+LIMIT 1;
+----
+struct_declaration	DEFINITION_CLASS
+
+# Test: Enum declaration should be DEFINITION_CLASS (with ENUM refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'enum_declaration'
+LIMIT 1;
+----
+enum_declaration	DEFINITION_CLASS
+
+# Test: Union declaration should be DEFINITION_CLASS (with REGULAR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'union_declaration'
+LIMIT 1;
+----
+union_declaration	DEFINITION_CLASS
+
+# Test: Error set declaration should be DEFINITION_CLASS (with ENUM refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'error_set_declaration'
+LIMIT 1;
+----
+error_set_declaration	DEFINITION_CLASS
+
+# Test: struct keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'struct'
+LIMIT 1;
+----
+struct	DEFINITION_CLASS
+
+# Test: enum keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'enum'
+LIMIT 1;
+----
+enum	DEFINITION_CLASS
+
+# Test: union keyword should be DEFINITION_CLASS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'union'
+LIMIT 1;
+----
+union	DEFINITION_CLASS
+
+# =============================================================================
+# MODULE REFINEMENTS
+# =============================================================================
+
+# Test: Source file should be DEFINITION_MODULE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'source_file'
+LIMIT 1;
+----
+source_file	DEFINITION_MODULE
+
+# =============================================================================
+# IMPORT REFINEMENTS
+# =============================================================================
+
+# Test: try expression should be ERROR_TRY
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'try_expression'
+LIMIT 1;
+----
+try_expression	ERROR_TRY
+
+# Test: try keyword should be ERROR_TRY
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'try'
+LIMIT 1;
+----
+try	ERROR_TRY
+
+# =============================================================================
+# CONTROL FLOW REFINEMENTS
+# =============================================================================
+
+# Test: If statement should be FLOW_CONDITIONAL (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'if_statement'
+LIMIT 1;
+----
+if_statement	FLOW_CONDITIONAL
+
+# Test: Switch expression should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'switch_expression'
+LIMIT 1;
+----
+switch_expression	FLOW_CONDITIONAL
+
+# Test: Switch case should be FLOW_CONDITIONAL (with MULTIWAY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'switch_case'
+LIMIT 1;
+----
+switch_case	FLOW_CONDITIONAL
+
+# Test: if keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'if'
+LIMIT 1;
+----
+if	FLOW_CONDITIONAL
+
+# Test: else keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'else'
+LIMIT 1;
+----
+else	FLOW_CONDITIONAL
+
+# Test: switch keyword should be FLOW_CONDITIONAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'switch'
+LIMIT 1;
+----
+switch	FLOW_CONDITIONAL
+
+# =============================================================================
+# LOOP REFINEMENTS
+# =============================================================================
+
+# Test: While statement should be FLOW_LOOP (with CONDITIONAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'while_statement'
+LIMIT 1;
+----
+while_statement	FLOW_LOOP
+
+# Test: For statement should be FLOW_LOOP (with ITERATOR refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'for_statement'
+LIMIT 1;
+----
+for_statement	FLOW_LOOP
+
+# Test: while keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'while'
+LIMIT 1;
+----
+while	FLOW_LOOP
+
+# Test: for keyword should be FLOW_LOOP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'for'
+LIMIT 1;
+----
+for	FLOW_LOOP
+
+# =============================================================================
+# JUMP REFINEMENTS
+# =============================================================================
+
+# Test: Return expression should be FLOW_JUMP (with RETURN refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'return_expression'
+LIMIT 1;
+----
+return_expression	FLOW_JUMP
+
+# Test: Break expression should be FLOW_JUMP (with BREAK refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'break_expression'
+LIMIT 1;
+----
+break_expression	FLOW_JUMP
+
+# Test: Continue expression should be FLOW_JUMP (with CONTINUE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'continue_expression'
+LIMIT 1;
+----
+continue_expression	FLOW_JUMP
+
+# Test: Defer statement should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'defer_statement'
+LIMIT 1;
+----
+defer_statement	FLOW_JUMP
+
+# Test: return keyword should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'return'
+LIMIT 1;
+----
+return	FLOW_JUMP
+
+# Test: break keyword should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'break'
+LIMIT 1;
+----
+break	FLOW_JUMP
+
+# Test: continue keyword should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'continue'
+LIMIT 1;
+----
+continue	FLOW_JUMP
+
+# Test: defer keyword should be FLOW_JUMP
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'defer'
+LIMIT 1;
+----
+defer	FLOW_JUMP
+
+# =============================================================================
+# ASYNC REFINEMENTS
+# =============================================================================
+
+# Test: Suspend statement should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'suspend_statement'
+LIMIT 1;
+----
+suspend_statement	FLOW_SYNC
+
+# Test: suspend keyword should be FLOW_SYNC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'suspend'
+LIMIT 1;
+----
+suspend	FLOW_SYNC
+
+# =============================================================================
+# CALL REFINEMENTS
+# =============================================================================
+
+# Test: Call expression should be COMPUTATION_CALL (with FUNCTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'call_expression'
+LIMIT 1;
+----
+call_expression	COMPUTATION_CALL
+
+# Test: Builtin function should be COMPUTATION_CALL (with FUNCTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'builtin_function'
+LIMIT 1;
+----
+builtin_function	COMPUTATION_CALL
+
+# Test: Field expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'field_expression'
+LIMIT 1;
+----
+field_expression	COMPUTATION_ACCESS
+
+# Test: Dereference expression should be COMPUTATION_ACCESS
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'dereference_expression'
+LIMIT 1;
+----
+dereference_expression	COMPUTATION_ACCESS
+
+# =============================================================================
+# OPERATOR REFINEMENTS
+# =============================================================================
+
+# Test: Binary expression should be OPERATOR_ARITHMETIC (with BINARY refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'binary_expression'
+LIMIT 1;
+----
+binary_expression	OPERATOR_ARITHMETIC
+
+# Test: Assignment expression should be OPERATOR_ASSIGNMENT (with SIMPLE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'assignment_expression'
+LIMIT 1;
+----
+assignment_expression	OPERATOR_ASSIGNMENT
+
+# Test: = operator should be OPERATOR_ASSIGNMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = '='
+LIMIT 1;
+----
+=	OPERATOR_ASSIGNMENT
+
+# Test: + operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = '+'
+LIMIT 1;
+----
++	OPERATOR_ARITHMETIC
+
+# Test: * operator should be OPERATOR_ARITHMETIC
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = '*'
+LIMIT 1;
+----
+*	OPERATOR_ARITHMETIC
+
+# Test: == operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = '=='
+LIMIT 1;
+----
+==	OPERATOR_COMPARISON
+
+# Test: < operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = '<'
+LIMIT 1;
+----
+<	OPERATOR_COMPARISON
+
+# Test: > operator should be OPERATOR_COMPARISON
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = '>'
+LIMIT 1;
+----
+>	OPERATOR_COMPARISON
+
+# Test: ! operator should be OPERATOR_LOGICAL
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = '!'
+LIMIT 1;
+----
+!	OPERATOR_LOGICAL
+
+# =============================================================================
+# LITERAL REFINEMENTS
+# =============================================================================
+
+# Test: Integer literal should be LITERAL_NUMBER (with INTEGER refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'integer'
+LIMIT 1;
+----
+integer	LITERAL_NUMBER
+
+# Test: Float literal should be LITERAL_NUMBER (with FLOAT refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'float'
+LIMIT 1;
+----
+float	LITERAL_NUMBER
+
+# Test: String literal should be LITERAL_STRING (with LITERAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'string'
+LIMIT 1;
+----
+string	LITERAL_STRING
+
+# Test: String content should be LITERAL_STRING
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'string_content'
+LIMIT 1;
+----
+string_content	LITERAL_STRING
+
+# Test: Struct initializer should be LITERAL_STRUCTURED (with MAPPING refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'struct_initializer'
+LIMIT 1;
+----
+struct_initializer	LITERAL_STRUCTURED
+
+# Test: Anonymous struct initializer should be LITERAL_STRUCTURED (with MAPPING refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'anonymous_struct_initializer'
+LIMIT 1;
+----
+anonymous_struct_initializer	LITERAL_STRUCTURED
+
+# Test: Initializer list should be LITERAL_STRUCTURED (with SEQUENCE refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'initializer_list'
+LIMIT 1;
+----
+initializer_list	LITERAL_STRUCTURED
+
+# =============================================================================
+# IDENTIFIER REFINEMENTS
+# =============================================================================
+
+# Test: Identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'identifier'
+LIMIT 1;
+----
+identifier	NAME_IDENTIFIER
+
+# Test: Builtin identifier should be NAME_IDENTIFIER
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'builtin_identifier'
+LIMIT 1;
+----
+builtin_identifier	NAME_IDENTIFIER
+
+# =============================================================================
+# METADATA REFINEMENTS
+# =============================================================================
+
+# Test: Comptime statement should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'comptime_statement'
+LIMIT 1;
+----
+comptime_statement	METADATA_ANNOTATION
+
+# Test: pub keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'pub'
+LIMIT 1;
+----
+pub	METADATA_ANNOTATION
+
+# Test: comptime keyword should be METADATA_ANNOTATION
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'comptime'
+LIMIT 1;
+----
+comptime	METADATA_ANNOTATION
+
+# Test: Comment should be METADATA_COMMENT
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'comment'
+LIMIT 1;
+----
+comment	METADATA_COMMENT
+
+# =============================================================================
+# TYPE SYSTEM
+# =============================================================================
+
+# Test: Builtin type should be TYPE_PRIMITIVE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'builtin_type'
+LIMIT 1;
+----
+builtin_type	TYPE_PRIMITIVE
+
+# Test: Pointer type should be TYPE_REFERENCE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'pointer_type'
+LIMIT 1;
+----
+pointer_type	TYPE_REFERENCE
+
+# Test: Array type should be TYPE_REFERENCE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'array_type'
+LIMIT 1;
+----
+array_type	TYPE_REFERENCE
+
+# Test: Error union type should be TYPE_REFERENCE
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'error_union_type'
+LIMIT 1;
+----
+error_union_type	TYPE_REFERENCE
+
+# =============================================================================
+# STRUCTURAL ELEMENTS
+# =============================================================================
+
+# Test: Block should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'block'
+LIMIT 1;
+----
+block	ORGANIZATION_BLOCK
+
+# Test: Block expression should be ORGANIZATION_BLOCK (with SEQUENTIAL refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'block_expression'
+LIMIT 1;
+----
+block_expression	ORGANIZATION_BLOCK
+
+# Test: Parameters should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'parameters'
+LIMIT 1;
+----
+parameters	ORGANIZATION_LIST
+
+# Test: Arguments should be ORGANIZATION_LIST (with COLLECTION refinement)
+query IT
+SELECT type, semantic_type_to_string(semantic_type) as sem_type
+FROM read_ast('test/data/zig/sample.zig', context := 'native')
+WHERE type = 'arguments'
+LIMIT 1;
+----
+arguments	ORGANIZATION_LIST

--- a/test/sql/native_extraction/dart_extraction.test
+++ b/test/sql/native_extraction/dart_extraction.test
@@ -106,3 +106,101 @@ WHERE type = 'class_definition' AND name = 'Runnable';
 ----
 Runnable	abstract_class	[]	[abstract]
 
+# =============================================================================
+# FUNCTION_SIGNATURE - Function Declarations
+# =============================================================================
+# Note: Dart emits both method_signature (outer) and function_signature (inner)
+# for class methods. function_signature is the one with full extraction data.
+
+# Test: Method with return type and parameters
+query ITT
+SELECT name, signature_type, parameters FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'function_signature' AND name = 'distanceTo';
+----
+distanceTo	double	[{'name': other, 'type': Point}]
+
+# Test: Override method with return type
+query IT
+SELECT name, signature_type FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'function_signature' AND name = 'toString';
+----
+toString	String
+
+# Test: Void function
+query IT
+SELECT name, signature_type FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'function_signature' AND name = 'printInfo';
+----
+printInfo	void
+
+# Test: Async function with Future return type
+query IT
+SELECT name, signature_type FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'function_signature' AND name = 'main';
+----
+main	Future
+
+# Test: Stream generator function with parameter
+query ITT
+SELECT name, signature_type, parameters FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'function_signature' AND name = 'countStream';
+----
+countStream	Stream	[{'name': max, 'type': int}]
+
+# Test: Iterable generator function with parameter
+query ITT
+SELECT name, signature_type, parameters FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'function_signature' AND name = 'naturals';
+----
+naturals	Iterable	[{'name': n, 'type': int}]
+
+# Test: Private function
+query IT
+SELECT name, signature_type FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'function_signature' AND name = '_privateHelper';
+----
+_privateHelper	void
+
+# =============================================================================
+# CONSTRUCTOR_SIGNATURE - Constructor Declarations
+# =============================================================================
+
+# Test: Const constructor
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'constant_constructor_signature' AND name = 'Point';
+----
+Point	NULL	[const]
+
+# Test: Factory constructor with parameters
+query ITT
+SELECT name, signature_type, parameters FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'factory_constructor_signature' AND name = 'Point';
+----
+Point	NULL	[{'name': map, 'type': Map}]
+
+# =============================================================================
+# METHOD_SIGNATURE - Method Declarations (outer wrapper)
+# =============================================================================
+
+# Test: Method with @override annotation
+query ITT
+SELECT name, modifiers, parameters FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'method_signature' AND name = 'area'
+ORDER BY start_line
+LIMIT 1;
+----
+area	[@override]	[]
+
+# =============================================================================
+# Semantic Type Validation
+# =============================================================================
+
+# Test: function_signature nodes have DEFINITION_FUNCTION semantic type
+query I
+SELECT COUNT(*) FROM read_ast('test/data/dart/sample.dart', context := 'native')
+WHERE type = 'function_signature'
+  AND name IS NOT NULL
+  AND semantic_type_to_string(semantic_type) = 'DEFINITION_FUNCTION';
+----
+10

--- a/test/sql/native_extraction/java_extraction.test
+++ b/test/sql/native_extraction/java_extraction.test
@@ -94,3 +94,141 @@ WHERE type = 'enum_declaration' AND name = 'DogBreed';
 ----
 DogBreed	[{'name': Serializable, 'type': implements}]	[enum]
 
+# =============================================================================
+# DEFINITION_FUNCTION - Method Declarations
+# =============================================================================
+
+# Test: Method return types are extracted correctly (includes inner interface method)
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+WHERE type = 'method_declaration' AND name IS NOT NULL
+ORDER BY start_line;
+----
+toString	String	[@Override, public]
+increment	void	[public]
+getCounter	int	[protected]
+reset	void	[private]
+main	void	[public, static]
+processData	String	[private, static]
+process	void	[]
+
+# Test: Method parameters are extracted
+query IT
+SELECT name, parameters FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+WHERE type = 'method_declaration' AND name IS NOT NULL
+  AND array_length(parameters) > 0
+ORDER BY start_line;
+----
+main	[{'name': args, 'type': 'String[]'}]
+processData	[{'name': input, 'type': String}]
+process	[{'name': data, 'type': String}]
+
+# Test: Abstract method in Inheritance.java (has no body)
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/languages/java/Inheritance.java', context := 'native')
+WHERE type = 'method_declaration' AND name = 'speak'
+ORDER BY start_line
+LIMIT 1;
+----
+speak	String	[public, abstract]
+
+# =============================================================================
+# DEFINITION_FUNCTION - Constructor Declarations
+# =============================================================================
+
+# Test: Constructor parameters are extracted (constructor has no return type)
+query ITT
+SELECT name, signature_type, parameters FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+WHERE type = 'constructor_declaration' AND name IS NOT NULL
+ORDER BY start_line;
+----
+Test	NULL	[]
+Test	NULL	[{'name': initialValue, 'type': int}]
+InnerClass	NULL	[{'name': name, 'type': String}]
+
+# Test: Constructors with parameters in Inheritance.java
+query IT
+SELECT name, parameters FROM read_ast('test/data/languages/java/Inheritance.java', context := 'native')
+WHERE type = 'constructor_declaration' AND name IS NOT NULL
+ORDER BY start_line;
+----
+Animal	[{'name': name, 'type': String}]
+Dog	[{'name': name, 'type': String}]
+Cat	[{'name': name, 'type': String}]
+Pet	[{'name': name, 'type': String}, {'name': owner, 'type': String}]
+ServiceAnimal	[{'name': name, 'type': String}]
+
+# =============================================================================
+# DEFINITION_VARIABLE - Field Declarations
+# =============================================================================
+
+# Test: Field names and types are extracted correctly
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+WHERE type = 'field_declaration' AND name IS NOT NULL
+ORDER BY start_line;
+----
+CONSTANT	String	[]
+counter	int	[]
+name	String	[]
+
+# Test: Field names in Inheritance.java
+query IT
+SELECT name, signature_type FROM read_ast('test/data/languages/java/Inheritance.java', context := 'native')
+WHERE type = 'field_declaration' AND name IS NOT NULL
+ORDER BY start_line;
+----
+name	String
+owner	String
+
+# =============================================================================
+# COMPUTATION_CALL - Method Invocations
+# =============================================================================
+
+# Test: Simple method calls have correct name and qualified_name
+query ITT
+SELECT name, qualified_name, parameters FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+WHERE type = 'method_invocation' AND name IS NOT NULL AND length(name) > 0
+ORDER BY start_line;
+----
+increment	test.increment	[]
+add	numbers.add	[{'name': '', 'type': i}]
+collect	NULL	[{'name': '', 'type': 'Collectors.toList()'}]
+filter	NULL	[{'name': '', 'type': 'n -> n % 2 == 0'}]
+stream	numbers.stream	[]
+toList	Collectors.toList	[]
+println	System.out.println	[{'name': '', 'type': '"Even numbers: " + evenNumbers'}]
+processData	processData	[{'name': '', 'type': 'null'}]
+println	System.err.println	[{'name': '', 'type': '"Error: " + e.getMessage()'}]
+getMessage	e.getMessage	[]
+toUpperCase	input.toUpperCase	[]
+
+# =============================================================================
+# Semantic Type Validation
+# =============================================================================
+
+# Test: Methods have DEFINITION_FUNCTION semantic type
+query I
+SELECT COUNT(*) FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+WHERE type = 'method_declaration'
+  AND name IS NOT NULL
+  AND semantic_type_to_string(semantic_type) = 'DEFINITION_FUNCTION';
+----
+7
+
+# Test: Constructors have DEFINITION_FUNCTION semantic type
+query I
+SELECT COUNT(*) FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+WHERE type = 'constructor_declaration'
+  AND name IS NOT NULL
+  AND semantic_type_to_string(semantic_type) = 'DEFINITION_FUNCTION';
+----
+3
+
+# Test: Method invocations have COMPUTATION_CALL semantic type
+query I
+SELECT COUNT(*) FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+WHERE type = 'method_invocation'
+  AND semantic_type_to_string(semantic_type) = 'COMPUTATION_CALL';
+----
+11

--- a/test/sql/native_extraction/php_extraction.test
+++ b/test/sql/native_extraction/php_extraction.test
@@ -106,3 +106,82 @@ WHERE type = 'enum_declaration' AND name = 'DogBreed';
 ----
 DogBreed	[{'name': Serializable, 'type': implements}]	[]
 
+# =============================================================================
+# DEFINITION_FUNCTION - Method Declarations
+# =============================================================================
+
+# Test: Constructor with typed parameter and public modifier
+query ITT
+SELECT name, parameters, modifiers FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'method_declaration' AND name = '__construct';
+----
+__construct	[{'name': $name, 'type': string}]	[public]
+
+# Test: Destructor with no parameters
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'method_declaration' AND name = '__destruct';
+----
+__destruct	NULL	[public]
+
+# Test: Public method with return type
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'method_declaration' AND name = 'getName'
+ORDER BY start_line
+LIMIT 1;
+----
+getName	string	[public]
+
+# Test: Private method with typed parameters and return type
+query ITTT
+SELECT name, signature_type, parameters, modifiers FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'method_declaration' AND name = 'validate';
+----
+validate	bool	[{'name': $input, 'type': mixed}]	[private]
+
+# Test: Protected method with array type
+query ITTT
+SELECT name, signature_type, parameters, modifiers FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'method_declaration' AND name = 'process';
+----
+process	array	[{'name': $items, 'type': array}]	[protected]
+
+# Test: Static method with public modifier
+query ITT
+SELECT name, parameters, modifiers FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'method_declaration' AND name = 'createFromArray';
+----
+createFromArray	[{'name': $data, 'type': array}]	[public, static]
+
+# Test: Void return type method
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'method_declaration' AND name = 'log';
+----
+log	void	[public]
+
+# =============================================================================
+# DEFINITION_VARIABLE - Property Declarations
+# =============================================================================
+
+# Test: Property modifiers are extracted correctly
+query I
+SELECT COUNT(*) FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'property_declaration'
+  AND array_length(modifiers) > 0;
+----
+3
+
+# =============================================================================
+# Semantic Type Validation
+# =============================================================================
+
+# Test: Methods have DEFINITION_FUNCTION semantic type
+query I
+SELECT COUNT(*) FROM read_ast('test/data/languages/php/test.php', context := 'native')
+WHERE type = 'method_declaration'
+  AND name IS NOT NULL
+  AND semantic_type_to_string(semantic_type) = 'DEFINITION_FUNCTION';
+----
+8

--- a/test/sql/native_extraction/swift_extraction.test
+++ b/test/sql/native_extraction/swift_extraction.test
@@ -109,3 +109,189 @@ WHERE type = 'class_declaration' AND name = 'DogBreed';
 ----
 DogBreed	[{'name': String, 'type': extends}, {'name': CaseIterable, 'type': extends}]	[]
 
+# =============================================================================
+# DEFINITION_FUNCTION - Function Declarations
+# =============================================================================
+
+# Test: Simple function with no parameters or return type
+query ITTT
+SELECT name, signature_type, parameters, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'draw'
+ORDER BY start_line
+LIMIT 1;
+----
+draw	NULL	[]	[]
+
+# Test: Function with external/internal parameter names and mutating modifier
+query ITT
+SELECT name, parameters, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'move'
+ORDER BY start_line
+LIMIT 1;
+----
+move	[{'name': to point, 'type': CGPoint}]	[mutating]
+
+# Test: Static function with return type
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'random';
+----
+random	Rectangle	[static]
+
+# Test: Function with underscore external name (suppressed label)
+query IT
+SELECT name, parameters FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'append';
+----
+append	[{'name': _ item, 'type': Element}]
+
+# Test: Function with optional return type
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'pop';
+----
+pop	Element?	[mutating]
+
+# Test: Function with function-type parameter
+query ITT
+SELECT name, signature_type, parameters FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'filter';
+----
+filter	[T]	[{'name': _ transform, 'type': '(Element) -> T?'}]
+
+# Test: Final method modifier
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'getId';
+----
+getId	UUID	[final]
+
+# Test: Override modifier
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'describe'
+ORDER BY start_line
+LIMIT 1 OFFSET 1;
+----
+describe	String	[override]
+
+# Test: Multiple parameters with mixed external names and defaults
+query IT
+SELECT name, parameters FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'truncated';
+----
+truncated	[{'name': to length, 'type': Int}, {'name': trailing, 'type': String}]
+
+# Test: Complex function with multiple parameter types including closures
+query IT
+SELECT name, parameters FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'addTask';
+----
+addTask	[{'name': _ title, 'type': String}, {'name': priority, 'type': Priority}, {'name': dueDate, 'type': Date?}]
+
+# Test: Function with higher-order parameter (closure with result type)
+query IT
+SELECT name, parameters FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration' AND name = 'getTasks';
+----
+getTasks	[{'name': sortedBy sortCriteria, 'type': '(Task, Task) -> Bool'}]
+
+# =============================================================================
+# DEFINITION_FUNCTION - Init Declarations (Constructors)
+# =============================================================================
+
+# Test: Init with typed parameters
+query ITT
+SELECT name, signature_type, parameters FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'init_declaration' AND name IS NOT NULL
+ORDER BY start_line
+LIMIT 1;
+----
+init	NULL	[{'name': width, 'type': Double}, {'name': height, 'type': Double}]
+
+# Test: Init with external/internal parameter names
+query IT
+SELECT name, parameters FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'init_declaration' AND name IS NOT NULL
+ORDER BY start_line
+LIMIT 1 OFFSET 1;
+----
+init	[{'name': square side, 'type': Double}]
+
+# Test: Convenience init modifier
+query ITT
+SELECT name, parameters, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'init_declaration' AND name IS NOT NULL
+ORDER BY start_line
+LIMIT 1 OFFSET 4;
+----
+init	[{'name': radius, 'type': Double}]	[convenience]
+
+# =============================================================================
+# DEFINITION_VARIABLE - Property Declarations
+# =============================================================================
+
+# Test: Properties with type annotations extract correctly
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'property_declaration' AND name = 'width'
+ORDER BY start_line
+LIMIT 1;
+----
+width	Double	[var]
+
+# Test: Let binding detected as modifier
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'property_declaration' AND name = '_id';
+----
+_id	UUID	[var]
+
+# Test: Properties with complex types (generic array)
+query IT
+SELECT name, signature_type FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'property_declaration' AND name = 'items'
+ORDER BY start_line
+LIMIT 1;
+----
+items	[Element]
+
+# Test: Computed property with return type
+query ITT
+SELECT name, signature_type, modifiers FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'property_declaration' AND name = 'area'
+ORDER BY start_line
+LIMIT 1;
+----
+area	Double	[var]
+
+# =============================================================================
+# Semantic Type Validation
+# =============================================================================
+
+# Test: Functions have DEFINITION_FUNCTION semantic type
+query I
+SELECT COUNT(*) FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'function_declaration'
+  AND name IS NOT NULL
+  AND semantic_type_to_string(semantic_type) = 'DEFINITION_FUNCTION';
+----
+26
+
+# Test: Init declarations have DEFINITION_FUNCTION semantic type
+query I
+SELECT COUNT(*) FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'init_declaration'
+  AND name IS NOT NULL
+  AND semantic_type_to_string(semantic_type) = 'DEFINITION_FUNCTION';
+----
+8
+
+# Test: Property declarations have DEFINITION_VARIABLE semantic type
+query I
+SELECT COUNT(*) FROM read_ast('test/data/swift/simple.swift', context := 'native')
+WHERE type = 'property_declaration'
+  AND name IS NOT NULL
+  AND semantic_type_to_string(semantic_type) = 'DEFINITION_VARIABLE';
+----
+75


### PR DESCRIPTION
## Summary
- **Java**: Fix type recognition (integral_type, floating_point_type, boolean_type), add constructor extraction, fix field name extraction (FIND_IN_DECLARATOR), fix method invocation name/qualified_name extraction
- **Swift**: Fix return type extraction (arrow marker instead of type_annotation), fix parameter extraction (direct children, simple_identifier), fix modifier extraction (modifiers wrapper node), fix property type/var-let extraction, add init constructor specialization
- **PHP**: Fix method modifier extraction (visibility_modifier is a direct child, not parent sibling)
- **All languages**: Expand native extraction tests with function, constructor, property, and semantic type validation sections (+717 lines of test coverage)

## Test plan
- [x] All 10 native extraction tests pass (832 assertions)
- [x] All 39 language tests pass (2170 assertions) - no regressions
- [x] All name extraction, audit, bug, and semantic tests pass
- [x] Build succeeds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)