### PR TITLE
fix: ast_imports/ast_exports correctness for cross-file resolution

### DIFF
--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -3778,7 +3778,9 @@ CREATE OR REPLACE MACRO ast_exports(
 ) AS TABLE
     SELECT *
     FROM read_ast(source, language)
-    WHERE is_exported(flags)
+    WHERE is_name_definition(flags)
+      AND is_exported(flags)
+      AND COALESCE(scope.current, 0) = 0
     ORDER BY file_path, start_line;
 
 
@@ -3801,44 +3803,155 @@ CREATE OR REPLACE MACRO ast_imports(
         ast AS (
             SELECT * FROM read_ast(source, language)
         ),
-        -- Find import statements via semantic type
+        -- Find import nodes via semantic type.
+        -- Require non-empty name to exclude structural wrappers
+        -- (JS import_clause, Go import_declaration) that also carry
+        -- EXTERNAL_IMPORT but hold no module path themselves.
         import_nodes AS (
             SELECT node_id, name as source_module, type as import_type,
-                   descendant_count, file_path, start_line, language
+                   descendant_count, file_path, start_line, language as lang
             FROM ast
             WHERE semantic_type = 'EXTERNAL_IMPORT'
               AND NOT is_syntax_only(flags)
-              AND descendant_count > 0  -- exclude keyword tokens
+              AND descendant_count > 0
+              AND name IS NOT NULL AND name != ''
         ),
-        -- Extract imported names: named identifier children of import nodes
-        -- that are not the module name itself
-        imported_names AS (
-            SELECT
-                i.file_path,
-                i.source_module,
-                i.import_type,
-                a.name as imported_name,
-                i.start_line
+        -- Locate the 'import' keyword within each import node (split point)
+        import_keywords AS (
+            SELECT i.node_id as import_id, i.file_path,
+                   MIN(a.node_id) as keyword_id
+            FROM import_nodes i
+            JOIN ast a ON a.parent_id = i.node_id
+              AND a.file_path = i.file_path
+              AND a.type IN ('import', 'use')
+            GROUP BY i.node_id, i.file_path
+        ),
+        -- Case 1: from-imports (Python import_from_statement)
+        -- Imported names are direct children after the 'import' keyword
+        from_import_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            JOIN import_keywords k ON k.import_id = i.node_id
+              AND k.file_path = i.file_path
+            JOIN ast a ON a.parent_id = i.node_id
+              AND a.file_path = i.file_path
+              AND a.node_id > k.keyword_id
+              AND a.type IN ('dotted_name', 'identifier')
+              AND a.name IS NOT NULL AND a.name != ''
+            WHERE i.import_type IN ('import_from_statement')
+        ),
+        -- Case 2: statement-imports with named specifiers (JS import { X } from 'Y',
+        --         Python import X as Y, Go aliased import_spec)
+        specifier_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
             FROM import_nodes i
             JOIN ast a ON a.node_id > i.node_id
               AND a.node_id <= i.node_id + i.descendant_count
-              AND a.type IN ('dotted_name', 'identifier', 'import_specifier',
-                            'import_default_specifier', 'scoped_identifier')
+              AND a.file_path = i.file_path
+              AND a.type IN ('import_specifier', 'import_default_specifier',
+                            'namespace_import', 'aliased_import',
+                            'import_spec')
               AND a.name IS NOT NULL AND a.name != ''
-              AND a.name != i.source_module  -- exclude the module name itself
-              AND a.depth = (
-                  -- Get the shallowest named children (avoid deep duplicates)
-                  SELECT MIN(a2.depth) FROM ast a2
-                  WHERE a2.node_id > i.node_id
-                    AND a2.node_id <= i.node_id + i.descendant_count
-                    AND a2.type IN ('dotted_name', 'identifier', 'import_specifier',
-                                   'import_default_specifier', 'scoped_identifier')
-                    AND a2.name IS NOT NULL AND a2.name != ''
-                    AND a2.name != i.source_module
+            WHERE i.import_type NOT IN ('import_from_statement')
+        ),
+        -- Case 3: JS default imports (import React from 'react')
+        -- The default name is an identifier direct child of import_clause
+        js_default_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            JOIN ast clause ON clause.parent_id = i.node_id
+              AND clause.file_path = i.file_path
+              AND clause.type = 'import_clause'
+            JOIN ast a ON a.parent_id = clause.node_id
+              AND a.file_path = i.file_path
+              AND a.type = 'identifier'
+              AND a.name IS NOT NULL AND a.name != ''
+            WHERE i.import_type NOT IN ('import_from_statement')
+              AND NOT EXISTS (
+                  SELECT 1 FROM specifier_names s
+                  WHERE s.file_path = i.file_path AND s.start_line = i.start_line
               )
+        ),
+        -- Case 3b: Rust simple use (use std::collections::HashMap)
+        -- The imported name is the last identifier child of the
+        -- top-level scoped_identifier
+        rust_use_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            JOIN ast sc ON sc.parent_id = i.node_id
+              AND sc.file_path = i.file_path
+              AND sc.type = 'scoped_identifier'
+            JOIN ast a ON a.parent_id = sc.node_id
+              AND a.file_path = i.file_path
+              AND a.type = 'identifier'
+              AND a.name IS NOT NULL AND a.name != ''
+              AND a.node_id = (
+                  SELECT MAX(a2.node_id) FROM ast a2
+                  WHERE a2.parent_id = sc.node_id
+                    AND a2.file_path = i.file_path
+                    AND a2.type = 'identifier'
+              )
+            WHERE i.import_type NOT IN ('import_from_statement')
+        ),
+        -- Case 3c: Rust use_list imports (use std::io::{Read, Write})
+        -- Identifiers inside use_list are the imported names
+        use_list_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            JOIN ast ul ON ul.node_id > i.node_id
+              AND ul.node_id <= i.node_id + i.descendant_count
+              AND ul.file_path = i.file_path
+              AND ul.type = 'use_list'
+            JOIN ast a ON a.parent_id = ul.node_id
+              AND a.file_path = i.file_path
+              AND a.type = 'identifier'
+              AND a.name IS NOT NULL AND a.name != ''
+            WHERE i.import_type NOT IN ('import_from_statement')
+        ),
+        -- Case 4: Bare imports (Python import os, Go import "fmt", Rust use std::io)
+        -- No separate imported name — the module itself is the import
+        bare_import_names AS (
+            SELECT i.file_path, i.source_module,
+                   i.source_module as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            WHERE i.source_module IS NOT NULL AND i.source_module != ''
+              AND NOT EXISTS (
+                  SELECT 1 FROM from_import_names f
+                  WHERE f.file_path = i.file_path AND f.start_line = i.start_line
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM specifier_names s
+                  WHERE s.file_path = i.file_path AND s.start_line = i.start_line
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM js_default_names j
+                  WHERE j.file_path = i.file_path AND j.start_line = i.start_line
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM rust_use_names r
+                  WHERE r.file_path = i.file_path AND r.start_line = i.start_line
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM use_list_names u
+                  WHERE u.file_path = i.file_path AND u.start_line = i.start_line
+              )
+        ),
+        all_imports AS (
+            SELECT * FROM from_import_names
+            UNION ALL SELECT * FROM specifier_names
+            UNION ALL SELECT * FROM js_default_names
+            UNION ALL SELECT * FROM rust_use_names
+            UNION ALL SELECT * FROM use_list_names
+            UNION ALL SELECT * FROM bare_import_names
         )
     SELECT file_path, source_module, imported_name, import_type, start_line
-    FROM imported_names
+    FROM all_imports
     ORDER BY file_path, start_line, imported_name;
 
 
@@ -3952,6 +4065,9 @@ CREATE OR REPLACE MACRO ast_callees(
            c.start_line   AS callee_line,
            c.peek         AS call_peek
     FROM ast c
+
+)SQLMACRO"
+        R"SQLMACRO(
     JOIN ast f
       ON f.node_id = c.scope.function
      AND f.file_path = c.file_path
@@ -3996,7 +4112,6 @@ CREATE OR REPLACE MACRO ast_callers(
     WHERE c.semantic_type = 'COMPUTATION_CALL'
       AND c.name IS NOT NULL AND c.name != ''
     ORDER BY c.file_path, c.start_line;
-
 )SQLMACRO"},
 };
 

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -3803,18 +3803,21 @@ CREATE OR REPLACE MACRO ast_imports(
         ast AS (
             SELECT * FROM read_ast(source, language)
         ),
-        -- Find import nodes via semantic type.
-        -- Require non-empty name to exclude structural wrappers
-        -- (JS import_clause, Go import_declaration) that also carry
-        -- EXTERNAL_IMPORT but hold no module path themselves.
+        -- Find top-level import nodes via semantic type.
+        -- Filters:
+        --   name != '' excludes structural wrappers (JS import_clause, Go import_declaration)
+        --   parent NOT EXTERNAL_IMPORT excludes sub-import nodes (Python aliased_import,
+        --     JS import_specifier) that also carry the semantic type from their parent
         import_nodes AS (
-            SELECT node_id, name as source_module, type as import_type,
-                   descendant_count, file_path, start_line, language as lang
-            FROM ast
-            WHERE semantic_type = 'EXTERNAL_IMPORT'
-              AND NOT is_syntax_only(flags)
-              AND descendant_count > 0
-              AND name IS NOT NULL AND name != ''
+            SELECT a.node_id, a.name as source_module, a.type as import_type,
+                   a.descendant_count, a.file_path, a.start_line
+            FROM ast a
+            LEFT JOIN ast p ON p.node_id = a.parent_id AND p.file_path = a.file_path
+            WHERE a.semantic_type = 'EXTERNAL_IMPORT'
+              AND NOT is_syntax_only(a.flags)
+              AND a.descendant_count > 0
+              AND a.name IS NOT NULL AND a.name != ''
+              AND (p.semantic_type IS NULL OR p.semantic_type != 'EXTERNAL_IMPORT')
         ),
         -- Locate the 'import' keyword within each import node (split point)
         import_keywords AS (
@@ -4057,6 +4060,9 @@ CREATE OR REPLACE MACRO ast_callees(
     WITH ast AS (
         SELECT * FROM read_ast(source, language)
     )
+
+)SQLMACRO"
+        R"SQLMACRO(
     SELECT f.name         AS caller,
            f.qualified_name AS caller_qualified,
            f.start_line   AS caller_line,
@@ -4065,9 +4071,6 @@ CREATE OR REPLACE MACRO ast_callees(
            c.start_line   AS callee_line,
            c.peek         AS call_peek
     FROM ast c
-
-)SQLMACRO"
-        R"SQLMACRO(
     JOIN ast f
       ON f.node_id = c.scope.function
      AND f.file_path = c.file_path

--- a/src/include/unified_ast_backend_impl.hpp
+++ b/src/include/unified_ast_backend_impl.hpp
@@ -260,7 +260,10 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 			if (config.context >= ContextLevel::NODE_TYPES_ONLY) {
 				PopulateSemanticFieldsTemplated(ast_node, adapter, entry.node, content, node_configs, config);
 
-				// Set IS_EXPORTED flag on name-binding nodes (definitions/declarations)
+				// Set IS_EXPORTED on name-binding nodes (declarations AND definitions).
+				// NAME_DECLARATION (0x04) bitmask matches both DECLARATION and DEFINITION
+				// since DEFINITION (0x06) also has bit 2 set. ast_exports() further
+				// narrows to definitions only via is_name_definition().
 				if ((ast_node.universal_flags & ASTNodeFlags::NAME_DECLARATION) &&
 				    adapter->IsPublicNode(entry.node, content)) {
 					ast_node.universal_flags |= ASTNodeFlags::IS_EXPORTED;

--- a/src/include/unified_ast_backend_impl.hpp
+++ b/src/include/unified_ast_backend_impl.hpp
@@ -260,8 +260,9 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 			if (config.context >= ContextLevel::NODE_TYPES_ONLY) {
 				PopulateSemanticFieldsTemplated(ast_node, adapter, entry.node, content, node_configs, config);
 
-				// Set IS_EXPORTED flag via language-specific IsPublicNode check
-				if (adapter->IsPublicNode(entry.node, content)) {
+				// Set IS_EXPORTED flag on name-binding nodes (definitions/declarations)
+				if ((ast_node.universal_flags & ASTNodeFlags::NAME_DECLARATION) &&
+				    adapter->IsPublicNode(entry.node, content)) {
 					ast_node.universal_flags |= ASTNodeFlags::IS_EXPORTED;
 				}
 			} else {

--- a/src/language_adapters/go_adapter.cpp
+++ b/src/language_adapters/go_adapter.cpp
@@ -65,6 +65,18 @@ string GoAdapter::ExtractNodeName(TSNode node, const string &content) const {
 				return FindChildByType(node, content, "package_identifier");
 			}
 		}
+		// import_spec: extract module path without quotes
+		if (strcmp(node_type_str, "import_spec") == 0) {
+			TSNode str_node = FindChildByTypeNode(node, "interpreted_string_literal");
+			if (!ts_node_is_null(str_node)) {
+				string result = FindChildByType(str_node, content, "interpreted_string_literal_content");
+				if (!result.empty()) {
+					return result;
+				}
+				return ExtractNodeText(str_node, content);
+			}
+			return "";
+		}
 		return ExtractByStrategy(node, content, config->name_strategy);
 	}
 

--- a/src/language_adapters/javascript_adapter.cpp
+++ b/src/language_adapters/javascript_adapter.cpp
@@ -62,9 +62,18 @@ string JavaScriptAdapter::ExtractNodeName(TSNode node, const string &content) co
 	const NodeConfig *config = GetNodeConfig(node_type_str);
 
 	if (config) {
-		// Import statements: module source is in a string child
+		// Import statements: module source is in a string child.
+		// Extract the string_fragment (without quotes) rather than the full string.
 		if (strcmp(node_type_str, "import_statement") == 0) {
-			return FindChildByType(node, content, "string");
+			TSNode string_node = FindChildByTypeNode(node, "string");
+			if (!ts_node_is_null(string_node)) {
+				string result = FindChildByType(string_node, content, "string_fragment");
+				if (!result.empty()) {
+					return result;
+				}
+				return ExtractNodeText(string_node, content);
+			}
+			return "";
 		}
 		return ExtractByStrategy(node, content, config->name_strategy);
 	}

--- a/src/language_adapters/python_adapter.cpp
+++ b/src/language_adapters/python_adapter.cpp
@@ -61,14 +61,29 @@ string PythonAdapter::ExtractNodeName(TSNode node, const string &content) const 
 	const NodeConfig *config = GetNodeConfig(node_type_str);
 
 	if (config) {
-		// Import statements: module name is in dotted_name child, not identifier
-		if (strcmp(node_type_str, "import_statement") == 0 || strcmp(node_type_str, "import_from_statement") == 0) {
-			string name = FindChildByType(node, content, "dotted_name");
-			if (name.empty()) {
-				// Relative imports (e.g., "from . import name") have no dotted_name
-				name = FindChildByType(node, content, "identifier");
+		if (strcmp(node_type_str, "import_from_statement") == 0) {
+			// Source module is before the 'import' keyword.
+			// Check for relative_import child first (from . import X, from ..foo import X)
+			TSNode relative = FindChildByTypeNode(node, "relative_import");
+			if (!ts_node_is_null(relative)) {
+				string prefix;
+				TSNode import_prefix = FindChildByTypeNode(relative, "import_prefix");
+				if (!ts_node_is_null(import_prefix)) {
+					prefix = ExtractNodeText(import_prefix, content);
+				}
+				string module_name = FindChildByType(relative, content, "dotted_name");
+				return prefix + module_name;
 			}
-			return name;
+			// Non-relative: first dotted_name child is the source module
+			return FindChildByType(node, content, "dotted_name");
+		}
+		if (strcmp(node_type_str, "import_statement") == 0) {
+			// Check for aliased_import (import os as alias) — extract original module name
+			TSNode aliased = FindChildByTypeNode(node, "aliased_import");
+			if (!ts_node_is_null(aliased)) {
+				return FindChildByType(aliased, content, "dotted_name");
+			}
+			return FindChildByType(node, content, "dotted_name");
 		}
 		return ExtractByStrategy(node, content, config->name_strategy);
 	}

--- a/src/language_adapters/rust_adapter.cpp
+++ b/src/language_adapters/rust_adapter.cpp
@@ -61,23 +61,38 @@ string RustAdapter::ExtractNodeName(TSNode node, const string &content) const {
 	const NodeConfig *config = GetNodeConfig(node_type_str);
 
 	if (config && config->name_strategy != ExtractionStrategy::CUSTOM) {
-		// Use declarations: extract just the path, not full "use path;" text
+		// Use declarations: extract the source module path
 		if (strcmp(node_type_str, "use_declaration") == 0) {
-			string name = FindChildByType(node, content, "scoped_identifier");
-			if (name.empty()) {
-				name = FindChildByType(node, content, "identifier");
+			// scoped_use_list (use std::io::{Read, Write}):
+			// source module is the scoped_identifier inside the list
+			TSNode scoped_list = FindChildByTypeNode(node, "scoped_use_list");
+			if (!ts_node_is_null(scoped_list)) {
+				return FindChildByType(scoped_list, content, "scoped_identifier");
 			}
-			if (name.empty()) {
-				name = FindChildByType(node, content, "scoped_use_list");
+			// Simple scoped path (use std::collections::HashMap):
+			// source module is the inner scoped_identifier (path without leaf)
+			TSNode outer = FindChildByTypeNode(node, "scoped_identifier");
+			if (!ts_node_is_null(outer)) {
+				TSNode inner = FindChildByTypeNode(outer, "scoped_identifier");
+				if (!ts_node_is_null(inner)) {
+					return ExtractNodeText(inner, content);
+				}
+				// 2-component path (use std::io): first child is the crate/module
+				uint32_t child_count = ts_node_child_count(outer);
+				for (uint32_t i = 0; i < child_count; i++) {
+					TSNode child = ts_node_child(outer, i);
+					const char *ctype = ts_node_type(child);
+					if (strcmp(ctype, "identifier") == 0 || strcmp(ctype, "crate") == 0 ||
+					    strcmp(ctype, "super") == 0 || strcmp(ctype, "self") == 0) {
+						return ExtractNodeText(child, content);
+					}
+				}
+				return ExtractNodeText(outer, content);
 			}
-			if (name.empty()) {
-				name = FindChildByType(node, content, "use_list");
-			}
+			// Bare identifier or use_wildcard
+			string name = FindChildByType(node, content, "identifier");
 			if (name.empty()) {
 				name = FindChildByType(node, content, "use_wildcard");
-			}
-			if (name.empty()) {
-				name = FindChildByType(node, content, "use_as_clause");
 			}
 			return name;
 		}

--- a/src/language_adapters/typescript_adapter.cpp
+++ b/src/language_adapters/typescript_adapter.cpp
@@ -63,9 +63,17 @@ string TypeScriptAdapter::ExtractNodeName(TSNode node, const string &content) co
 	const NodeConfig *config = GetNodeConfig(node_type_str);
 
 	if (config) {
-		// Import statements: module source is in a string child
+		// Import statements: extract string_fragment (without quotes) from string child
 		if (strcmp(node_type_str, "import_statement") == 0 || strcmp(node_type_str, "import_require_clause") == 0) {
-			return FindChildByType(node, content, "string");
+			TSNode string_node = FindChildByTypeNode(node, "string");
+			if (!ts_node_is_null(string_node)) {
+				string result = FindChildByType(string_node, content, "string_fragment");
+				if (!result.empty()) {
+					return result;
+				}
+				return ExtractNodeText(string_node, content);
+			}
+			return "";
 		}
 		return ExtractByStrategy(node, content, config->name_strategy);
 	}

--- a/src/sql_macros/scope_resolution.sql
+++ b/src/sql_macros/scope_resolution.sql
@@ -57,18 +57,21 @@ CREATE OR REPLACE MACRO ast_imports(
         ast AS (
             SELECT * FROM read_ast(source, language)
         ),
-        -- Find import nodes via semantic type.
-        -- Require non-empty name to exclude structural wrappers
-        -- (JS import_clause, Go import_declaration) that also carry
-        -- EXTERNAL_IMPORT but hold no module path themselves.
+        -- Find top-level import nodes via semantic type.
+        -- Filters:
+        --   name != '' excludes structural wrappers (JS import_clause, Go import_declaration)
+        --   parent NOT EXTERNAL_IMPORT excludes sub-import nodes (Python aliased_import,
+        --     JS import_specifier) that also carry the semantic type from their parent
         import_nodes AS (
-            SELECT node_id, name as source_module, type as import_type,
-                   descendant_count, file_path, start_line, language as lang
-            FROM ast
-            WHERE semantic_type = 'EXTERNAL_IMPORT'
-              AND NOT is_syntax_only(flags)
-              AND descendant_count > 0
-              AND name IS NOT NULL AND name != ''
+            SELECT a.node_id, a.name as source_module, a.type as import_type,
+                   a.descendant_count, a.file_path, a.start_line
+            FROM ast a
+            LEFT JOIN ast p ON p.node_id = a.parent_id AND p.file_path = a.file_path
+            WHERE a.semantic_type = 'EXTERNAL_IMPORT'
+              AND NOT is_syntax_only(a.flags)
+              AND a.descendant_count > 0
+              AND a.name IS NOT NULL AND a.name != ''
+              AND (p.semantic_type IS NULL OR p.semantic_type != 'EXTERNAL_IMPORT')
         ),
         -- Locate the 'import' keyword within each import node (split point)
         import_keywords AS (

--- a/src/sql_macros/scope_resolution.sql
+++ b/src/sql_macros/scope_resolution.sql
@@ -32,7 +32,9 @@ CREATE OR REPLACE MACRO ast_exports(
 ) AS TABLE
     SELECT *
     FROM read_ast(source, language)
-    WHERE is_exported(flags)
+    WHERE is_name_definition(flags)
+      AND is_exported(flags)
+      AND COALESCE(scope.current, 0) = 0
     ORDER BY file_path, start_line;
 
 
@@ -55,44 +57,155 @@ CREATE OR REPLACE MACRO ast_imports(
         ast AS (
             SELECT * FROM read_ast(source, language)
         ),
-        -- Find import statements via semantic type
+        -- Find import nodes via semantic type.
+        -- Require non-empty name to exclude structural wrappers
+        -- (JS import_clause, Go import_declaration) that also carry
+        -- EXTERNAL_IMPORT but hold no module path themselves.
         import_nodes AS (
             SELECT node_id, name as source_module, type as import_type,
-                   descendant_count, file_path, start_line, language
+                   descendant_count, file_path, start_line, language as lang
             FROM ast
             WHERE semantic_type = 'EXTERNAL_IMPORT'
               AND NOT is_syntax_only(flags)
-              AND descendant_count > 0  -- exclude keyword tokens
+              AND descendant_count > 0
+              AND name IS NOT NULL AND name != ''
         ),
-        -- Extract imported names: named identifier children of import nodes
-        -- that are not the module name itself
-        imported_names AS (
-            SELECT
-                i.file_path,
-                i.source_module,
-                i.import_type,
-                a.name as imported_name,
-                i.start_line
+        -- Locate the 'import' keyword within each import node (split point)
+        import_keywords AS (
+            SELECT i.node_id as import_id, i.file_path,
+                   MIN(a.node_id) as keyword_id
+            FROM import_nodes i
+            JOIN ast a ON a.parent_id = i.node_id
+              AND a.file_path = i.file_path
+              AND a.type IN ('import', 'use')
+            GROUP BY i.node_id, i.file_path
+        ),
+        -- Case 1: from-imports (Python import_from_statement)
+        -- Imported names are direct children after the 'import' keyword
+        from_import_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            JOIN import_keywords k ON k.import_id = i.node_id
+              AND k.file_path = i.file_path
+            JOIN ast a ON a.parent_id = i.node_id
+              AND a.file_path = i.file_path
+              AND a.node_id > k.keyword_id
+              AND a.type IN ('dotted_name', 'identifier')
+              AND a.name IS NOT NULL AND a.name != ''
+            WHERE i.import_type IN ('import_from_statement')
+        ),
+        -- Case 2: statement-imports with named specifiers (JS import { X } from 'Y',
+        --         Python import X as Y, Go aliased import_spec)
+        specifier_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
             FROM import_nodes i
             JOIN ast a ON a.node_id > i.node_id
               AND a.node_id <= i.node_id + i.descendant_count
-              AND a.type IN ('dotted_name', 'identifier', 'import_specifier',
-                            'import_default_specifier', 'scoped_identifier')
+              AND a.file_path = i.file_path
+              AND a.type IN ('import_specifier', 'import_default_specifier',
+                            'namespace_import', 'aliased_import',
+                            'import_spec')
               AND a.name IS NOT NULL AND a.name != ''
-              AND a.name != i.source_module  -- exclude the module name itself
-              AND a.depth = (
-                  -- Get the shallowest named children (avoid deep duplicates)
-                  SELECT MIN(a2.depth) FROM ast a2
-                  WHERE a2.node_id > i.node_id
-                    AND a2.node_id <= i.node_id + i.descendant_count
-                    AND a2.type IN ('dotted_name', 'identifier', 'import_specifier',
-                                   'import_default_specifier', 'scoped_identifier')
-                    AND a2.name IS NOT NULL AND a2.name != ''
-                    AND a2.name != i.source_module
+            WHERE i.import_type NOT IN ('import_from_statement')
+        ),
+        -- Case 3: JS default imports (import React from 'react')
+        -- The default name is an identifier direct child of import_clause
+        js_default_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            JOIN ast clause ON clause.parent_id = i.node_id
+              AND clause.file_path = i.file_path
+              AND clause.type = 'import_clause'
+            JOIN ast a ON a.parent_id = clause.node_id
+              AND a.file_path = i.file_path
+              AND a.type = 'identifier'
+              AND a.name IS NOT NULL AND a.name != ''
+            WHERE i.import_type NOT IN ('import_from_statement')
+              AND NOT EXISTS (
+                  SELECT 1 FROM specifier_names s
+                  WHERE s.file_path = i.file_path AND s.start_line = i.start_line
               )
+        ),
+        -- Case 3b: Rust simple use (use std::collections::HashMap)
+        -- The imported name is the last identifier child of the
+        -- top-level scoped_identifier
+        rust_use_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            JOIN ast sc ON sc.parent_id = i.node_id
+              AND sc.file_path = i.file_path
+              AND sc.type = 'scoped_identifier'
+            JOIN ast a ON a.parent_id = sc.node_id
+              AND a.file_path = i.file_path
+              AND a.type = 'identifier'
+              AND a.name IS NOT NULL AND a.name != ''
+              AND a.node_id = (
+                  SELECT MAX(a2.node_id) FROM ast a2
+                  WHERE a2.parent_id = sc.node_id
+                    AND a2.file_path = i.file_path
+                    AND a2.type = 'identifier'
+              )
+            WHERE i.import_type NOT IN ('import_from_statement')
+        ),
+        -- Case 3c: Rust use_list imports (use std::io::{Read, Write})
+        -- Identifiers inside use_list are the imported names
+        use_list_names AS (
+            SELECT i.file_path, i.source_module, a.name as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            JOIN ast ul ON ul.node_id > i.node_id
+              AND ul.node_id <= i.node_id + i.descendant_count
+              AND ul.file_path = i.file_path
+              AND ul.type = 'use_list'
+            JOIN ast a ON a.parent_id = ul.node_id
+              AND a.file_path = i.file_path
+              AND a.type = 'identifier'
+              AND a.name IS NOT NULL AND a.name != ''
+            WHERE i.import_type NOT IN ('import_from_statement')
+        ),
+        -- Case 4: Bare imports (Python import os, Go import "fmt", Rust use std::io)
+        -- No separate imported name — the module itself is the import
+        bare_import_names AS (
+            SELECT i.file_path, i.source_module,
+                   i.source_module as imported_name,
+                   i.import_type, i.start_line
+            FROM import_nodes i
+            WHERE i.source_module IS NOT NULL AND i.source_module != ''
+              AND NOT EXISTS (
+                  SELECT 1 FROM from_import_names f
+                  WHERE f.file_path = i.file_path AND f.start_line = i.start_line
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM specifier_names s
+                  WHERE s.file_path = i.file_path AND s.start_line = i.start_line
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM js_default_names j
+                  WHERE j.file_path = i.file_path AND j.start_line = i.start_line
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM rust_use_names r
+                  WHERE r.file_path = i.file_path AND r.start_line = i.start_line
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM use_list_names u
+                  WHERE u.file_path = i.file_path AND u.start_line = i.start_line
+              )
+        ),
+        all_imports AS (
+            SELECT * FROM from_import_names
+            UNION ALL SELECT * FROM specifier_names
+            UNION ALL SELECT * FROM js_default_names
+            UNION ALL SELECT * FROM rust_use_names
+            UNION ALL SELECT * FROM use_list_names
+            UNION ALL SELECT * FROM bare_import_names
         )
     SELECT file_path, source_module, imported_name, import_type, start_line
-    FROM imported_names
+    FROM all_imports
     ORDER BY file_path, start_line, imported_name;
 
 

--- a/test/data/go/import_forms.go
+++ b/test/data/go/import_forms.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+import "os"
+import (
+	"net/http"
+	"encoding/json"
+	myalias "github.com/example/pkg"
+)

--- a/test/data/javascript/import_forms.js
+++ b/test/data/javascript/import_forms.js
@@ -1,0 +1,8 @@
+// All JavaScript import forms
+import React from 'react';
+import { useState, useEffect } from 'react';
+import { useState as useReactState } from 'react';
+import * as ReactDOM from 'react-dom';
+import './styles.css';
+const fs = require('fs');
+const { readFile } = require('fs');

--- a/test/data/javascript/import_forms.ts
+++ b/test/data/javascript/import_forms.ts
@@ -1,0 +1,5 @@
+// TypeScript import forms
+import React from 'react';
+import { useState, useEffect } from 'react';
+import type { FC, ReactNode } from 'react';
+import * as path from 'path';

--- a/test/data/python/import_forms.py
+++ b/test/data/python/import_forms.py
@@ -1,0 +1,11 @@
+# All Python import forms
+import os
+import os.path
+import os as operating_system
+from pathlib import Path
+from pathlib import Path, PurePath
+from collections.abc import Mapping
+from . import utils
+from .. import base
+from ..foo import bar
+from ..foo.bar import baz, qux

--- a/test/data/rust/import_forms.rs
+++ b/test/data/rust/import_forms.rs
@@ -1,0 +1,5 @@
+use std::io;
+use std::collections::HashMap;
+use crate::foo::bar;
+use super::utils;
+use std::io::{Read, Write};

--- a/test/sql/core/glob_array_support.test
+++ b/test/sql/core/glob_array_support.test
@@ -115,9 +115,9 @@ HAVING COUNT(*) > 0
 ORDER BY language;
 ----
 cpp	534	2
-go	462	3
-javascript	779	4
-python	3183	16
+go	501	4
+javascript	877	5
+python	3272	17
 
 # Test 13: Consistent ordering (DuckDB convention)
 # ===============================================

--- a/test/sql/languages/go_language_support.test
+++ b/test/sql/languages/go_language_support.test
@@ -48,7 +48,7 @@ WHERE type IN ('package_identifier', 'import_spec') AND name IS NOT NULL
 ORDER BY start_line;
 ----
 main	package_identifier
-"fmt"	import_spec
+fmt	import_spec
 
 # Test 6: Go semantic types
 # =========================

--- a/test/sql/languages/import_name_extraction.test
+++ b/test/sql/languages/import_name_extraction.test
@@ -54,13 +54,13 @@ WHERE type = 'import_from_statement' AND name = 'collections.abc';
 ----
 import_from_statement	collections.abc
 
-# Test: relative import falls back to identifier
+# Test: relative import extracts dot prefix as source module
 query TT
 SELECT type, name
 FROM read_ast('test/data/python/imports.py', context := 'native')
-WHERE type = 'import_from_statement' AND name = 'utils';
+WHERE type = 'import_from_statement' AND name = '.';
 ----
-import_from_statement	utils
+import_from_statement	.
 
 # =============================================================================
 # JAVASCRIPT
@@ -74,7 +74,7 @@ WHERE type = 'import_statement'
 ORDER BY start_line
 LIMIT 1;
 ----
-import_statement	"react"
+import_statement	react
 
 # Test: all JS imports extract module source
 query TT
@@ -83,10 +83,10 @@ FROM read_ast('test/data/javascript/imports.js', context := 'native')
 WHERE type = 'import_statement'
 ORDER BY start_line;
 ----
-import_statement	"react"
-import_statement	"react"
-import_statement	"path"
-import_statement	"side-effect"
+import_statement	react
+import_statement	react
+import_statement	path
+import_statement	side-effect
 
 # =============================================================================
 # TYPESCRIPT
@@ -100,7 +100,7 @@ WHERE type = 'import_statement'
 ORDER BY start_line
 LIMIT 1;
 ----
-import_statement	"react"
+import_statement	react
 
 # =============================================================================
 # C
@@ -151,8 +151,8 @@ FROM read_ast('test/data/rust/imports.rs', context := 'native')
 WHERE type = 'use_declaration'
 ORDER BY start_line;
 ----
-use_declaration	std::collections::HashMap
-use_declaration	std::io
+use_declaration	std::collections
+use_declaration	std
 use_declaration	std::io::*
 
 # =============================================================================

--- a/test/sql/languages/python_refinements.test
+++ b/test/sql/languages/python_refinements.test
@@ -164,13 +164,13 @@ WHERE type = 'import_from_statement' AND name = 'collections.abc';
 ----
 import_from_statement	collections.abc
 
-# Test: relative import (from . import name) falls back to identifier
+# Test: relative import (from . import name) extracts dot prefix as source module
 query TT
 SELECT type, name
 FROM read_ast('test/data/python/imports.py', context := 'native')
-WHERE type = 'import_from_statement' AND name = 'utils';
+WHERE type = 'import_from_statement' AND name = '.';
 ----
-import_from_statement	utils
+import_from_statement	.
 
 # =============================================================================
 # CALL REFINEMENTS

--- a/test/sql/languages/rust_language_support.test
+++ b/test/sql/languages/rust_language_support.test
@@ -53,7 +53,7 @@ SELECT name, type FROM read_ast('test/data/rust/simple.rs')
 WHERE type = 'use_declaration' AND name IS NOT NULL
 ORDER BY start_line;
 ----
-std::collections::HashMap	use_declaration
+std::collections	use_declaration
 super::*	use_declaration
 
 # Test 6: Rust semantic types

--- a/test/sql/multi_file_edge_cases.test
+++ b/test/sql/multi_file_edge_cases.test
@@ -164,7 +164,7 @@ WHERE parent_id IS NOT NULL;
 # ====================================
 # All patterns should be processed
 query I
-SELECT COUNT(DISTINCT file_path) = 21 as processes_all_files
+SELECT COUNT(DISTINCT file_path) = 23 as processes_all_files
 FROM read_ast([
     'test/data/python/*.py',
     'test/data/javascript/*.js',

--- a/test/sql/qualified_name.test
+++ b/test/sql/qualified_name.test
@@ -173,18 +173,21 @@ F	V[F]
 # Test 13: Import statements get I[name] prefix
 # =============================================================================
 
-# Python aliased import produces I[np]
+# Python aliased import: import_statement gets I[numpy], alias gets I[np]
 query II
 SELECT name, ast_qualified_name_as_string(qualified_name)
 FROM parse_ast('import numpy as np', 'python')
-WHERE ast_qualified_name_as_string(qualified_name) LIKE 'I[%';
+WHERE ast_qualified_name_as_string(qualified_name) LIKE 'I[%'
+ORDER BY name;
 ----
 np	I[np]
+numpy	I[numpy]
 
 # =============================================================================
 # Test 14: Filter by import kind with 'I[' prefix pattern
 # =============================================================================
 
+# 4 nodes: import_statement os, import_statement sys, import_statement numpy, aliased_import np
 query I
 SELECT COUNT(*)
 FROM parse_ast('
@@ -194,7 +197,7 @@ import numpy as np
 ', 'python')
 WHERE ast_qualified_name_as_string(qualified_name) LIKE 'I[%';
 ----
-3
+4
 
 # =============================================================================
 # Test 15: JavaScript export specifiers get E[name] prefix

--- a/test/sql/test_resolver.test
+++ b/test/sql/test_resolver.test
@@ -1,0 +1,125 @@
+# name: test/sql/test_resolver.test
+# group: [sql]
+
+# Tests for ast_exports / ast_imports compatibility and cross-file resolution
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# ast_exports: module-level public definitions only
+# =============================================================================
+
+# Should return exactly 10 module-level public definitions
+query I
+SELECT COUNT(*) FROM ast_exports('test/data/python/sample_app.py');
+----
+10
+
+# Every export is a name definition with IS_EXPORTED flag
+query I
+SELECT COUNT(*) FROM ast_exports('test/data/python/sample_app.py')
+WHERE NOT is_name_definition(flags) OR NOT is_exported(flags);
+----
+0
+
+# No nested definitions leak through (all at module scope)
+query I
+SELECT COUNT(*) FROM ast_exports('test/data/python/sample_app.py')
+WHERE scope.current != 0;
+----
+0
+
+# Class methods should NOT appear in exports
+query I
+SELECT COUNT(*) FROM ast_exports('test/data/python/sample_app.py')
+WHERE type = 'function_definition' AND name IN ('load', 'get', 'connect', 'execute', 'get_user');
+----
+0
+
+# Module-level functions SHOULD appear
+query I
+SELECT COUNT(*) FROM ast_exports('test/data/python/sample_app.py')
+WHERE type = 'function_definition' AND name IN ('process_file', 'transform', 'validate_email', 'main');
+----
+4
+
+# Classes SHOULD appear
+query I
+SELECT COUNT(*) FROM ast_exports('test/data/python/sample_app.py')
+WHERE type = 'class_definition';
+----
+3
+
+# =============================================================================
+# IS_EXPORTED flag is only on definitions (not references or syntax)
+# =============================================================================
+
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py')
+WHERE is_name_reference(flags) AND is_exported(flags);
+----
+0
+
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py')
+WHERE is_syntax_only(flags) AND is_exported(flags);
+----
+0
+
+# =============================================================================
+# ast_imports: Python import extraction
+# =============================================================================
+
+# All imports extract correctly (bare and from-imports)
+query III
+SELECT source_module, imported_name, import_type
+FROM ast_imports('test/data/python/sample_app.py');
+----
+os	os	import_statement
+json	json	import_statement
+pathlib	Path	import_from_statement
+
+# Comprehensive Python import forms
+query III
+SELECT source_module, imported_name, import_type
+FROM ast_imports('workspace/sandbox/import_forms.py')
+ORDER BY start_line, imported_name;
+----
+os	os	import_statement
+os.path	os.path	import_statement
+os	operating_system	import_statement
+pathlib	Path	import_from_statement
+pathlib	Path	import_from_statement
+pathlib	PurePath	import_from_statement
+collections.abc	Mapping	import_from_statement
+.	utils	import_from_statement
+..	base	import_from_statement
+..foo	bar	import_from_statement
+..foo.bar	baz	import_from_statement
+..foo.bar	qux	import_from_statement
+
+# =============================================================================
+# Cross-file resolution: imports + exports join surface
+# =============================================================================
+
+# Imports from sample_app.py should be resolvable against pathlib exports
+# (within-project resolution would work for project-internal imports)
+query II
+SELECT i.source_module, i.imported_name
+FROM ast_imports('test/data/python/sample_app.py') i
+WHERE i.source_module NOT IN ('os', 'json');
+----
+pathlib	Path
+
+# =============================================================================
+# Multi-file glob: no cross-contamination between files
+# =============================================================================
+
+query I
+SELECT COUNT(*) FROM ast_imports('workspace/sandbox/import_forms.*')
+WHERE source_module LIKE '%react%' AND file_path NOT LIKE '%.js' AND file_path NOT LIKE '%.ts';
+----
+0

--- a/test/sql/test_resolver.test
+++ b/test/sql/test_resolver.test
@@ -85,7 +85,7 @@ pathlib	Path	import_from_statement
 # Comprehensive Python import forms
 query III
 SELECT source_module, imported_name, import_type
-FROM ast_imports('workspace/sandbox/import_forms.py')
+FROM ast_imports('test/data/python/import_forms.py')
 ORDER BY start_line, imported_name;
 ----
 os	os	import_statement
@@ -119,7 +119,7 @@ pathlib	Path
 # =============================================================================
 
 query I
-SELECT COUNT(*) FROM ast_imports('workspace/sandbox/import_forms.*')
+SELECT COUNT(*) FROM ast_imports('test/data/*/import_forms.*')
 WHERE source_module LIKE '%react%' AND file_path NOT LIKE '%.js' AND file_path NOT LIKE '%.ts';
 ----
 0


### PR DESCRIPTION
## Summary
- Fix IS_EXPORTED flag to only apply to definition/declaration nodes, not all nodes
- Fix ast_exports to return only module-level public definitions (was returning 447 nodes, now returns 10)
- Complete rewrite of ast_imports macro fixing cross-file contamination, missing bare imports, broken relative imports, quote artifacts in JS/TS/Go module names, and Rust scoped path leakage
- Language adapter fixes for Python, JS, TS, Go, and Rust import name extraction

## Test plan
- [x] All 204 tests pass (10,724 assertions)
- [x] Python: all import forms (bare, dotted, aliased, from, relative with `.`/`..`, multi-name)
- [x] JS: default imports, named imports, namespace imports, side-effect imports
- [x] TS: same as JS plus type imports
- [x] Go: bare imports, grouped imports, aliased imports (quote-free module names)
- [x] Rust: simple use, scoped paths, use lists, wildcard imports
- [x] Multi-file glob: no cross-contamination between files
- [x] ast_exports: only definitions at module scope with IS_EXPORTED flag
- [x] IS_EXPORTED flag not set on references or syntax-only nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)