### PR TITLE
feat: parse-time filtering (max_depth, prune) and C# name extraction fix

### DIFF
--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -1134,22 +1134,12 @@ CREATE OR REPLACE MACRO ast_dead_code(source, language := NULL) AS TABLE
 -- Uses scope-aware attribution: nested function calls belong to the inner function.
 -- Usage: SELECT * FROM ast_get_calls('src/**/*.py')
 -- Usage: SELECT * FROM ast_get_calls('src/main.py') WHERE call_type = 'method'
+-- See also: ast_callees/ast_callers in scope_resolution.sql for simpler
+-- caller/callee pairs without call-type classification.
 CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
     WITH
         ast AS (
             SELECT * FROM read_ast(source, language)
-        ),
-        functions AS (
-            SELECT
-                a.node_id AS func_id,
-                a.name AS func_name,
-                a.file_path,
-                a.language AS func_lang,
-                a.descendant_count
-            FROM ast a
-            WHERE is_function_definition(a.semantic_type)
-              AND is_construct(a.flags)
-              AND a.name IS NOT NULL AND a.name != ''
         ),
         calls AS (
             SELECT
@@ -1159,7 +1149,8 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
                 a.peek,
                 a.file_path,
                 a.language,
-                a.start_line
+                a.start_line,
+                a.scope.function AS scope_function
             FROM ast a
             WHERE is_function_call(a.semantic_type)
               AND a.name IS NOT NULL AND a.name != ''
@@ -1183,18 +1174,13 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
                 c.language,
                 c.start_line,
                 ct.target_type,
-                f.func_id AS caller_node_id,
-                f.func_name AS caller_name
+                f.node_id AS caller_node_id,
+                f.name AS caller_name
             FROM calls c
             LEFT JOIN call_targets ct ON ct.call_id = c.node_id
-            LEFT JOIN functions f
-              ON f.file_path = c.file_path
-             AND f.func_id < c.node_id
-             AND c.node_id <= f.func_id + f.descendant_count
-            QUALIFY ROW_NUMBER() OVER (
-                PARTITION BY c.node_id
-                ORDER BY f.func_id DESC NULLS LAST
-            ) = 1
+            LEFT JOIN ast f
+              ON f.node_id = c.scope_function
+             AND f.file_path = c.file_path
         )
     SELECT
         cwc.file_path,
@@ -4158,6 +4144,9 @@ CREATE OR REPLACE MACRO ast_resolve(
 -- For each function definition, finds all call expressions within its scope.
 -- Returns (caller_name, caller_line, callee_name, callee_line) pairs.
 --
+-- See also: ast_get_calls/ast_call_graph in tree_navigation.sql for richer
+-- call extraction with call-type classification (function/method/constructor/macro).
+--
 -- Usage:
 --   SELECT * FROM ast_callees('src/**/*.py');
 --   SELECT caller, callee FROM ast_callees('src/*.py') WHERE caller = 'main';
@@ -4170,14 +4159,14 @@ CREATE OR REPLACE MACRO ast_callees(
     -- enclosing function — precomputed at parse time. So "find calls inside
     -- function F" collapses from an O(calls x funcs) range join into a
     -- simple hash join on scope.function. The range-join version this
+
+)SQLMACRO"
+        R"SQLMACRO(
     -- replaces took up to 20 seconds on DuckDB's own source tree; this
     -- runs in under a second.
     WITH ast AS (
         SELECT * FROM read_ast(source, language)
     )
-
-)SQLMACRO"
-        R"SQLMACRO(
     SELECT f.name         AS caller,
            f.qualified_name AS caller_qualified,
            f.start_line   AS caller_line,

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -1124,6 +1124,108 @@ CREATE OR REPLACE MACRO ast_dead_code(source, language := NULL) AS TABLE
         dc.reason
     FROM dead_code dc
     ORDER BY dc.file_path, dc.start_line;
+
+-- =============================================================================
+-- Call Extraction
+-- =============================================================================
+
+-- Extract all function/method calls from source code
+-- Returns one row per call site with the containing function (caller) identified.
+-- Uses scope-aware attribution: nested function calls belong to the inner function.
+-- Usage: SELECT * FROM ast_get_calls('src/**/*.py')
+-- Usage: SELECT * FROM ast_get_calls('src/main.py') WHERE call_type = 'method'
+CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
+    WITH
+        ast AS (
+            SELECT * FROM read_ast(source, language)
+        ),
+        functions AS (
+            SELECT
+                a.node_id AS func_id,
+                a.name AS func_name,
+                a.file_path,
+                a.language AS func_lang,
+                a.descendant_count
+            FROM ast a
+            WHERE is_function_definition(a.semantic_type)
+              AND is_construct(a.flags)
+              AND a.name IS NOT NULL AND a.name != ''
+        ),
+        calls AS (
+            SELECT
+                a.node_id,
+                a.name,
+                a.type,
+                a.peek,
+                a.file_path,
+                a.language,
+                a.start_line
+            FROM ast a
+            WHERE is_function_call(a.semantic_type)
+              AND a.name IS NOT NULL AND a.name != ''
+        ),
+        calls_with_caller AS (
+            SELECT
+                c.node_id,
+                c.name AS called_name,
+                c.type AS call_node_type,
+                c.peek,
+                c.file_path,
+                c.language,
+                c.start_line,
+                f.func_id AS caller_node_id,
+                f.func_name AS caller_name
+            FROM calls c
+            LEFT JOIN functions f
+              ON f.file_path = c.file_path
+             AND f.func_id < c.node_id
+             AND c.node_id <= f.func_id + f.descendant_count
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY c.node_id
+                ORDER BY f.func_id DESC NULLS LAST
+            ) = 1
+        )
+    SELECT
+        cwc.file_path,
+        COALESCE(cwc.caller_name, '<module>') AS caller_name,
+        cwc.called_name,
+        cwc.peek AS call_expression,
+        CASE
+            WHEN cwc.call_node_type IN ('new_expression', 'object_creation_expression',
+                                         'constructor_invocation', 'init_expression',
+                                         'composite_literal', 'struct_expression')
+                THEN 'constructor'
+            WHEN cwc.call_node_type IN ('macro_invocation')
+                THEN 'macro'
+            WHEN cwc.peek LIKE '%.' || cwc.called_name || '(%'
+                THEN 'method'
+            ELSE 'function'
+        END AS call_type,
+        cwc.language,
+        cwc.start_line,
+        cwc.node_id,
+        cwc.caller_node_id
+    FROM calls_with_caller cwc
+    ORDER BY cwc.file_path, cwc.start_line;
+
+-- Build a call graph from source code
+-- Returns aggregated caller→callee pairs with call counts.
+-- Usage: SELECT * FROM ast_call_graph('src/**/*.py') ORDER BY call_count DESC
+-- Usage: SELECT * FROM ast_call_graph('src/**/*.py') WHERE caller = 'main'
+CREATE OR REPLACE MACRO ast_call_graph(source, language := NULL) AS TABLE
+    WITH
+        raw_calls AS (
+            SELECT * FROM ast_get_calls(source, language)
+        )
+    SELECT
+        rc.file_path,
+        rc.caller_name AS caller,
+        rc.called_name AS callee,
+        rc.call_type,
+        COUNT(*) AS call_count
+    FROM raw_calls rc
+    GROUP BY rc.file_path, rc.caller_name, rc.called_name, rc.call_type
+    ORDER BY rc.file_path, rc.caller_name, rc.called_name;
 )SQLMACRO"},
     {"pattern_matching.sql", R"SQLMACRO(
 -- =============================================================================

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -4230,6 +4230,165 @@ CREATE OR REPLACE MACRO ast_callers(
     WHERE c.semantic_type = 'COMPUTATION_CALL'
       AND c.name IS NOT NULL AND c.name != ''
     ORDER BY c.file_path, c.start_line;
+
+
+-- =============================================================================
+-- ast_find_references: Find all uses of a symbol via scope-chain resolution
+-- =============================================================================
+--
+-- Given a target name, finds every reference and call site that resolves to
+-- a definition of that name through the scope chain. Handles shadowed names
+-- correctly: if two scopes define the same name, only references that resolve
+-- to the specific definition are returned.
+--
+-- Usage:
+--   SELECT * FROM ast_find_references('src/**/*.py', 'process');
+--   SELECT * FROM ast_find_references('src/main.py', 'x') WHERE ref_kind = 'call';
+--   SELECT * FROM ast_find_references('src/*.py', 'Service', language := 'python');
+
+CREATE OR REPLACE MACRO ast_find_references(
+    source,
+    target_name,
+    language := NULL
+) AS TABLE
+    WITH
+        ast AS (
+            SELECT * FROM read_ast(source, language)
+        ),
+        -- Target definitions: all definitions matching the name
+        target_defs AS (
+            SELECT
+                a.node_id AS def_node_id,
+                a.name,
+                a.type AS def_type,
+                a.file_path,
+                a.start_line AS def_line,
+                a.peek AS def_peek,
+                a.scope.current AS def_scope
+            FROM ast a
+            WHERE is_name_definition(a.flags)
+              AND a.name = target_name
+        ),
+        -- All identifier references to the target name with scope chain.
+        -- Excludes name-binding identifiers inside definition/declaration
+        -- nodes (e.g., the 'process' identifier inside 'def process():').
+        refs AS (
+            SELECT
+                a.node_id AS ref_node_id,
+                a.name AS ref_name,
+                a.type AS ref_type,
+                a.start_line AS ref_line,
+                a.file_path,
+                a.parent_id,
+                a.scope.current AS scope_current,
+                s.scope.stack AS scope_stack
+            FROM ast a
+            JOIN ast s ON s.node_id = a.scope.current AND s.file_path = a.file_path
+            LEFT JOIN ast p ON p.node_id = a.parent_id AND p.file_path = a.file_path
+            WHERE is_name_reference(a.flags)
+              AND a.name = target_name
+              AND s.scope.stack IS NOT NULL
+              AND NOT COALESCE(binds_name(p.flags), false)
+        ),
+        -- Unnest scope chain for each reference
+        search_scopes AS (
+            SELECT
+                r.ref_node_id, r.ref_name, r.ref_type, r.ref_line,
+                r.file_path, r.parent_id,
+                unnest(r.scope_stack).id AS search_scope_id,
+                generate_series(1, len(r.scope_stack)) AS scope_distance
+            FROM refs r
+        ),
+        -- Find which target definition each reference resolves to
+        candidates AS (
+            SELECT
+                ss.ref_node_id,
+                ss.ref_line,
+                ss.ref_type,
+                ss.file_path,
+                ss.parent_id,
+                ss.scope_distance,
+                td.def_node_id,
+                td.def_line
+            FROM search_scopes ss
+            JOIN ast d ON d.scope.current = ss.search_scope_id
+              AND d.file_path = ss.file_path
+              AND d.name = ss.ref_name
+              AND is_name_definition(d.flags)
+            JOIN target_defs td ON td.def_node_id = d.node_id
+              AND td.file_path = d.file_path
+        ),
+        -- Pick closest definition per reference (innermost scope)
+        resolved_refs AS (
+            SELECT DISTINCT ON (ref_node_id)
+                ref_node_id, ref_line, ref_type, file_path, parent_id,
+                def_node_id, def_line
+            FROM candidates
+            ORDER BY ref_node_id, scope_distance DESC
+        ),
+        -- Classify: if the ref's parent is a call node, this is a call site.
+        -- For calls, promote to the call node (type, line, peek).
+        -- For references, use the parent's peek for surrounding context.
+        classified_refs AS (
+            SELECT
+                rr.file_path,
+                target_name AS name,
+                CASE
+                    WHEN is_function_call(p.semantic_type) THEN 'call'
+                    ELSE 'reference'
+                END AS ref_kind,
+                COALESCE(
+                    CASE WHEN is_function_call(p.semantic_type) THEN p.type END,
+                    rr.ref_type
+                ) AS node_type,
+                COALESCE(
+                    CASE WHEN is_function_call(p.semantic_type) THEN p.start_line END,
+                    rr.ref_line
+                ) AS start_line,
+                COALESCE(p.peek, ref_node.peek) AS peek,
+                COALESCE(f.name, '<module>') AS scope_name,
+                rr.def_node_id,
+                rr.ref_node_id
+            FROM resolved_refs rr
+            LEFT JOIN ast p ON p.node_id = rr.parent_id AND p.file_path = rr.file_path
+            LEFT JOIN ast ref_node ON ref_node.node_id = rr.ref_node_id AND ref_node.file_path = rr.file_path
+            LEFT JOIN ast f ON f.node_id = ref_node.scope.function AND f.file_path = rr.file_path
+        ),
+        -- Definition sites
+        def_sites AS (
+            SELECT
+                td.file_path,
+                target_name AS name,
+                'definition' AS ref_kind,
+                td.def_type AS node_type,
+                td.def_line AS start_line,
+                td.def_peek AS peek,
+                COALESCE(f.name, '<module>') AS scope_name,
+                td.def_node_id
+            FROM target_defs td
+            LEFT JOIN ast d ON d.node_id = td.def_node_id AND d.file_path = td.file_path
+            LEFT JOIN ast f ON f.node_id = d.scope.function AND f.file_path = td.file_path
+        ),
+        combined AS (
+            SELECT file_path, name, ref_kind, node_type, start_line,
+                   peek, scope_name, def_node_id
+            FROM def_sites
+            UNION
+            SELECT file_path, name, ref_kind, node_type, start_line,
+                   peek, scope_name, def_node_id
+            FROM classified_refs
+        )
+    SELECT
+        file_path,
+        name,
+        ref_kind,
+        node_type,
+        start_line,
+        peek,
+        scope_name,
+        def_node_id
+    FROM combined
+    ORDER BY file_path, start_line, ref_kind;
 )SQLMACRO"},
 };
 

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -1164,6 +1164,15 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
             WHERE is_function_call(a.semantic_type)
               AND a.name IS NOT NULL AND a.name != ''
         ),
+        call_targets AS (
+            SELECT
+                c.node_id AS call_id,
+                child.type AS target_type
+            FROM calls c
+            JOIN ast child
+              ON child.parent_id = c.node_id
+             AND child.sibling_index = 0
+        ),
         calls_with_caller AS (
             SELECT
                 c.node_id,
@@ -1173,9 +1182,11 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
                 c.file_path,
                 c.language,
                 c.start_line,
+                ct.target_type,
                 f.func_id AS caller_node_id,
                 f.func_name AS caller_name
             FROM calls c
+            LEFT JOIN call_targets ct ON ct.call_id = c.node_id
             LEFT JOIN functions f
               ON f.file_path = c.file_path
              AND f.func_id < c.node_id
@@ -1197,7 +1208,9 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
                 THEN 'constructor'
             WHEN cwc.call_node_type IN ('macro_invocation')
                 THEN 'macro'
-            WHEN cwc.peek LIKE '%.' || cwc.called_name || '(%'
+            WHEN cwc.target_type IN ('attribute', 'member_expression',
+                                      'field_expression', 'selector_expression',
+                                      'navigation_expression', 'field_access')
                 THEN 'method'
             ELSE 'function'
         END AS call_type,

--- a/src/include/unified_ast_backend.hpp
+++ b/src/include/unified_ast_backend.hpp
@@ -17,6 +17,7 @@ namespace duckdb {
 struct SemanticFilter {
 	uint8_t mask;
 	uint8_t value;
+	bool subtree; // true = prune node + all descendants; false = re-parent children
 };
 
 struct ExtractionConfig {

--- a/src/include/unified_ast_backend.hpp
+++ b/src/include/unified_ast_backend.hpp
@@ -14,6 +14,11 @@ namespace duckdb {
 // Extraction Configuration System
 //==============================================================================
 
+struct SemanticFilter {
+	uint8_t mask;
+	uint8_t value;
+};
+
 struct ExtractionConfig {
 	ContextLevel context = ContextLevel::NATIVE; // Default to native for backward compatibility
 	SourceLevel source = SourceLevel::LINES;
@@ -21,6 +26,15 @@ struct ExtractionConfig {
 	PeekLevel peek = PeekLevel::SMART;
 	int32_t peek_size = 120;          // Used when peek == CUSTOM
 	bool include_full_schema = false; // When true, schema includes all columns regardless of level settings
+
+	// Parse-time filtering (#014)
+	int32_t max_depth = -1;                     // -1 = unlimited
+	uint8_t prune_flag_mask = 0;                // prune if (flags & mask) != 0
+	vector<SemanticFilter> prune_type_filters;  // prune if (type & f.mask) == f.value
+	bool prune_unnamed = false;
+	bool prune_leaves = false;
+	bool prune_internal = false;
+	bool has_prune = false;
 
 	// Get a schema-level config: if include_full_schema, return max levels for schema generation
 	ExtractionConfig GetSchemaConfig() const {
@@ -59,6 +73,7 @@ struct ExtractionConfig {
 // Parse extraction config from SQL parameters
 ExtractionConfig ParseExtractionConfig(const string &context_str, const string &source_str, const string &structure_str,
                                        const string &peek_str, int32_t peek_size = 120);
+void CompilePrunePolicy(const string &policy_name, ExtractionConfig &config);
 
 // Result structure for unified parsing backend
 struct ASTSource {

--- a/src/include/unified_ast_backend_impl.hpp
+++ b/src/include/unified_ast_backend_impl.hpp
@@ -73,11 +73,7 @@ static int ShouldPruneNode(const ASTNode &node, uint32_t ts_child_count,
 	// Semantic type filters (comments, literals, imports, types, punctuation)
 	for (auto &f : config.prune_type_filters) {
 		if ((node.semantic_type & f.mask) == f.value) {
-			uint8_t kind = node.semantic_type & 0xF0;
-			if (kind == SemanticTypes::LITERAL || kind == SemanticTypes::EXTERNAL || kind == SemanticTypes::TYPE) {
-				return 2; // subtree prune
-			}
-			return 1;
+			return f.subtree ? 2 : 1;
 		}
 	}
 
@@ -86,7 +82,7 @@ static int ShouldPruneNode(const ASTNode &node, uint32_t ts_child_count,
 	if (config.prune_internal) {
 		if ((node.universal_flags & ASTNodeFlags::BINDS_NAME) &&
 		    !(node.universal_flags & ASTNodeFlags::IS_EXPORTED)) {
-			return 1;
+			return 2;
 		}
 	}
 	return 0;

--- a/src/include/unified_ast_backend_impl.hpp
+++ b/src/include/unified_ast_backend_impl.hpp
@@ -59,6 +59,39 @@ static string SanitizeUTF8(const string &input) {
 	return string(char_array.begin(), char_array.end() - 1);         // Exclude null terminator
 }
 
+// Helper: decide whether to prune a node at parse time.
+// Returns: 0 = keep, 1 = node prune (re-parent children), 2 = subtree prune (drop everything)
+static int ShouldPruneNode(const ASTNode &node, uint32_t ts_child_count,
+                           const ExtractionConfig &config) {
+	if (!config.has_prune) return 0;
+
+	// Flag-based (syntax)
+	if (config.prune_flag_mask && (node.universal_flags & config.prune_flag_mask)) {
+		return 1;
+	}
+
+	// Semantic type filters (comments, literals, imports, types, punctuation)
+	for (auto &f : config.prune_type_filters) {
+		if ((node.semantic_type & f.mask) == f.value) {
+			uint8_t kind = node.semantic_type & 0xF0;
+			if (kind == SemanticTypes::LITERAL || kind == SemanticTypes::EXTERNAL) {
+				return 2; // subtree prune
+			}
+			return 1;
+		}
+	}
+
+	if (config.prune_unnamed && node.name_raw.empty()) return 1;
+	if (config.prune_leaves && ts_child_count == 0) return 1;
+	if (config.prune_internal) {
+		if ((node.universal_flags & ASTNodeFlags::BINDS_NAME) &&
+		    !(node.universal_flags & ASTNodeFlags::IS_EXPORTED)) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
 // Template implementation with ExtractionConfig - eliminates virtual calls
 template <typename AdapterType>
 ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapter, const string &content,
@@ -120,6 +153,9 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 	// having to re-scan the AST, and also lets us emit a typed scope.stack.
 	vector<ASTNode::ScopeEntry> scope_node_stack;
 
+	// Per-parent sibling counter for re-indexing after prune (only allocated when pruning)
+	unordered_map<int64_t, int32_t> sibling_counters;
+
 	while (!stack.empty()) {
 		// Check if the top entry is processed before copying
 		if (!stack.back().processed) {
@@ -127,20 +163,15 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 			auto entry = stack.back();
 			// First visit - create node and add children
 			entry.processed = true;
-			entry.node_index = result.nodes.size();
+			// NOTE: node_index assignment is DEFERRED until after prune check.
+			// Pruned nodes never get added to result.nodes, so they must not
+			// claim an index.
 
-			// Update the stack entry with the processed flag and node_index
+			// Update the stack entry with the processed flag
 			stack.back().processed = true;
-			stack.back().node_index = entry.node_index;
 
-			// Track max depth
-			max_depth = std::max(max_depth, entry.depth);
-
-			// Create ASTNode
+			// Create ASTNode (properties extracted before prune check)
 			ASTNode ast_node;
-
-			// Basic information - use node_index as node_id
-			ast_node.node_id = entry.node_index;
 
 			// MEMORY SAFETY: Explicit copy of tree-sitter string data
 			const char *ts_type = ts_node_type(entry.node); // Points to tree-sitter memory
@@ -217,11 +248,11 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 			}
 
 			// Extract source text (peek) with configurable size and mode
-			uint32_t start_byte = ts_node_start_byte(entry.node); // By-value copy ✅
-			uint32_t end_byte = ts_node_end_byte(entry.node);     // By-value copy ✅
+			uint32_t start_byte = ts_node_start_byte(entry.node); // By-value copy
+			uint32_t end_byte = ts_node_end_byte(entry.node);     // By-value copy
 			if (start_byte < content.size() && end_byte <= content.size() && end_byte > start_byte) {
 				// MEMORY SAFETY: Create owned copy of source text slice
-				string source_text = content.substr(start_byte, end_byte - start_byte); // COPY ✅
+				string source_text = content.substr(start_byte, end_byte - start_byte); // COPY
 
 				// Apply peek configuration and sanitize UTF-8
 				if (config.peek == PeekLevel::NONE || config.peek_size == 0) {
@@ -276,6 +307,44 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 				ast_node.type_normalized = "";
 				ast_node.native_extraction_attempted = false;
 			}
+
+			// === PRUNE CHECK ===
+			// Must happen AFTER property extraction (semantic_type, flags, name needed
+			// for policy evaluation) and BEFORE emit/scope tracking.
+			if (config.has_prune) {
+				int prune_action = ShouldPruneNode(ast_node, child_count, config);
+				if (prune_action == 2) {
+					// Subtree prune: drop this node AND all children
+					stack.pop_back();
+					continue;
+				}
+				if (prune_action == 1) {
+					// Node prune: skip this node but re-parent children
+					stack.pop_back();
+					if (child_count > 0) {
+						for (int32_t i = child_count - 1; i >= 0; i--) {
+							TSNode child = ts_node_child(entry.node, i);
+							// Re-parent to pruned node's parent, keep same depth
+							stack.push_back({child, entry.parent_id, entry.depth, i, false, 0});
+						}
+					}
+					continue;
+				}
+			}
+
+			// === ASSIGN NODE INDEX (deferred until after prune check) ===
+			entry.node_index = result.nodes.size();
+			stack.back().node_index = entry.node_index;
+			ast_node.node_id = entry.node_index;
+
+			// Assign sibling_index: when pruning, use per-parent counters for
+			// contiguous sibling indices; otherwise use tree-sitter's index.
+			if (config.has_prune) {
+				ast_node.sibling_index = sibling_counters[entry.parent_id]++;
+			}
+
+			// Track max depth (only for emitted nodes)
+			max_depth = std::max(max_depth, entry.depth);
 
 			// Scope tracking: populate the scope struct for every node.
 			//   scope.current = nearest enclosing scope (top of stack)
@@ -369,10 +438,16 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 			result.nodes.push_back(ast_node);
 
 			// Add children to stack in reverse order for correct processing
-			int64_t current_id = ast_node.node_index;
-			for (int32_t i = child_count - 1; i >= 0; i--) {
-				TSNode child = ts_node_child(entry.node, i);
-				stack.push_back({child, current_id, entry.depth + 1, i, false, 0});
+			// max_depth check: when depth-limited, don't push children
+			bool depth_limited = (config.max_depth >= 0 && entry.depth >= static_cast<uint32_t>(config.max_depth));
+			if (depth_limited) {
+				result.nodes.back().children_count = 0;
+			} else {
+				int64_t current_id = ast_node.node_id;
+				for (int32_t i = child_count - 1; i >= 0; i--) {
+					TSNode child = ts_node_child(entry.node, i);
+					stack.push_back({child, current_id, entry.depth + 1, i, false, 0});
+				}
 			}
 		} else {
 			// Second visit - get the processed entry for descendant calculation
@@ -385,6 +460,14 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 			if (config.structure >= StructureLevel::FULL) {
 				int32_t descendant_count = result.nodes.size() - entry.node_index - 1;
 				result.nodes[entry.node_index].descendant_count = descendant_count;
+
+				// When pruning, children_count must reflect actual emitted children
+				// (some may have been pruned, others re-parented from pruned nodes).
+				if (config.has_prune) {
+					auto it = sibling_counters.find(static_cast<int64_t>(entry.node_index));
+					result.nodes[entry.node_index].children_count =
+					    (it != sibling_counters.end()) ? it->second : 0;
+				}
 			}
 
 			// Update legacy fields after descendant count change

--- a/src/include/unified_ast_backend_impl.hpp
+++ b/src/include/unified_ast_backend_impl.hpp
@@ -74,7 +74,7 @@ static int ShouldPruneNode(const ASTNode &node, uint32_t ts_child_count,
 	for (auto &f : config.prune_type_filters) {
 		if ((node.semantic_type & f.mask) == f.value) {
 			uint8_t kind = node.semantic_type & 0xF0;
-			if (kind == SemanticTypes::LITERAL || kind == SemanticTypes::EXTERNAL) {
+			if (kind == SemanticTypes::LITERAL || kind == SemanticTypes::EXTERNAL || kind == SemanticTypes::TYPE) {
 				return 2; // subtree prune
 			}
 			return 1;

--- a/src/language_adapters/csharp_adapter.cpp
+++ b/src/language_adapters/csharp_adapter.cpp
@@ -60,6 +60,16 @@ string CSharpAdapter::ExtractNodeName(TSNode node, const string &content) const 
 	const NodeConfig *config = GetNodeConfig(node_type_str);
 
 	if (config) {
+		// method_declaration: use grammar field API to get the 'name' field directly.
+		// FindChildByType / FIND_IDENTIFIER returns the first identifier child, which is the
+		// return type for non-primitive return types (e.g. Task, Task<string>).
+		if (strcmp(node_type_str, "method_declaration") == 0) {
+			TSNode name_node = ts_node_child_by_field_name(node, "name", 4);
+			if (!ts_node_is_null(name_node)) {
+				return ExtractNodeText(name_node, content);
+			}
+		}
+
 		if (config->name_strategy == ExtractionStrategy::CUSTOM) {
 			// C#-specific custom extraction
 			string node_type = string(node_type_str);

--- a/src/read_ast_streaming_function.cpp
+++ b/src/read_ast_streaming_function.cpp
@@ -111,6 +111,23 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindTwoArg(ClientContext &co
 	ExtractionConfig extraction_config =
 	    ParseExtractionConfig(context_str, source_str, structure_str, peek_mode, peek_size);
 
+	// Parse max_depth parameter (#014)
+	if (seen_parameters.find("max_depth") != seen_parameters.end()) {
+		extraction_config.max_depth = input.named_parameters.at("max_depth").GetValue<int32_t>();
+	}
+
+	// Parse prune parameter (#014)
+	if (seen_parameters.find("prune") != seen_parameters.end()) {
+		auto &prune_value = input.named_parameters.at("prune");
+		auto &policy_list = ListValue::GetChildren(prune_value);
+		for (auto &policy : policy_list) {
+			if (policy.IsNull()) {
+				throw BinderException("Prune policy list cannot contain NULL values");
+			}
+			CompilePrunePolicy(StringUtil::Lower(policy.ToString()), extraction_config);
+		}
+	}
+
 	// Use flat dynamic schema based on extraction config
 	return_types = UnifiedASTBackend::GetFlatDynamicTableSchema(extraction_config);
 	names = UnifiedASTBackend::GetFlatDynamicTableColumnNames(extraction_config);
@@ -217,6 +234,23 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindOneArg(ClientContext &co
 	// Create ExtractionConfig from parsed parameters
 	ExtractionConfig extraction_config =
 	    ParseExtractionConfig(context_str, source_str, structure_str, peek_mode, peek_size);
+
+	// Parse max_depth parameter (#014)
+	if (seen_parameters.find("max_depth") != seen_parameters.end()) {
+		extraction_config.max_depth = input.named_parameters.at("max_depth").GetValue<int32_t>();
+	}
+
+	// Parse prune parameter (#014)
+	if (seen_parameters.find("prune") != seen_parameters.end()) {
+		auto &prune_value = input.named_parameters.at("prune");
+		auto &policy_list = ListValue::GetChildren(prune_value);
+		for (auto &policy : policy_list) {
+			if (policy.IsNull()) {
+				throw BinderException("Prune policy list cannot contain NULL values");
+			}
+			CompilePrunePolicy(StringUtil::Lower(policy.ToString()), extraction_config);
+		}
+	}
 
 	// Use flat dynamic schema based on extraction config
 	return_types = UnifiedASTBackend::GetFlatDynamicTableSchema(extraction_config);
@@ -609,6 +643,8 @@ static TableFunction GetReadASTFlatFunctionTwoArg() {
 	read_ast.named_parameters["structure"] = LogicalType::VARCHAR;
 	read_ast.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
 	read_ast.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	// Legacy parameters for backward compatibility
 	read_ast.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -629,6 +665,8 @@ static TableFunction GetReadASTFlatFunctionOneArg() {
 	read_ast.named_parameters["structure"] = LogicalType::VARCHAR;
 	read_ast.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
 	read_ast.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	// Legacy parameters for backward compatibility
 	read_ast.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -648,6 +686,8 @@ static TableFunction GetReadASTStreamingFunctionTwoArg() {
 	read_ast_streaming.named_parameters["peek_size"] = LogicalType::INTEGER;
 	read_ast_streaming.named_parameters["peek_mode"] = LogicalType::VARCHAR;
 	read_ast_streaming.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast_streaming.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast_streaming.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 	return read_ast_streaming;
 }
 
@@ -661,6 +701,8 @@ static TableFunction GetReadASTStreamingFunctionOneArg() {
 	read_ast_streaming.named_parameters["peek_size"] = LogicalType::INTEGER;
 	read_ast_streaming.named_parameters["peek_mode"] = LogicalType::VARCHAR;
 	read_ast_streaming.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast_streaming.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast_streaming.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 	return read_ast_streaming;
 }
 
@@ -761,6 +803,23 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindTwoArg(ClientCon
 	// Create ExtractionConfig from parsed parameters
 	ExtractionConfig extraction_config =
 	    ParseExtractionConfig(context_str, source_str, structure_str, peek_mode, peek_size);
+
+	// Parse max_depth parameter (#014)
+	if (seen_parameters.find("max_depth") != seen_parameters.end()) {
+		extraction_config.max_depth = input.named_parameters.at("max_depth").GetValue<int32_t>();
+	}
+
+	// Parse prune parameter (#014)
+	if (seen_parameters.find("prune") != seen_parameters.end()) {
+		auto &prune_value = input.named_parameters.at("prune");
+		auto &policy_list = ListValue::GetChildren(prune_value);
+		for (auto &policy : policy_list) {
+			if (policy.IsNull()) {
+				throw BinderException("Prune policy list cannot contain NULL values");
+			}
+			CompilePrunePolicy(StringUtil::Lower(policy.ToString()), extraction_config);
+		}
+	}
 
 	// Use hierarchical backend schema
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
@@ -870,6 +929,23 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindOneArg(ClientCon
 	ExtractionConfig extraction_config =
 	    ParseExtractionConfig(context_str, source_str, structure_str, peek_mode, peek_size);
 
+	// Parse max_depth parameter (#014)
+	if (seen_parameters.find("max_depth") != seen_parameters.end()) {
+		extraction_config.max_depth = input.named_parameters.at("max_depth").GetValue<int32_t>();
+	}
+
+	// Parse prune parameter (#014)
+	if (seen_parameters.find("prune") != seen_parameters.end()) {
+		auto &prune_value = input.named_parameters.at("prune");
+		auto &policy_list = ListValue::GetChildren(prune_value);
+		for (auto &policy : policy_list) {
+			if (policy.IsNull()) {
+				throw BinderException("Prune policy list cannot contain NULL values");
+			}
+			CompilePrunePolicy(StringUtil::Lower(policy.ToString()), extraction_config);
+		}
+	}
+
 	// Use hierarchical backend schema
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
 	names = UnifiedASTBackend::GetHierarchicalTableColumnNames();
@@ -892,6 +968,8 @@ static TableFunction GetReadASTFunctionTwoArg() {
 	read_ast_hierarchical_new.named_parameters["structure"] = LogicalType::VARCHAR;
 	read_ast_hierarchical_new.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
 	read_ast_hierarchical_new.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast_hierarchical_new.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast_hierarchical_new.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	// Legacy parameters for backward compatibility
 	read_ast_hierarchical_new.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -913,6 +991,8 @@ static TableFunction GetReadASTHierarchicalFunctionTwoArg() {
 	read_ast_hierarchical.named_parameters["structure"] = LogicalType::VARCHAR;
 	read_ast_hierarchical.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
 	read_ast_hierarchical.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast_hierarchical.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast_hierarchical.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	// Legacy parameters for backward compatibility
 	read_ast_hierarchical.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -933,6 +1013,8 @@ static TableFunction GetReadASTFunctionOneArg() {
 	read_ast_hierarchical_new.named_parameters["structure"] = LogicalType::VARCHAR;
 	read_ast_hierarchical_new.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
 	read_ast_hierarchical_new.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast_hierarchical_new.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast_hierarchical_new.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	// Legacy parameters for backward compatibility
 	read_ast_hierarchical_new.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -952,6 +1034,8 @@ static TableFunction GetReadASTHierarchicalFunctionOneArg() {
 	read_ast_hierarchical.named_parameters["structure"] = LogicalType::VARCHAR;
 	read_ast_hierarchical.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
 	read_ast_hierarchical.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast_hierarchical.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast_hierarchical.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	// Legacy parameters for backward compatibility
 	read_ast_hierarchical.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -972,6 +1056,8 @@ static TableFunction GetReadASTFlatAliasFunctionOneArg() {
 	read_ast_flat.named_parameters["structure"] = LogicalType::VARCHAR;
 	read_ast_flat.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
 	read_ast_flat.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast_flat.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast_flat.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	// Legacy parameters for backward compatibility
 	read_ast_flat.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -991,6 +1077,8 @@ static TableFunction GetReadASTFlatAliasFunctionTwoArg() {
 	read_ast_flat.named_parameters["structure"] = LogicalType::VARCHAR;
 	read_ast_flat.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
 	read_ast_flat.named_parameters["batch_size"] = LogicalType::INTEGER;
+	read_ast_flat.named_parameters["max_depth"] = LogicalType::INTEGER;
+	read_ast_flat.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
 
 	// Legacy parameters for backward compatibility
 	read_ast_flat.named_parameters["peek_size"] = LogicalType::INTEGER;

--- a/src/sql_macros/scope_resolution.sql
+++ b/src/sql_macros/scope_resolution.sql
@@ -297,6 +297,9 @@ CREATE OR REPLACE MACRO ast_resolve(
 -- For each function definition, finds all call expressions within its scope.
 -- Returns (caller_name, caller_line, callee_name, callee_line) pairs.
 --
+-- See also: ast_get_calls/ast_call_graph in tree_navigation.sql for richer
+-- call extraction with call-type classification (function/method/constructor/macro).
+--
 -- Usage:
 --   SELECT * FROM ast_callees('src/**/*.py');
 --   SELECT caller, callee FROM ast_callees('src/*.py') WHERE caller = 'main';

--- a/src/sql_macros/scope_resolution.sql
+++ b/src/sql_macros/scope_resolution.sql
@@ -366,3 +366,162 @@ CREATE OR REPLACE MACRO ast_callers(
     WHERE c.semantic_type = 'COMPUTATION_CALL'
       AND c.name IS NOT NULL AND c.name != ''
     ORDER BY c.file_path, c.start_line;
+
+
+-- =============================================================================
+-- ast_find_references: Find all uses of a symbol via scope-chain resolution
+-- =============================================================================
+--
+-- Given a target name, finds every reference and call site that resolves to
+-- a definition of that name through the scope chain. Handles shadowed names
+-- correctly: if two scopes define the same name, only references that resolve
+-- to the specific definition are returned.
+--
+-- Usage:
+--   SELECT * FROM ast_find_references('src/**/*.py', 'process');
+--   SELECT * FROM ast_find_references('src/main.py', 'x') WHERE ref_kind = 'call';
+--   SELECT * FROM ast_find_references('src/*.py', 'Service', language := 'python');
+
+CREATE OR REPLACE MACRO ast_find_references(
+    source,
+    target_name,
+    language := NULL
+) AS TABLE
+    WITH
+        ast AS (
+            SELECT * FROM read_ast(source, language)
+        ),
+        -- Target definitions: all definitions matching the name
+        target_defs AS (
+            SELECT
+                a.node_id AS def_node_id,
+                a.name,
+                a.type AS def_type,
+                a.file_path,
+                a.start_line AS def_line,
+                a.peek AS def_peek,
+                a.scope.current AS def_scope
+            FROM ast a
+            WHERE is_name_definition(a.flags)
+              AND a.name = target_name
+        ),
+        -- All identifier references to the target name with scope chain.
+        -- Excludes name-binding identifiers inside definition/declaration
+        -- nodes (e.g., the 'process' identifier inside 'def process():').
+        refs AS (
+            SELECT
+                a.node_id AS ref_node_id,
+                a.name AS ref_name,
+                a.type AS ref_type,
+                a.start_line AS ref_line,
+                a.file_path,
+                a.parent_id,
+                a.scope.current AS scope_current,
+                s.scope.stack AS scope_stack
+            FROM ast a
+            JOIN ast s ON s.node_id = a.scope.current AND s.file_path = a.file_path
+            LEFT JOIN ast p ON p.node_id = a.parent_id AND p.file_path = a.file_path
+            WHERE is_name_reference(a.flags)
+              AND a.name = target_name
+              AND s.scope.stack IS NOT NULL
+              AND NOT COALESCE(binds_name(p.flags), false)
+        ),
+        -- Unnest scope chain for each reference
+        search_scopes AS (
+            SELECT
+                r.ref_node_id, r.ref_name, r.ref_type, r.ref_line,
+                r.file_path, r.parent_id,
+                unnest(r.scope_stack).id AS search_scope_id,
+                generate_series(1, len(r.scope_stack)) AS scope_distance
+            FROM refs r
+        ),
+        -- Find which target definition each reference resolves to
+        candidates AS (
+            SELECT
+                ss.ref_node_id,
+                ss.ref_line,
+                ss.ref_type,
+                ss.file_path,
+                ss.parent_id,
+                ss.scope_distance,
+                td.def_node_id,
+                td.def_line
+            FROM search_scopes ss
+            JOIN ast d ON d.scope.current = ss.search_scope_id
+              AND d.file_path = ss.file_path
+              AND d.name = ss.ref_name
+              AND is_name_definition(d.flags)
+            JOIN target_defs td ON td.def_node_id = d.node_id
+              AND td.file_path = d.file_path
+        ),
+        -- Pick closest definition per reference (innermost scope)
+        resolved_refs AS (
+            SELECT DISTINCT ON (ref_node_id)
+                ref_node_id, ref_line, ref_type, file_path, parent_id,
+                def_node_id, def_line
+            FROM candidates
+            ORDER BY ref_node_id, scope_distance DESC
+        ),
+        -- Classify: if the ref's parent is a call node, this is a call site.
+        -- For calls, promote to the call node (type, line, peek).
+        -- For references, use the parent's peek for surrounding context.
+        classified_refs AS (
+            SELECT
+                rr.file_path,
+                target_name AS name,
+                CASE
+                    WHEN is_function_call(p.semantic_type) THEN 'call'
+                    ELSE 'reference'
+                END AS ref_kind,
+                COALESCE(
+                    CASE WHEN is_function_call(p.semantic_type) THEN p.type END,
+                    rr.ref_type
+                ) AS node_type,
+                COALESCE(
+                    CASE WHEN is_function_call(p.semantic_type) THEN p.start_line END,
+                    rr.ref_line
+                ) AS start_line,
+                COALESCE(p.peek, ref_node.peek) AS peek,
+                COALESCE(f.name, '<module>') AS scope_name,
+                rr.def_node_id,
+                rr.ref_node_id
+            FROM resolved_refs rr
+            LEFT JOIN ast p ON p.node_id = rr.parent_id AND p.file_path = rr.file_path
+            LEFT JOIN ast ref_node ON ref_node.node_id = rr.ref_node_id AND ref_node.file_path = rr.file_path
+            LEFT JOIN ast f ON f.node_id = ref_node.scope.function AND f.file_path = rr.file_path
+        ),
+        -- Definition sites
+        def_sites AS (
+            SELECT
+                td.file_path,
+                target_name AS name,
+                'definition' AS ref_kind,
+                td.def_type AS node_type,
+                td.def_line AS start_line,
+                td.def_peek AS peek,
+                COALESCE(f.name, '<module>') AS scope_name,
+                td.def_node_id
+            FROM target_defs td
+            LEFT JOIN ast d ON d.node_id = td.def_node_id AND d.file_path = td.file_path
+            LEFT JOIN ast f ON f.node_id = d.scope.function AND f.file_path = td.file_path
+        ),
+        combined AS (
+            SELECT file_path, name, ref_kind, node_type, start_line,
+                   peek, scope_name, def_node_id
+            FROM def_sites
+            UNION
+            SELECT file_path, name, ref_kind, node_type, start_line,
+                   peek, scope_name, def_node_id
+            FROM classified_refs
+        )
+    SELECT
+        file_path,
+        name,
+        ref_kind,
+        node_type,
+        start_line,
+        peek,
+        scope_name,
+        def_node_id
+    FROM combined
+    ORDER BY file_path, start_line, ref_kind;

--- a/src/sql_macros/tree_navigation.sql
+++ b/src/sql_macros/tree_navigation.sql
@@ -786,6 +786,15 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
             WHERE is_function_call(a.semantic_type)
               AND a.name IS NOT NULL AND a.name != ''
         ),
+        call_targets AS (
+            SELECT
+                c.node_id AS call_id,
+                child.type AS target_type
+            FROM calls c
+            JOIN ast child
+              ON child.parent_id = c.node_id
+             AND child.sibling_index = 0
+        ),
         calls_with_caller AS (
             SELECT
                 c.node_id,
@@ -795,9 +804,11 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
                 c.file_path,
                 c.language,
                 c.start_line,
+                ct.target_type,
                 f.func_id AS caller_node_id,
                 f.func_name AS caller_name
             FROM calls c
+            LEFT JOIN call_targets ct ON ct.call_id = c.node_id
             LEFT JOIN functions f
               ON f.file_path = c.file_path
              AND f.func_id < c.node_id
@@ -819,7 +830,9 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
                 THEN 'constructor'
             WHEN cwc.call_node_type IN ('macro_invocation')
                 THEN 'macro'
-            WHEN cwc.peek LIKE '%.' || cwc.called_name || '(%'
+            WHEN cwc.target_type IN ('attribute', 'member_expression',
+                                      'field_expression', 'selector_expression',
+                                      'navigation_expression', 'field_access')
                 THEN 'method'
             ELSE 'function'
         END AS call_type,

--- a/src/sql_macros/tree_navigation.sql
+++ b/src/sql_macros/tree_navigation.sql
@@ -747,3 +747,105 @@ CREATE OR REPLACE MACRO ast_dead_code(source, language := NULL) AS TABLE
     FROM dead_code dc
     ORDER BY dc.file_path, dc.start_line;
 
+-- =============================================================================
+-- Call Extraction
+-- =============================================================================
+
+-- Extract all function/method calls from source code
+-- Returns one row per call site with the containing function (caller) identified.
+-- Uses scope-aware attribution: nested function calls belong to the inner function.
+-- Usage: SELECT * FROM ast_get_calls('src/**/*.py')
+-- Usage: SELECT * FROM ast_get_calls('src/main.py') WHERE call_type = 'method'
+CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
+    WITH
+        ast AS (
+            SELECT * FROM read_ast(source, language)
+        ),
+        functions AS (
+            SELECT
+                a.node_id AS func_id,
+                a.name AS func_name,
+                a.file_path,
+                a.language AS func_lang,
+                a.descendant_count
+            FROM ast a
+            WHERE is_function_definition(a.semantic_type)
+              AND is_construct(a.flags)
+              AND a.name IS NOT NULL AND a.name != ''
+        ),
+        calls AS (
+            SELECT
+                a.node_id,
+                a.name,
+                a.type,
+                a.peek,
+                a.file_path,
+                a.language,
+                a.start_line
+            FROM ast a
+            WHERE is_function_call(a.semantic_type)
+              AND a.name IS NOT NULL AND a.name != ''
+        ),
+        calls_with_caller AS (
+            SELECT
+                c.node_id,
+                c.name AS called_name,
+                c.type AS call_node_type,
+                c.peek,
+                c.file_path,
+                c.language,
+                c.start_line,
+                f.func_id AS caller_node_id,
+                f.func_name AS caller_name
+            FROM calls c
+            LEFT JOIN functions f
+              ON f.file_path = c.file_path
+             AND f.func_id < c.node_id
+             AND c.node_id <= f.func_id + f.descendant_count
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY c.node_id
+                ORDER BY f.func_id DESC NULLS LAST
+            ) = 1
+        )
+    SELECT
+        cwc.file_path,
+        COALESCE(cwc.caller_name, '<module>') AS caller_name,
+        cwc.called_name,
+        cwc.peek AS call_expression,
+        CASE
+            WHEN cwc.call_node_type IN ('new_expression', 'object_creation_expression',
+                                         'constructor_invocation', 'init_expression',
+                                         'composite_literal', 'struct_expression')
+                THEN 'constructor'
+            WHEN cwc.call_node_type IN ('macro_invocation')
+                THEN 'macro'
+            WHEN cwc.peek LIKE '%.' || cwc.called_name || '(%'
+                THEN 'method'
+            ELSE 'function'
+        END AS call_type,
+        cwc.language,
+        cwc.start_line,
+        cwc.node_id,
+        cwc.caller_node_id
+    FROM calls_with_caller cwc
+    ORDER BY cwc.file_path, cwc.start_line;
+
+-- Build a call graph from source code
+-- Returns aggregated caller→callee pairs with call counts.
+-- Usage: SELECT * FROM ast_call_graph('src/**/*.py') ORDER BY call_count DESC
+-- Usage: SELECT * FROM ast_call_graph('src/**/*.py') WHERE caller = 'main'
+CREATE OR REPLACE MACRO ast_call_graph(source, language := NULL) AS TABLE
+    WITH
+        raw_calls AS (
+            SELECT * FROM ast_get_calls(source, language)
+        )
+    SELECT
+        rc.file_path,
+        rc.caller_name AS caller,
+        rc.called_name AS callee,
+        rc.call_type,
+        COUNT(*) AS call_count
+    FROM raw_calls rc
+    GROUP BY rc.file_path, rc.caller_name, rc.called_name, rc.call_type
+    ORDER BY rc.file_path, rc.caller_name, rc.called_name;
+

--- a/src/sql_macros/tree_navigation.sql
+++ b/src/sql_macros/tree_navigation.sql
@@ -756,22 +756,12 @@ CREATE OR REPLACE MACRO ast_dead_code(source, language := NULL) AS TABLE
 -- Uses scope-aware attribution: nested function calls belong to the inner function.
 -- Usage: SELECT * FROM ast_get_calls('src/**/*.py')
 -- Usage: SELECT * FROM ast_get_calls('src/main.py') WHERE call_type = 'method'
+-- See also: ast_callees/ast_callers in scope_resolution.sql for simpler
+-- caller/callee pairs without call-type classification.
 CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
     WITH
         ast AS (
             SELECT * FROM read_ast(source, language)
-        ),
-        functions AS (
-            SELECT
-                a.node_id AS func_id,
-                a.name AS func_name,
-                a.file_path,
-                a.language AS func_lang,
-                a.descendant_count
-            FROM ast a
-            WHERE is_function_definition(a.semantic_type)
-              AND is_construct(a.flags)
-              AND a.name IS NOT NULL AND a.name != ''
         ),
         calls AS (
             SELECT
@@ -781,7 +771,8 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
                 a.peek,
                 a.file_path,
                 a.language,
-                a.start_line
+                a.start_line,
+                a.scope.function AS scope_function
             FROM ast a
             WHERE is_function_call(a.semantic_type)
               AND a.name IS NOT NULL AND a.name != ''
@@ -805,18 +796,13 @@ CREATE OR REPLACE MACRO ast_get_calls(source, language := NULL) AS TABLE
                 c.language,
                 c.start_line,
                 ct.target_type,
-                f.func_id AS caller_node_id,
-                f.func_name AS caller_name
+                f.node_id AS caller_node_id,
+                f.name AS caller_name
             FROM calls c
             LEFT JOIN call_targets ct ON ct.call_id = c.node_id
-            LEFT JOIN functions f
-              ON f.file_path = c.file_path
-             AND f.func_id < c.node_id
-             AND c.node_id <= f.func_id + f.descendant_count
-            QUALIFY ROW_NUMBER() OVER (
-                PARTITION BY c.node_id
-                ORDER BY f.func_id DESC NULLS LAST
-            ) = 1
+            LEFT JOIN ast f
+              ON f.node_id = c.scope_function
+             AND f.file_path = c.file_path
         )
     SELECT
         cwc.file_path,

--- a/src/unified_ast_backend.cpp
+++ b/src/unified_ast_backend.cpp
@@ -1997,4 +1997,31 @@ void UnifiedASTBackend::ResetStructVectorState(Vector &vector) {
 	}
 }
 
+void CompilePrunePolicy(const string &policy_name, ExtractionConfig &config) {
+	config.has_prune = true;
+	if (policy_name == "syntax") {
+		config.prune_flag_mask |= ASTNodeFlags::IS_SYNTAX_ONLY;
+	} else if (policy_name == "comments") {
+		config.prune_type_filters.push_back({0xFC, SemanticTypes::METADATA_COMMENT});
+	} else if (policy_name == "literals") {
+		config.prune_type_filters.push_back({0xF0, SemanticTypes::LITERAL});
+	} else if (policy_name == "imports") {
+		config.prune_type_filters.push_back({0xF0, SemanticTypes::EXTERNAL});
+	} else if (policy_name == "types") {
+		config.prune_type_filters.push_back({0xF0, SemanticTypes::TYPE});
+	} else if (policy_name == "punctuation") {
+		config.prune_type_filters.push_back({0xFC, SemanticTypes::PARSER_PUNCTUATION});
+	} else if (policy_name == "unnamed") {
+		config.prune_unnamed = true;
+	} else if (policy_name == "leaves") {
+		config.prune_leaves = true;
+	} else if (policy_name == "internal") {
+		config.prune_internal = true;
+	} else {
+		throw BinderException("Unknown prune policy: '" + policy_name +
+		    "'. Valid policies: syntax, comments, literals, imports, types, "
+		    "punctuation, unnamed, leaves, internal");
+	}
+}
+
 } // namespace duckdb

--- a/src/unified_ast_backend.cpp
+++ b/src/unified_ast_backend.cpp
@@ -2002,15 +2002,15 @@ void CompilePrunePolicy(const string &policy_name, ExtractionConfig &config) {
 	if (policy_name == "syntax") {
 		config.prune_flag_mask |= ASTNodeFlags::IS_SYNTAX_ONLY;
 	} else if (policy_name == "comments") {
-		config.prune_type_filters.push_back({0xFC, SemanticTypes::METADATA_COMMENT});
+		config.prune_type_filters.push_back({0xFC, SemanticTypes::METADATA_COMMENT, false});
 	} else if (policy_name == "literals") {
-		config.prune_type_filters.push_back({0xF0, SemanticTypes::LITERAL});
+		config.prune_type_filters.push_back({0xF0, SemanticTypes::LITERAL, true});
 	} else if (policy_name == "imports") {
-		config.prune_type_filters.push_back({0xF0, SemanticTypes::EXTERNAL});
+		config.prune_type_filters.push_back({0xF0, SemanticTypes::EXTERNAL, true});
 	} else if (policy_name == "types") {
-		config.prune_type_filters.push_back({0xF0, SemanticTypes::TYPE});
+		config.prune_type_filters.push_back({0xF0, SemanticTypes::TYPE, true});
 	} else if (policy_name == "punctuation") {
-		config.prune_type_filters.push_back({0xFC, SemanticTypes::PARSER_PUNCTUATION});
+		config.prune_type_filters.push_back({0xFC, SemanticTypes::PARSER_PUNCTUATION, false});
 	} else if (policy_name == "unnamed") {
 		config.prune_unnamed = true;
 	} else if (policy_name == "leaves") {

--- a/test/data/call_extraction/calls.go
+++ b/test/data/call_extraction/calls.go
@@ -1,0 +1,49 @@
+package main
+
+import "fmt"
+
+func helper() int {
+	return 42
+}
+
+func process(data string) string {
+	result := transform(data)
+	validated := validate(result)
+	fmt.Println("processing")
+	return validated
+}
+
+func transform(data string) string {
+	return data
+}
+
+func validate(data string) bool {
+	return len(data) > 0
+}
+
+type Service struct {
+	db string
+}
+
+func NewService(db string) *Service {
+	return &Service{db: db}
+}
+
+func (s *Service) Fetch(query string) []string {
+	return s.db.Execute(query)
+}
+
+func (s *Service) ProcessAll() []string {
+	data := s.Fetch("SELECT 1")
+	return transform(data[0])
+}
+
+func outer() {
+	helper()
+	process("test")
+}
+
+func main() {
+	svc := NewService("db")
+	fmt.Println(svc)
+}

--- a/test/data/call_extraction/calls.js
+++ b/test/data/call_extraction/calls.js
@@ -1,0 +1,40 @@
+function helper() {
+    return 42;
+}
+
+function process(data) {
+    const result = transform(data);
+    console.log("processing");
+    return result;
+}
+
+function transform(data) {
+    return JSON.parse(data);
+}
+
+class Service {
+    constructor(db) {
+        this.db = db;
+    }
+
+    fetch(query) {
+        const result = this.db.execute(query);
+        return result.fetchAll();
+    }
+
+    processAll() {
+        const data = this.fetch("SELECT 1");
+        return transform(data);
+    }
+}
+
+function outer() {
+    function inner() {
+        helper();
+    }
+    inner();
+    process("test");
+}
+
+const svc = new Service("db");
+console.log("module level");

--- a/test/data/call_extraction/calls.py
+++ b/test/data/call_extraction/calls.py
@@ -1,0 +1,37 @@
+import os
+import json
+
+def helper():
+    return 42
+
+def process(data):
+    result = transform(data)
+    validated = validate(result)
+    os.path.exists("/tmp")
+    return validated
+
+def transform(data):
+    return json.loads(data)
+
+def validate(data):
+    return len(data) > 0
+
+class Service:
+    def __init__(self, db):
+        self.db = db
+
+    def fetch(self, query):
+        result = self.db.execute(query)
+        return result.fetchall()
+
+    def process_all(self):
+        data = self.fetch("SELECT 1")
+        return transform(data)
+
+def outer():
+    def inner():
+        helper()
+    inner()
+    process("test")
+
+print("module level")

--- a/test/data/call_extraction/calls.rs
+++ b/test/data/call_extraction/calls.rs
@@ -1,0 +1,50 @@
+fn helper() -> i32 {
+    42
+}
+
+fn process(data: &str) -> String {
+    let result = transform(data);
+    let validated = validate(&result);
+    println!("processing");
+    validated
+}
+
+fn transform(data: &str) -> String {
+    data.to_string()
+}
+
+fn validate(data: &str) -> String {
+    data.trim().to_string()
+}
+
+struct Service {
+    db: String,
+}
+
+impl Service {
+    fn new(db: &str) -> Self {
+        Service { db: db.to_string() }
+    }
+
+    fn fetch(&self, query: &str) -> Vec<String> {
+        self.db.execute(query)
+    }
+
+    fn process_all(&self) -> Vec<String> {
+        let data = self.fetch("SELECT 1");
+        transform(&data[0])
+    }
+}
+
+fn outer() {
+    fn inner() {
+        helper();
+    }
+    inner();
+    process("test");
+}
+
+fn main() {
+    let svc = Service::new("db");
+    println!("done");
+}

--- a/test/data/find_references/refs.go
+++ b/test/data/find_references/refs.go
@@ -1,0 +1,40 @@
+package main
+
+import "fmt"
+
+func helper() int {
+	return 42
+}
+
+func process(data string) string {
+	result := transform(data)
+	helper()
+	return result
+}
+
+func transform(data string) string {
+	return data
+}
+
+type Service struct {
+	db string
+}
+
+func NewService(db string) *Service {
+	return &Service{db: db}
+}
+
+func (s *Service) Fetch(query string) string {
+	return s.db
+}
+
+func (s *Service) Run() string {
+	data := s.Fetch("SELECT 1")
+	return process(data)
+}
+
+func main() {
+	svc := NewService("db")
+	result := svc.Run()
+	fmt.Println(result)
+}

--- a/test/data/find_references/refs.js
+++ b/test/data/find_references/refs.js
@@ -1,0 +1,30 @@
+const config = { timeout: 30 };
+
+function helper(x) {
+    return x * 2;
+}
+
+function process(data) {
+    const x = helper(data);
+    console.log(x);
+    return x;
+}
+
+class Service {
+    constructor(db) {
+        this.db = db;
+    }
+
+    fetch(query) {
+        return this.db.execute(query);
+    }
+
+    run() {
+        const data = this.fetch("SELECT 1");
+        return process(data);
+    }
+}
+
+const svc = new Service("postgres");
+const result = svc.run();
+console.log(result);

--- a/test/data/find_references/refs.py
+++ b/test/data/find_references/refs.py
@@ -1,0 +1,26 @@
+x = 10
+
+def process(x):
+    y = x + 1
+    return y
+
+def transform(data):
+    x = data * 2
+    result = process(x)
+    return result
+
+class Service:
+    def __init__(self, db):
+        self.db = db
+
+    def fetch(self, query):
+        return self.db.execute(query)
+
+    def run(self):
+        data = self.fetch("SELECT 1")
+        return process(data)
+
+def main():
+    svc = Service("postgres")
+    result = svc.run()
+    print(result)

--- a/test/data/find_references/refs.rs
+++ b/test/data/find_references/refs.rs
@@ -1,0 +1,38 @@
+fn helper() -> i32 {
+    42
+}
+
+fn process(data: &str) -> String {
+    let result = transform(data);
+    helper();
+    result
+}
+
+fn transform(data: &str) -> String {
+    data.to_string()
+}
+
+struct Service {
+    db: String,
+}
+
+impl Service {
+    fn new(db: &str) -> Self {
+        Service { db: db.to_string() }
+    }
+
+    fn fetch(&self, query: &str) -> String {
+        self.db.clone()
+    }
+
+    fn run(&self) -> String {
+        let data = self.fetch("SELECT 1");
+        process(&data)
+    }
+}
+
+fn main() {
+    let svc = Service::new("db");
+    let result = svc.run();
+    println!("{}", result);
+}

--- a/test/sql/bugs/010_csharp_name_extraction.test
+++ b/test/sql/bugs/010_csharp_name_extraction.test
@@ -1,0 +1,24 @@
+# name: test/sql/bugs/010_csharp_name_extraction.test
+# description: Bug #010 — C# method name extraction picks return type instead of method name
+# group: [bugs]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# Methods with non-primitive return types should extract the method name, not the return type.
+# 'private async Task PrivateAsync()' should have name='PrivateAsync', not name='Task'
+# 'public async Task<string> FetchData(string url)' should have name='FetchData', not name='Task'
+
+query II
+SELECT name, type
+FROM read_ast('test/data/modifier_audit/async_functions.cs')
+WHERE type = 'method_declaration'
+ORDER BY start_line;
+----
+FetchData	method_declaration
+SyncHelper	method_declaration
+StaticHelper	method_declaration
+PrivateAsync	method_declaration
+VirtualMethod	method_declaration

--- a/test/sql/parse_time_filtering.test
+++ b/test/sql/parse_time_filtering.test
@@ -13,3 +13,148 @@ statement error
 SELECT * FROM read_ast('test/data/python/sample_app.py', prune := ['invalid_policy']);
 ----
 Unknown prune policy
+
+# =============================================================================
+# Section 2: max_depth filtering
+# =============================================================================
+
+# max_depth := 0 returns only the root node
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', max_depth := 0);
+----
+1
+
+# Root at max_depth 0 has descendant_count = 0
+query II
+SELECT type, descendant_count
+FROM read_ast('test/data/python/sample_app.py', max_depth := 0);
+----
+module	0
+
+# max_depth := 1 returns root + direct children only
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', max_depth := 1)
+WHERE depth > 1;
+----
+0
+
+# Boundary nodes at max_depth have children_count = 0
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', max_depth := 1)
+WHERE depth = 1 AND children_count > 0;
+----
+0
+
+# Without max_depth, same file has nodes at depth > 1
+query I
+SELECT COUNT(*) > 0 FROM read_ast('test/data/python/sample_app.py')
+WHERE depth > 1;
+----
+true
+
+# max_depth := -1 (default) has no effect
+query I
+SELECT COUNT(*) > 0 FROM read_ast('test/data/python/sample_app.py', max_depth := -1)
+WHERE depth > 5;
+----
+true
+
+# =============================================================================
+# Section 3: prune -- syntax policy
+# =============================================================================
+
+# No syntax-only nodes in output
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['syntax'])
+WHERE is_syntax_only(flags);
+----
+0
+
+# Fewer total nodes with syntax pruned
+query I
+SELECT
+    (SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py')) >
+    (SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['syntax']));
+----
+true
+
+# =============================================================================
+# Section 4: prune -- comments policy
+# =============================================================================
+
+# No comment nodes in output (METADATA_COMMENT = 0x20, super_type mask = 0xFC)
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['comments'])
+WHERE (semantic_type & 252) = 32;
+----
+0
+
+# =============================================================================
+# Section 5: prune -- composition
+# =============================================================================
+
+# Multiple policies compose
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['syntax', 'comments'])
+WHERE is_syntax_only(flags) OR (semantic_type & 252) = 32;
+----
+0
+
+# =============================================================================
+# Section 6: Tree consistency after pruning
+# =============================================================================
+
+# Every parent_id references an emitted node
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['syntax']) a
+WHERE a.parent_id >= 0
+  AND a.parent_id NOT IN (
+    SELECT node_id FROM read_ast('test/data/python/sample_app.py', prune := ['syntax'])
+  );
+----
+0
+
+# Sibling indices contiguous per parent
+query I
+SELECT COUNT(*) FROM (
+    SELECT parent_id, MAX(sibling_index) + 1 AS max_sib, COUNT(*) AS child_count
+    FROM read_ast('test/data/python/sample_app.py', prune := ['syntax'])
+    WHERE parent_id >= 0
+    GROUP BY parent_id
+    HAVING max_sib != child_count
+);
+----
+0
+
+# descendant_count matches actual descendants
+query I
+SELECT COUNT(*) FROM (
+    WITH ast AS (SELECT * FROM read_ast('test/data/python/sample_app.py', prune := ['syntax']))
+    SELECT a.node_id, a.descendant_count,
+           (SELECT COUNT(*) FROM ast b WHERE b.node_id > a.node_id AND b.node_id <= a.node_id + a.descendant_count) AS actual
+    FROM ast a
+    WHERE a.descendant_count != actual
+);
+----
+0
+
+# =============================================================================
+# Section 7: Empty prune list = no change
+# =============================================================================
+
+query I
+SELECT
+    (SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py')) =
+    (SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := []));
+----
+true
+
+# =============================================================================
+# Section 8: prune + max_depth combined
+# =============================================================================
+
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['syntax'], max_depth := 2)
+WHERE is_syntax_only(flags) OR depth > 2;
+----
+0

--- a/test/sql/parse_time_filtering.test
+++ b/test/sql/parse_time_filtering.test
@@ -1,0 +1,15 @@
+# name: test/sql/parse_time_filtering.test
+# description: Test parse-time filtering (max_depth and prune parameters)
+# group: [sitting_duck]
+
+require sitting_duck
+
+# =============================================================================
+# Section 1: Parameter validation
+# =============================================================================
+
+# Invalid prune policy name throws error
+statement error
+SELECT * FROM read_ast('test/data/python/sample_app.py', prune := ['invalid_policy']);
+----
+Unknown prune policy

--- a/test/sql/parse_time_filtering.test
+++ b/test/sql/parse_time_filtering.test
@@ -158,3 +158,33 @@ SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['synta
 WHERE is_syntax_only(flags) OR depth > 2;
 ----
 0
+
+# =============================================================================
+# Section 9: Integration — macros work on pruned ASTs
+# =============================================================================
+
+# ast_definitions works on unpruned source (default prune=[])
+query I
+SELECT COUNT(*) > 0
+FROM ast_definitions('test/data/python/sample_app.py');
+----
+true
+
+# ast_get_calls works on unpruned source
+query I
+SELECT COUNT(*) > 0
+FROM ast_get_calls('test/data/python/sample_app.py');
+----
+true
+
+# =============================================================================
+# Section 10: prune reduces node count significantly
+# =============================================================================
+
+# Syntax nodes are typically 30-60% of all nodes
+query I
+SELECT
+    (SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['syntax'])) <
+    (SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py')) * 0.8;
+----
+true

--- a/test/sql/parse_time_filtering.test
+++ b/test/sql/parse_time_filtering.test
@@ -181,6 +181,58 @@ true
 # Section 10: prune reduces node count significantly
 # =============================================================================
 
+# =============================================================================
+# Section 10: Node prune re-parents children to grandparent
+# =============================================================================
+
+# When an unnamed non-leaf node is pruned, its children should appear
+# under the pruned node's parent. Verify by checking that every emitted
+# node's parent_id references another emitted node (no orphans).
+query I
+SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['unnamed']) a
+WHERE a.parent_id >= 0
+  AND a.parent_id NOT IN (
+    SELECT node_id FROM read_ast('test/data/python/sample_app.py', prune := ['unnamed'])
+  );
+----
+0
+
+# Sibling indices remain contiguous after re-parenting
+query I
+SELECT COUNT(*) FROM (
+    SELECT parent_id, MAX(sibling_index) + 1 AS max_sib, COUNT(*) AS child_count
+    FROM read_ast('test/data/python/sample_app.py', prune := ['unnamed'])
+    WHERE parent_id >= 0
+    GROUP BY parent_id
+    HAVING max_sib != child_count
+);
+----
+0
+
+# descendant_count stays consistent after re-parenting
+query I
+SELECT COUNT(*) FROM (
+    WITH ast AS (SELECT * FROM read_ast('test/data/python/sample_app.py', prune := ['unnamed']))
+    SELECT a.node_id, a.descendant_count,
+           (SELECT COUNT(*) FROM ast b WHERE b.node_id > a.node_id AND b.node_id <= a.node_id + a.descendant_count) AS actual
+    FROM ast a
+    WHERE a.descendant_count != actual
+);
+----
+0
+
+# Unnamed prune should actually remove nodes (unnamed nodes exist in this file)
+query I
+SELECT
+    (SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py')) >
+    (SELECT COUNT(*) FROM read_ast('test/data/python/sample_app.py', prune := ['unnamed']));
+----
+true
+
+# =============================================================================
+# Section 11: prune reduces node count significantly
+# =============================================================================
+
 # Syntax nodes are typically 30-60% of all nodes
 query I
 SELECT

--- a/test/sql/scope_resolution/find_references.test
+++ b/test/sql/scope_resolution/find_references.test
@@ -1,0 +1,187 @@
+# name: test/sql/scope_resolution/find_references.test
+# group: [sitting_duck]
+
+# Test ast_find_references() — scope-aware reference finding
+
+require sitting_duck
+
+# =============================================================================
+# Section 1: Python — basic function references
+# =============================================================================
+
+# Definition + call sites for 'process'
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.py', 'process')
+ORDER BY start_line;
+----
+definition	function_definition	3	<module>
+call	call	9	transform
+call	call	21	run
+
+# 'transform' — defined but never called in this file
+query III
+SELECT ref_kind, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.py', 'transform')
+ORDER BY start_line;
+----
+definition	7	<module>
+
+# =============================================================================
+# Section 2: Python — class references
+# =============================================================================
+
+# Class definition + constructor call
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.py', 'Service')
+ORDER BY start_line;
+----
+definition	class_definition	12	<module>
+call	call	24	main
+
+# =============================================================================
+# Section 3: Python — variable references with shadowing
+# =============================================================================
+
+# 'x' has definitions at module level and inside transform
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.py', 'x')
+ORDER BY start_line;
+----
+definition	assignment	1	<module>
+reference	identifier	3	process
+reference	identifier	4	process
+definition	assignment	8	transform
+reference	identifier	9	transform
+
+# 'result' — local variable in two different scopes
+query III
+SELECT ref_kind, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.py', 'result')
+ORDER BY start_line;
+----
+definition	9	transform
+reference	10	transform
+definition	25	main
+reference	26	main
+
+# =============================================================================
+# Section 4: Python — larger file (sample_app.py)
+# =============================================================================
+
+# validate_email: definition + single call in main
+query III
+SELECT ref_kind, start_line, scope_name
+FROM ast_find_references('test/data/python/sample_app.py', 'validate_email')
+ORDER BY start_line;
+----
+definition	122	<module>
+call	156	main
+
+# process_file: definition + single call in main
+query III
+SELECT ref_kind, start_line, scope_name
+FROM ast_find_references('test/data/python/sample_app.py', 'process_file')
+ORDER BY start_line;
+----
+definition	100	<module>
+call	157	main
+
+# Config: class definition + usage in main
+query III
+SELECT ref_kind, start_line, scope_name
+FROM ast_find_references('test/data/python/sample_app.py', 'Config')
+ORDER BY start_line;
+----
+definition	10	<module>
+call	146	main
+
+# =============================================================================
+# Section 5: JavaScript — function and constructor references
+# =============================================================================
+
+# 'process' in JS
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.js', 'process')
+ORDER BY start_line;
+----
+definition	function_declaration	7	<module>
+call	call_expression	24	run
+
+# 'helper' in JS
+query III
+SELECT ref_kind, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.js', 'helper')
+ORDER BY start_line;
+----
+definition	3	<module>
+call	8	process
+
+# 'Service' class in JS
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.js', 'Service')
+ORDER BY start_line;
+----
+definition	class_declaration	13	<module>
+call	new_expression	28	<module>
+
+# =============================================================================
+# Section 6: Filtering patterns — common use cases
+# =============================================================================
+
+# Only call sites (exclude definition)
+query II
+SELECT start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.py', 'process')
+WHERE ref_kind = 'call';
+----
+9	transform
+21	run
+
+# Only definitions
+query II
+SELECT start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.py', 'x')
+WHERE ref_kind = 'definition';
+----
+1	<module>
+8	transform
+
+# Count references per symbol
+query II
+SELECT ref_kind, COUNT(*)
+FROM ast_find_references('test/data/find_references/refs.py', 'x')
+GROUP BY ref_kind
+ORDER BY ref_kind;
+----
+definition	2
+reference	3
+
+# =============================================================================
+# Section 7: No references found
+# =============================================================================
+
+# Nonexistent symbol returns empty
+query I
+SELECT COUNT(*)
+FROM ast_find_references('test/data/find_references/refs.py', 'nonexistent');
+----
+0
+
+# =============================================================================
+# Section 8: def_node_id output — for disambiguating same-name definitions
+# =============================================================================
+
+# Both 'x' definitions have different def_node_ids
+query II
+SELECT DISTINCT def_node_id, start_line
+FROM ast_find_references('test/data/find_references/refs.py', 'x')
+WHERE ref_kind = 'definition'
+ORDER BY start_line;
+----
+2	1
+36	8

--- a/test/sql/scope_resolution/find_references.test
+++ b/test/sql/scope_resolution/find_references.test
@@ -185,3 +185,103 @@ ORDER BY start_line;
 ----
 2	1
 36	8
+
+# =============================================================================
+# Section 9: Rust — function and struct references
+# =============================================================================
+
+# 'helper' — definition + call site
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.rs', 'helper')
+ORDER BY start_line;
+----
+definition	function_item	1	<module>
+call	call_expression	7	process
+
+# 'process' — definition + call from method
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.rs', 'process')
+ORDER BY start_line;
+----
+definition	function_item	5	<module>
+call	call_expression	30	run
+
+# 'transform' — definition + call
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.rs', 'transform')
+ORDER BY start_line;
+----
+call	call_expression	6	process
+definition	function_item	11	<module>
+
+# 'Service' — struct def, impl def, type refs
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.rs', 'Service')
+ORDER BY start_line;
+----
+definition	struct_item	15	<module>
+definition	impl_item	19	<module>
+reference	type_identifier	21	new
+reference	identifier	35	main
+
+# 'fetch' — method definition + method call (field_identifier)
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.rs', 'fetch')
+ORDER BY start_line;
+----
+definition	function_item	24	<module>
+reference	field_identifier	29	run
+
+# =============================================================================
+# Section 10: Go — function and method references
+# =============================================================================
+
+# 'helper' — definition + call
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.go', 'helper')
+ORDER BY start_line;
+----
+definition	function_declaration	5	<module>
+call	call_expression	11	process
+
+# 'process' — definition + call from method
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.go', 'process')
+ORDER BY start_line;
+----
+definition	function_declaration	9	<module>
+call	call_expression	33	Run
+
+# 'transform' — definition + call
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.go', 'transform')
+ORDER BY start_line;
+----
+call	call_expression	10	process
+definition	function_declaration	15	<module>
+
+# 'NewService' — definition + constructor call
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.go', 'NewService')
+ORDER BY start_line;
+----
+definition	function_declaration	23	<module>
+call	call_expression	37	main
+
+# 'Fetch' — method definition + method reference (field_identifier)
+query IIII
+SELECT ref_kind, node_type, start_line, scope_name
+FROM ast_find_references('test/data/find_references/refs.go', 'Fetch')
+ORDER BY start_line;
+----
+definition	method_declaration	27	<module>
+reference	field_identifier	32	Run

--- a/test/sql/tree_navigation/call_extraction.test
+++ b/test/sql/tree_navigation/call_extraction.test
@@ -1,0 +1,236 @@
+# name: test/sql/tree_navigation/call_extraction.test
+# group: [sitting_duck]
+
+# Test ast_get_calls() and ast_call_graph() SQL macros
+
+require sitting_duck
+
+# =============================================================================
+# Section 1: Python — ast_get_calls basic functionality
+# =============================================================================
+
+# All calls with caller attribution and call type
+query IIIII
+SELECT caller_name, called_name, call_type, call_expression, start_line
+FROM ast_get_calls('test/data/call_extraction/calls.py')
+ORDER BY start_line;
+----
+process	transform	function	transform(data)	8
+process	validate	function	validate(result)	9
+process	exists	method	os.path.exists("/tmp")	10
+transform	loads	method	json.loads(data)	14
+validate	len	function	len(data)	17
+fetch	execute	method	self.db.execute(query)	24
+fetch	fetchall	method	result.fetchall()	25
+process_all	fetch	method	self.fetch("SELECT 1")	28
+process_all	transform	function	transform(data)	29
+inner	helper	function	helper()	33
+outer	inner	function	inner()	34
+outer	process	function	process("test")	35
+<module>	print	function	print("module level")	37
+
+# Nested function scope: inner() calls helper, not outer
+query II
+SELECT caller_name, called_name
+FROM ast_get_calls('test/data/call_extraction/calls.py')
+WHERE called_name = 'helper';
+----
+inner	helper
+
+# Module-level calls
+query II
+SELECT caller_name, called_name
+FROM ast_get_calls('test/data/call_extraction/calls.py')
+WHERE caller_name = '<module>';
+----
+<module>	print
+
+# Method calls only
+query III
+SELECT caller_name, called_name, call_expression
+FROM ast_get_calls('test/data/call_extraction/calls.py')
+WHERE call_type = 'method'
+ORDER BY start_line;
+----
+process	exists	os.path.exists("/tmp")
+transform	loads	json.loads(data)
+fetch	execute	self.db.execute(query)
+fetch	fetchall	result.fetchall()
+process_all	fetch	self.fetch("SELECT 1")
+
+# =============================================================================
+# Section 2: JavaScript — constructor detection
+# =============================================================================
+
+query IIIII
+SELECT caller_name, called_name, call_type, call_expression, start_line
+FROM ast_get_calls('test/data/call_extraction/calls.js')
+ORDER BY start_line;
+----
+process	transform	function	transform(data)	6
+process	log	method	console.log("processing")	7
+transform	parse	method	JSON.parse(data)	12
+fetch	execute	method	this.db.execute(query)	21
+fetch	fetchAll	method	result.fetchAll()	22
+processAll	fetch	method	this.fetch("SELECT 1")	26
+processAll	transform	function	transform(data)	27
+inner	helper	function	helper()	33
+outer	inner	function	inner()	35
+outer	process	function	process("test")	36
+<module>	Service	constructor	new Service("db")	39
+<module>	log	method	console.log("module level")	40
+
+# Constructor calls only
+query II
+SELECT caller_name, called_name
+FROM ast_get_calls('test/data/call_extraction/calls.js')
+WHERE call_type = 'constructor';
+----
+<module>	Service
+
+# =============================================================================
+# Section 3: Rust — macro detection
+# =============================================================================
+
+query IIIII
+SELECT caller_name, called_name, call_type, call_expression, start_line
+FROM ast_get_calls('test/data/call_extraction/calls.rs')
+ORDER BY start_line;
+----
+process	transform	function	transform(data)	6
+process	validate	function	validate(&result)	7
+process	println	macro	println!("processing")	8
+transform	to_string	method	data.to_string()	13
+validate	trim	method	data.trim()	17
+validate	to_string	method	data.trim().to_string()	17
+new	to_string	method	db.to_string()	26
+fetch	execute	method	self.db.execute(query)	30
+process_all	fetch	method	self.fetch("SELECT 1")	34
+process_all	transform	function	transform(&data[0])	35
+inner	helper	function	helper()	41
+outer	inner	function	inner()	43
+outer	process	function	process("test")	44
+main	new	function	Service::new("db")	48
+main	println	macro	println!("done")	49
+
+# Macro calls only
+query II
+SELECT caller_name, called_name
+FROM ast_get_calls('test/data/call_extraction/calls.rs')
+WHERE call_type = 'macro'
+ORDER BY start_line;
+----
+process	println
+main	println
+
+# =============================================================================
+# Section 4: Go — method receiver syntax
+# =============================================================================
+
+query IIIII
+SELECT caller_name, called_name, call_type, call_expression, start_line
+FROM ast_get_calls('test/data/call_extraction/calls.go')
+ORDER BY start_line;
+----
+process	transform	function	transform(data)	10
+process	validate	function	validate(result)	11
+process	Println	method	fmt.Println("processing")	12
+validate	len	function	len(data)	21
+Fetch	Execute	method	s.db.Execute(query)	33
+ProcessAll	Fetch	method	s.Fetch("SELECT 1")	37
+ProcessAll	transform	function	transform(data[0])	38
+outer	helper	function	helper()	42
+outer	process	function	process("test")	43
+main	NewService	function	NewService("db")	47
+main	Println	method	fmt.Println(svc)	48
+
+# =============================================================================
+# Section 5: ast_call_graph — aggregation
+# =============================================================================
+
+# Python call graph
+query IIII
+SELECT caller, callee, call_type, call_count
+FROM ast_call_graph('test/data/call_extraction/calls.py')
+ORDER BY caller, callee;
+----
+<module>	print	function	1
+fetch	execute	method	1
+fetch	fetchall	method	1
+inner	helper	function	1
+outer	inner	function	1
+outer	process	function	1
+process	exists	method	1
+process	transform	function	1
+process	validate	function	1
+process_all	fetch	method	1
+process_all	transform	function	1
+transform	loads	method	1
+validate	len	function	1
+
+# =============================================================================
+# Section 6: Filtering patterns — common use cases
+# =============================================================================
+
+# What does process() call? (Python)
+query II
+SELECT called_name, call_type
+FROM ast_get_calls('test/data/call_extraction/calls.py')
+WHERE caller_name = 'process'
+ORDER BY start_line;
+----
+transform	function
+validate	function
+exists	method
+
+# Who calls transform? (Python)
+query I
+SELECT caller_name
+FROM ast_get_calls('test/data/call_extraction/calls.py')
+WHERE called_name = 'transform'
+ORDER BY start_line;
+----
+process
+process_all
+
+# =============================================================================
+# Section 7: ast_get_calls with sample_app.py (larger file)
+# =============================================================================
+
+# Call graph for a realistic file
+query IIII
+SELECT caller, callee, call_type, call_count
+FROM ast_call_graph('test/data/python/sample_app.py')
+WHERE caller = 'main'
+ORDER BY callee;
+----
+main	Config	function	1
+main	DatabaseConnection	function	1
+main	UserService	function	1
+main	close	method	1
+main	connect	method	1
+main	export_users	method	1
+main	get	method	1
+main	len	function	1
+main	load	method	1
+main	print	function	1
+main	process_file	function	1
+main	validate_email	function	1
+
+# =============================================================================
+# Section 8: Language column verification
+# =============================================================================
+
+query II
+SELECT DISTINCT language, call_type
+FROM ast_get_calls('test/data/call_extraction/calls.rs')
+WHERE call_type = 'macro';
+----
+rust	macro
+
+query II
+SELECT DISTINCT language, call_type
+FROM ast_get_calls('test/data/call_extraction/calls.js')
+WHERE call_type = 'constructor';
+----
+javascript	constructor

--- a/tracker/PRIORITIES.md
+++ b/tracker/PRIORITIES.md
@@ -1,6 +1,6 @@
 # DuckDB AST Extension - Development Priorities
 
-**Last Updated:** 2026-04-26
+**Last Updated:** 2026-04-26 (post-sprint update)
 
 ## Priority Levels
 
@@ -12,6 +12,8 @@
 ## Current Status
 
 ### Completed (since last update on 2026-04-26)
+- **Parse-time filtering (#014)** — `prune` and `max_depth` parameters on `read_ast`; named prune policies (`syntax`, `comments`); tree-healing DFS maintains parent_id, sibling_index, descendant_count consistency
+- **Bug #010: C# name extraction return type** — Fixed C# adapter to use `ts_node_child_by_field_name(node, "name")` instead of first-identifier scan; async Task methods now extract method name correctly
 - `ast_find_references()` with scope-chain resolution (#016) — finds all definition/reference/call sites for a symbol, resolves through scope chain, tested across Python, JS, Rust, Go (200 assertions)
 - `ast_get_calls()` and `ast_call_graph()` (#017) — scope-aware call extraction with call-type classification (function/method/constructor/macro), O(1) caller attribution via scope.function, tested across Python, JS, Rust, Go (392 assertions)
 - Async/modifier extraction across all 8 languages (PR #69) — `list_contains(modifiers, 'async')` now works for Python, JS, TS, Rust, Kotlin, Swift, Dart, C#
@@ -53,14 +55,12 @@
 
 ### Open Bugs
 - #006 Performance tests slow (26s vs 0.1s for basic tests) - Medium priority
-- #010 C# name extraction picks up return type instead of method name - Medium priority
+- #010 C# name extraction picks up return type instead of method name - **Fixed 2026-04-26**
 
 ## Immediate Priorities
 
 ### P1 - Core Analysis Functions
-1. **[FEATURE] Parse-Time Filtering** (#014)
-   - Add `only_types`, `max_depth` parameters to read_ast
-   - Essential for large codebases, 5-50x memory reduction
+*(#014 parse-time filtering is complete — see Completed section above)*
 
 ### P2 - Pattern Matching Evolution
 1. **[FEATURE] Native Tree-sitter Query API** (#028)

--- a/tracker/PRIORITIES.md
+++ b/tracker/PRIORITIES.md
@@ -1,6 +1,6 @@
 # DuckDB AST Extension - Development Priorities
 
-**Last Updated:** 2026-04-25
+**Last Updated:** 2026-04-26
 
 ## Priority Levels
 
@@ -11,7 +11,9 @@
 
 ## Current Status
 
-### Completed (since last update on 2026-04-25)
+### Completed (since last update on 2026-04-26)
+- `ast_find_references()` with scope-chain resolution (#016) — finds all definition/reference/call sites for a symbol, resolves through scope chain, tested across Python, JS, Rust, Go (200 assertions)
+- `ast_get_calls()` and `ast_call_graph()` (#017) — scope-aware call extraction with call-type classification (function/method/constructor/macro), O(1) caller attribution via scope.function, tested across Python, JS, Rust, Go (392 assertions)
 - Async/modifier extraction across all 8 languages (PR #69) — `list_contains(modifiers, 'async')` now works for Python, JS, TS, Rust, Kotlin, Swift, Dart, C#
 - `ast_imports`/`ast_exports` correctness for cross-file resolution (PR #68) — IS_EXPORTED flag gated to name-binding nodes, import dedup, 5-language adapter fixes
 - IS_EXPORTED flag for file-level visibility (PR #65) — scope-aware export detection
@@ -44,7 +46,7 @@
 - 87 test files covering all languages and features
 - Bugs #001-005, #007-013 all fixed
 - IS_SYNTAX_ONLY flags, punctuation consistency, comparison type fixes
-- 104 test files, 5457 assertions
+- 106 test files, 6049 assertions
 
 ### Stalled
 - #023 Unified function architecture — no activity since January 2026, deprioritized
@@ -59,14 +61,6 @@
 1. **[FEATURE] Parse-Time Filtering** (#014)
    - Add `only_types`, `max_depth` parameters to read_ast
    - Essential for large codebases, 5-50x memory reduction
-
-2. **[FEATURE] ast_find_references()** (#016)
-   - Find all uses of a variable/function within scope
-   - Core navigation feature
-
-3. **[FEATURE] ast_get_calls()** (#017)
-   - Extract function/method calls within a node
-   - Essential for call graph analysis
 
 ### P2 - Pattern Matching Evolution
 1. **[FEATURE] Native Tree-sitter Query API** (#028)

--- a/tracker/PRIORITIES.md
+++ b/tracker/PRIORITIES.md
@@ -1,6 +1,6 @@
 # DuckDB AST Extension - Development Priorities
 
-**Last Updated:** 2026-03-30
+**Last Updated:** 2026-04-25
 
 ## Priority Levels
 
@@ -11,7 +11,12 @@
 
 ## Current Status
 
-### Completed (since last update on 2026-03-04)
+### Completed (since last update on 2026-04-25)
+- Async/modifier extraction across all 8 languages (PR #69) — `list_contains(modifiers, 'async')` now works for Python, JS, TS, Rust, Kotlin, Swift, Dart, C#
+- `ast_imports`/`ast_exports` correctness for cross-file resolution (PR #68) — IS_EXPORTED flag gated to name-binding nodes, import dedup, 5-language adapter fixes
+- IS_EXPORTED flag for file-level visibility (PR #65) — scope-aware export detection
+- Custom selector predicates via `ast_selector_predicate_*` macros (PR #67)
+- CSS selector bug fixes: `:has(.class)`, `:not(:has())`, combinator+pseudo-class, compound filter leaks, decorrelated join performance (17x speedup)
 - Recursive pattern matching (#57) — `<**>` any-depth wildcards, relational operators (`ast_has`, `ast_not_has`, `ast_inside`, `ast_precedes`, `ast_follows`)
 - Optional `<?>` and negation `<~>` wildcards (#58, #59) — complete wildcard cardinality system
 - `detect_language()` scalar function (#56) — expose language detection for downstream tools
@@ -37,14 +42,16 @@
 - Children/descendant counts for O(1) subtree operations
 - Parser ownership refactor, KIND taxonomy integration
 - 87 test files covering all languages and features
-- Bugs #001-005, #007-013 all fixed (13 of 13 total)
+- Bugs #001-005, #007-013 all fixed
 - IS_SYNTAX_ONLY flags, punctuation consistency, comparison type fixes
+- 104 test files, 5457 assertions
 
 ### Stalled
 - #023 Unified function architecture — no activity since January 2026, deprioritized
 
-### Only Open Bug
+### Open Bugs
 - #006 Performance tests slow (26s vs 0.1s for basic tests) - Medium priority
+- #010 C# name extraction picks up return type instead of method name - Medium priority
 
 ## Immediate Priorities
 

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -17,7 +17,7 @@ tracker/
 └── README.md                 # This file
 ```
 
-## Current Status (Updated 2026-03-04)
+## Current Status (Updated 2026-04-26)
 
 ### Language Support: 27 languages
 Bash, C, C++, C#, CSS, Dart, Go, GraphQL, HCL, HTML, Java, JavaScript, JSON,
@@ -34,7 +34,7 @@ YAML, Zig
 - Source code extraction (`ast_get_source()`)
 - Comprehensive semantic predicate functions (`is_function_definition()`, etc.)
 
-### Test Suite: 75 test files
+### Test Suite: 87+ test files
 Covers all languages, pattern matching, semantic types, edge cases, and regressions.
 
 ## Bug Summary
@@ -52,10 +52,11 @@ Covers all languages, pattern matching, semantic types, edge cases, and regressi
 | 009 | is_syntax_only Not Set for Delimiters | Fixed |
 | 010 | Inconsistent Punctuation Types | Fixed |
 | 011 | Comparison Semantic Type Mismatch | Fixed |
+| 010b | C# Name Extraction Picks Up Return Type | Fixed |
 | 012 | Import Name Extraction | Fixed |
 | 013 | FIND_IDENTIFIER Missing Types | Fixed |
 
-**12 of 13 bugs fixed.** Only #006 (performance tests slow) remains open.
+**13 of 14 bugs fixed.** Only #006 (performance tests slow) remains open.
 
 ## Feature Summary
 
@@ -74,8 +75,8 @@ Covers all languages, pattern matching, semantic types, edge cases, and regressi
 - #023 Unified function architecture (Phase 1)
 
 ### Open / Planned (by priority)
-- **P1**: ast_get_source with context (#013), parse-time filtering (#014), parent chain (#015)
-- **P1 Done**: find references (#016), get calls (#017)
+- **P1**: ast_get_source with context (#013), parent chain (#015)
+- **P1 Done**: parse-time filtering (#014), find references (#016), get calls (#017)
 - **P2**: Native tree-sitter query API (#028), pattern by example (#029), pattern matching C++ (#030), columnar AST (#012-columnar)
 - **P2**: Taxonomy exposure audit (#020), concise CLI syntax (#022), standardized extraction API (#026)
 - **P3**: Native AST type (#011), AI agent UX (#010), performance caching, AST diff analysis

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -74,7 +74,8 @@ Covers all languages, pattern matching, semantic types, edge cases, and regressi
 - #023 Unified function architecture (Phase 1)
 
 ### Open / Planned (by priority)
-- **P1**: ast_get_source with context (#013), parse-time filtering (#014), parent chain (#015), find references (#016), get calls (#017)
+- **P1**: ast_get_source with context (#013), parse-time filtering (#014), parent chain (#015)
+- **P1 Done**: find references (#016), get calls (#017)
 - **P2**: Native tree-sitter query API (#028), pattern by example (#029), pattern matching C++ (#030), columnar AST (#012-columnar)
 - **P2**: Taxonomy exposure audit (#020), concise CLI syntax (#022), standardized extraction API (#026)
 - **P3**: Native AST type (#011), AI agent UX (#010), performance caching, AST diff analysis

--- a/tracker/bugs/010-csharp-name-extraction-return-type.md
+++ b/tracker/bugs/010-csharp-name-extraction-return-type.md
@@ -1,0 +1,47 @@
+# Bug #010: C# name extraction picks up return type instead of method name
+
+**Status:** Open
+**Severity:** Medium
+**Component:** C# language adapter / FIND_IDENTIFIER strategy
+**Reported:** 2026-04-25
+
+## Summary
+
+For C# methods with `async Task` or `async Task<T>` return types, the `name` column extracts `Task` (the return type) instead of the actual method name. This is because `FIND_IDENTIFIER` picks the first `identifier` node in the tree-sitter AST, and `Task` appears before the method name.
+
+## Reproduction
+
+```sql
+LOAD sitting_duck;
+
+SELECT name, modifiers FROM read_ast('test/data/modifier_audit/async_functions.cs', context := 'native')
+WHERE is_function_definition(semantic_type) AND name != ''
+ORDER BY start_line;
+```
+
+**Expected:** `PrivateAsync` with `modifiers = [private, async]`
+**Actual:** `Task` with `modifiers = [private, async]`
+
+## Root Cause
+
+C# tree-sitter grammar for `private async Task PrivateAsync()` produces:
+```
+method_declaration
+  modifier("private")
+  modifier("async")
+  identifier("Task")      <-- return type, but parsed as identifier
+  identifier("PrivateAsync")  <-- actual method name
+```
+
+The `FIND_IDENTIFIER` strategy takes the first `identifier` child, which is the return type `Task` rather than the method name `PrivateAsync`.
+
+## Possible Fixes
+
+1. Use a named field lookup (`ts_node_child_by_field_name(node, "name", ...)`) instead of first-identifier scan
+2. Skip identifiers that appear before the parameter list
+3. Add C#-specific name extraction that skips type identifiers
+
+## Impact
+
+- Affects any C# method with a non-predefined return type (Task, List, etc.)
+- Methods returning `void`, `int`, `string` etc. are unaffected (those are `predefined_type` nodes, not `identifier`)

--- a/tracker/bugs/010-csharp-name-extraction-return-type.md
+++ b/tracker/bugs/010-csharp-name-extraction-return-type.md
@@ -1,9 +1,10 @@
 # Bug #010: C# name extraction picks up return type instead of method name
 
-**Status:** Open
+**Status:** Fixed
 **Severity:** Medium
 **Component:** C# language adapter / FIND_IDENTIFIER strategy
 **Reported:** 2026-04-25
+**Fixed:** 2026-04-26
 
 ## Summary
 
@@ -45,3 +46,7 @@ The `FIND_IDENTIFIER` strategy takes the first `identifier` child, which is the 
 
 - Affects any C# method with a non-predefined return type (Task, List, etc.)
 - Methods returning `void`, `int`, `string` etc. are unaffected (those are `predefined_type` nodes, not `identifier`)
+
+## Fix
+
+Used `ts_node_child_by_field_name(node, "name")` in the C# language adapter instead of the generic `FIND_IDENTIFIER` strategy (which takes the first `identifier` child). The `method_declaration` grammar node exposes a `name` field that points directly to the method name, bypassing the return type `identifier`. The fix was implemented in the C# adapter's name extraction path.

--- a/tracker/bugs/resolved/008-css-selector-issues.md
+++ b/tracker/bugs/resolved/008-css-selector-issues.md
@@ -1,6 +1,6 @@
 # Bug: CSS Selector Issues Discovered During Test Coverage Expansion
 
-**Status:** Open
+**Status:** Resolved (all 6 bugs fixed)
 **Priority:** Medium-High
 **Discovered:** 2026-04-13
 

--- a/tracker/bugs/resolved/009-async-modifiers-not-extracted.md
+++ b/tracker/bugs/resolved/009-async-modifiers-not-extracted.md
@@ -1,0 +1,39 @@
+# Bug #009: Async/modifier keywords not extracted across languages
+
+**Status:** Resolved
+**Severity:** Medium
+**Component:** Native context extraction
+**Reported:** 2026-04-19
+**Resolved:** 2026-04-25
+**PRs:** #69
+
+## Summary
+
+Async and other keyword modifiers (static, public, suspend, unsafe, etc.) were not being extracted into the `modifiers[]` column for functions in most languages. Only JavaScript/TypeScript had working async extraction via dedicated `async_function_declaration` node types.
+
+## Root Cause
+
+Each language's tree-sitter grammar places modifier keywords in different locations relative to the function node. The extractors assumed a single structure that only matched some grammars:
+
+- **Python**: `ASYNC_FUNCTION` strategy never triggered (tree-sitter emits `function_definition` with `async` child, not `async_function_definition`)
+- **Rust**: `function_modifiers` is a child of `function_item`, extractor only checked siblings
+- **Kotlin**: `modifiers` node is a direct child of `function_declaration`, extractor only checked parent's children
+- **Swift**: `async`/`throws` are standalone children (not inside `modifiers` node); `visibility_modifier` wasn't in the allow-list
+- **Dart**: `function_body` (containing async marker) is a sibling of `function_signature`, not a child
+
+## Fix
+
+Each language's `FUNCTION_WITH_PARAMS` extractor was updated to check the correct tree-sitter structure. A shared `EnsureModifier()` helper was added to prevent duplicates across all `ASYNC_FUNCTION` fallback paths.
+
+## Languages fixed
+
+| Language | Modifiers now extracted |
+|----------|----------------------|
+| Python | async |
+| JavaScript | async, static |
+| TypeScript | async, static |
+| Rust | async, pub, unsafe, extern, const |
+| Kotlin | suspend, private, inline |
+| Swift | async, throws, public, static, mutating |
+| Dart | async, async*, sync*, static |
+| C# | (already worked: public, async, static, private, virtual) |

--- a/tracker/features/014-filter-at-parse-time.md
+++ b/tracker/features/014-filter-at-parse-time.md
@@ -2,79 +2,58 @@
 
 **Source**: Peer Review Feedback  
 **Priority**: P1 (High - Essential for performance)
-**Status**: Design Phase
+**Status**: Complete
+**Completed**: 2026-04-26
 
 ## Overview
 
-Add filtering capabilities directly to `read_ast` and `read_ast_objects` functions to reduce the number of nodes loaded into memory. Critical for handling large codebases efficiently.
+Add filtering capabilities directly to `read_ast` to reduce the number of nodes loaded into memory. Critical for handling large codebases efficiently.
 
-## API Design
-
-```sql
--- Enhanced read_ast with filtering
-read_ast_objects(
-    file_pattern,
-    language,
-    only_types := ['function_definition', 'class_definition'],  -- New!
-    max_depth := 3  -- New!
-)
-```
-
-## Detailed Filter Options
+## Implemented API
 
 ```sql
--- Using our designed node_filter struct
-read_ast_objects(
-    'src/**/*.py',
-    'python', 
-    node_filter := {
-        include: ['function_*', 'class_*'],  -- Pattern support
-        exclude: ['*_test', 'test_*'],       -- Exclude patterns
-        preset: 'definitions',               -- Or use presets
-        max_depth: 5
-    }
-)
+-- max_depth: cut off traversal at a given depth (root = 0)
+SELECT * FROM read_ast('src/**/*.py', max_depth := 3);
+
+-- prune: skip node categories at parse time (before SQL filtering)
+SELECT * FROM read_ast('src/**/*.py', prune := ['syntax']);
+SELECT * FROM read_ast('src/**/*.py', prune := ['comments']);
+SELECT * FROM read_ast('src/**/*.py', prune := ['syntax', 'comments']);
+
+-- Combined
+SELECT * FROM read_ast('src/**/*.py', prune := ['syntax'], max_depth := 5);
 ```
 
-## Language Presets
+## Implementation Summary
 
-```python
-PRESETS = {
-    'definitions': ['function_definition', 'class_definition', 'variable_declaration'],
-    'signatures': ['function_definition', 'method_definition'],  
-    'imports': ['import_statement', 'import_from_statement'],
-    'structure': ['class_definition', 'module', 'namespace']
-}
-```
+### Parameters Added
+- `max_depth` (INTEGER, default -1): Maximum node depth to emit; -1 = unlimited. Boundary nodes have their `children_count` and `descendant_count` zeroed to reflect the truncated view.
+- `prune` (VARCHAR[], default []): Named prune policies applied during DFS traversal before emitting nodes. Pruned subtrees are skipped entirely and parent `descendant_count` values are adjusted to remain consistent.
+
+### Prune Policies
+| Policy | Nodes Removed |
+|--------|---------------|
+| `syntax` | Nodes where `is_syntax_only(flags)` is true (punctuation, delimiters, keywords) |
+| `comments` | Nodes where `(semantic_type & 252) = 32` (METADATA_COMMENT super-type) |
+
+### Tree Healing
+Pruning maintains tree consistency guarantees:
+- Every `parent_id` references an emitted node
+- `sibling_index` values are contiguous per parent (re-numbered after pruning)
+- `descendant_count` reflects only emitted descendants
+
+### Files Changed
+- `src/include/ast_extraction_config.hpp` — `SemanticFilter` struct, `prune` field on `ExtractionConfig`
+- `src/core/ast_extraction_config.cpp` — `CompilePrunePolicy()` implementation
+- `src/functions/read_ast.cpp` — parameter registration and bind-time parsing
+- `src/core/ast_reader.cpp` — `ShouldPruneNode()` helper, `max_depth` cutoff, tree-healing DFS integration
 
 ## Performance Impact
 
 - **Current**: Parse all nodes, filter in SQL → O(n) memory
-- **With Filtering**: Skip unwanted nodes during parse → O(m) memory where m << n
-- **Expected**: 5-50x memory reduction for focused queries
+- **With `prune := ['syntax']`**: Typically removes 30-60% of nodes before SQL sees them
+- **With `max_depth`**: Early cutoff for structure-only queries
 
-## Implementation Notes
+## Design Notes
 
-1. Modify tree-sitter traversal to skip non-matching nodes
-2. Still need to traverse for structure (can't skip children of skipped nodes)
-3. Early termination at max_depth
-4. Language handlers define their presets
-
-## Example Impact
-
-```sql
--- Before: Loads 50,000 nodes, filters to 500
-SELECT * FROM read_ast_objects('large_project/', 'python')
-WHERE type IN ('function_definition', 'class_definition');
-
--- After: Loads only ~2,000 nodes (functions + structure)
-SELECT * FROM read_ast_objects('large_project/', 'python',
-    only_types := ['function_definition', 'class_definition']);
-```
-
-## Next Steps
-
-1. Modify parser traversal logic
-2. Add filter parameter to read functions
-3. Implement pattern matching for types
-4. Define language-specific presets
+The original design proposed `only_types` include/exclude pattern filtering and language-specific presets. The implemented design chose named semantic policies (`syntax`, `comments`) instead, which are language-agnostic and align with the existing `is_syntax_only()` / semantic-type system. The include/exclude pattern approach remains viable as a future extension.

--- a/tracker/features/016-ast-find-references.md
+++ b/tracker/features/016-ast-find-references.md
@@ -2,96 +2,58 @@
 
 **Source**: Peer Review Feedback
 **Priority**: P1 (High - Core navigation feature)
-**Status**: Design Phase
+**Status**: Complete
 
 ## Overview
 
-Find all references to a name within a given scope. Essential for understanding code dependencies and refactoring.
+Find all references to a named symbol within a file, using scope-chain resolution to correctly associate references with their definitions.
 
-## API Design
-
-```sql
--- Function signatures
-ast_find_references(name, scope_id := NULL) → TABLE(node_id, type, line, context)
-ast_find_references(nodes, name, scope_id := NULL) → JSON[]
-
--- Macro version
-.find_references(name, scope_id := NULL)
-```
-
-## Usage Examples
+## Implemented API
 
 ```sql
--- Find all calls to a function
-SELECT * FROM ast_find_references('calculate_tax', NULL)
-FROM read_ast_objects('billing/*.py', 'python');
+-- Find all definitions, references, and call sites for 'process'
+SELECT ref_kind, node_type, start_line, scope_name, peek
+FROM ast_find_references('src/main.py', 'process')
+ORDER BY start_line;
 
--- Find references within a specific class
-WITH class_scope AS (
-    SELECT node_id 
-    FROM read_ast_objects('models.py', 'python')
-    WHERE type = 'class_definition' AND name = 'Order'
-)
-SELECT * FROM ast_find_references('total_amount', class_scope.node_id)
-FROM read_ast_objects('models.py', 'python'), class_scope;
+-- Filter to just call sites
+SELECT start_line, scope_name, peek
+FROM ast_find_references('src/**/*.rs', 'helper')
+WHERE ref_kind = 'call';
 
--- Chain syntax
-SELECT ast(nodes)
-    .find_references('user_id')
-    .get_source(1) as usage_contexts
-FROM read_ast_objects('api.py', 'python');
+-- Count references per kind
+SELECT ref_kind, COUNT(*)
+FROM ast_find_references('src/app.js', 'Service')
+GROUP BY ref_kind;
 ```
 
-## Implementation Challenges
+## Output Columns
 
-1. **Name Resolution**: Same name can refer to different things in different scopes
-2. **Language Specific**: Each language has different scoping rules
-3. **Performance**: Need efficient scope-aware search
+| Column | Type | Description |
+|--------|------|-------------|
+| file_path | VARCHAR | Source file path |
+| name | VARCHAR | Symbol name |
+| ref_kind | VARCHAR | `definition`, `reference`, or `call` |
+| node_type | VARCHAR | Tree-sitter node type (e.g., `function_item`, `identifier`) |
+| start_line | UINTEGER | Line number |
+| peek | VARCHAR | Source context |
+| scope_name | VARCHAR | Containing scope name (or `<module>`) |
+| def_node_id | BIGINT | Node ID of the resolved definition |
 
-## Implementation Strategy
+## Implementation
 
-### Phase 1: Simple Text Matching
-```sql
--- Basic implementation: find by name match
-CREATE FUNCTION ast_find_references_simple(
-    nodes JSON,
-    target_name VARCHAR,
-    scope_id INTEGER DEFAULT NULL
-) AS (
-    SELECT node
-    FROM json_array_elements(nodes) as node
-    WHERE node->>'name' = target_name
-      AND node->>'type' IN ('identifier', 'variable_reference', 'function_call')
-      AND (scope_id IS NULL OR is_within_scope(node, scope_id))
-);
-```
+- **Location**: `src/sql_macros/scope_resolution.sql`
+- **Signature**: `ast_find_references(source, target_name, language := NULL)`
+- **Approach**: Inlines the `ast_resolve` pattern filtered to a target name
+  - Finds all `is_name_definition` nodes matching the target
+  - Finds all `is_name_reference` nodes matching the target (excluding `binds_name` identifiers)
+  - Walks scope chains via `scope.stack` to resolve each reference to its innermost definition
+  - Promotes references whose parent is a call node to `ref_kind = 'call'`
+  - UNIONs definition sites with resolved reference sites
 
-### Phase 2: Scope-Aware Search
-- Track variable definitions and their scopes
-- Resolve names based on language scoping rules
-- Handle imports and qualified names
+## Test Coverage
 
-### Phase 3: Smart References
-- Understand method calls vs function calls
-- Handle renamed imports
-- Track type information where available
-
-## Benefits
-
-- **Navigation**: Jump to all uses of a variable/function
-- **Refactoring**: Find what needs updating
-- **Understanding**: See how code is used
-- **Analysis**: Identify unused code
-
-## Related Features
-
-- Works with `ast_get_parent_chain()` for scope analysis
-- Combines with `ast_get_source()` to show usage context
-- Enhanced by annotation system for better accuracy
-
-## Next Steps
-
-1. Implement basic name matching
-2. Add scope containment checking  
-3. Create language-specific refinements
-4. Consider semantic analysis integration
+- **Test file**: `test/sql/scope_resolution/find_references.test`
+- **Assertions**: 200 across Python, JavaScript, Rust, Go
+- **Fixtures**: `test/data/find_references/refs.{py,js,rs,go}`
+- **Scenarios**: Function refs, class/struct refs, variable shadowing, method refs, constructor calls, filtering patterns, empty results, def_node_id disambiguation

--- a/tracker/features/017-ast-get-calls.md
+++ b/tracker/features/017-ast-get-calls.md
@@ -1,132 +1,73 @@
-# ast_get_calls() - Extract Function Calls
+# ast_get_calls() / ast_call_graph() - Call Extraction
 
 **Source**: Peer Review Feedback
 **Priority**: P1 (High - Essential for dependency analysis)
-**Status**: Ready for Implementation
+**Status**: Complete
 
 ## Overview
 
-Find all function/method calls within a node (usually a function). Critical for understanding dependencies and call graphs.
+Extract function/method calls from source files with call-type classification and scope-aware caller attribution. Build caller→callee call graphs.
 
-## API Design
-
-```sql
--- Function signature  
-ast_get_calls(node_id) → TABLE(called_name, call_type, line, arguments)
-ast_get_calls(nodes) → JSON[]
-
--- Macro version
-.get_calls()
-```
-
-## Usage Examples
+## Implemented API
 
 ```sql
--- Find what functions are called by each function
-SELECT 
-    f.name as function_name,
-    c.called_name,
-    COUNT(*) as call_count
-FROM read_ast_objects('service.py', 'python') f,
-     LATERAL ast_get_calls(f.node_id) c
-WHERE f.type = 'function_definition'
-GROUP BY f.name, c.called_name;
+-- All calls in a file with caller attribution and call type
+SELECT caller_name, called_name, call_type, call_expression, start_line
+FROM ast_get_calls('src/main.py');
 
--- Find external dependencies
-SELECT DISTINCT called_name
-FROM read_ast_objects('module.py', 'python'),
-     LATERAL ast_get_calls(node_id)
-WHERE call_type = 'external'
-ORDER BY called_name;
+-- Only method calls
+SELECT * FROM ast_get_calls('src/**/*.rs')
+WHERE call_type = 'method';
 
--- Chain syntax for complexity analysis
-SELECT ast(nodes)
-    .filter_type(['function_definition'])
-    .with_annotations('calls')
-    .filter_by_annotation('calls.count', '> 10') as complex_functions
-FROM read_ast_objects('app.py', 'python');
+-- Aggregated call graph
+SELECT caller, callee, call_type, call_count
+FROM ast_call_graph('src/service.go');
 ```
 
-## Implementation Strategy
+## ast_get_calls Output Columns
 
-### Direct Implementation
-```sql
-CREATE FUNCTION ast_get_calls_impl(nodes JSON, node_id INTEGER) AS (
-    -- Find all call expressions within the subtree
-    WITH RECURSIVE subtree AS (
-        SELECT node FROM json_array_elements(nodes) node
-        WHERE node->>'id' = node_id::VARCHAR
-        
-        UNION ALL
-        
-        SELECT child.node
-        FROM subtree s,
-             json_array_elements(nodes) child(node)
-        WHERE child.node->>'parent_id' = s.node->>'id'
-    )
-    SELECT 
-        node->>'name' as called_name,
-        node->>'type' as call_type,
-        node->'position'->>'start_row' as line
-    FROM subtree
-    WHERE node->>'normalized_type' = 'function_call'
-);
-```
+| Column | Type | Description |
+|--------|------|-------------|
+| file_path | VARCHAR | Source file path |
+| caller_name | VARCHAR | Containing function name (or `<module>`) |
+| called_name | VARCHAR | Name of the called function/method |
+| call_expression | VARCHAR | Full call expression (peek) |
+| call_type | VARCHAR | `function`, `method`, `constructor`, or `macro` |
+| language | VARCHAR | Source language |
+| start_line | UINTEGER | Line number |
+| node_id | BIGINT | Call node ID |
+| caller_node_id | BIGINT | Caller function node ID |
 
-### As Annotation
-```json
-{
-    "type": "function_definition",
-    "name": "process_order",
-    "annotations": {
-        "calls": {
-            "internal": ["validate_order", "calculate_tax", "save_order"],
-            "external": ["logging.info", "db.commit"],
-            "count": 5
-        }
-    }
-}
-```
+## ast_call_graph Output Columns
 
-## Call Types to Track
+| Column | Type | Description |
+|--------|------|-------------|
+| file_path | VARCHAR | Source file path |
+| caller | VARCHAR | Caller function name |
+| callee | VARCHAR | Called function name |
+| call_type | VARCHAR | Call type classification |
+| call_count | BIGINT | Number of calls |
 
-1. **Function Calls**: `calculate_tax()`
-2. **Method Calls**: `order.calculate_total()`  
-3. **Static Calls**: `OrderService.process()`
-4. **Module Calls**: `math.sqrt()`
-5. **Constructor Calls**: `new User()` / `User()`
+## Call Type Classification
 
-## Benefits
+| Type | Detection Method |
+|------|-----------------|
+| `constructor` | Call node type is `new_expression`, `object_creation_expression`, etc. |
+| `macro` | Call node type is `macro_invocation` |
+| `method` | First child of call node is `attribute`, `member_expression`, `field_expression`, `selector_expression`, etc. |
+| `function` | Default — first child is `identifier` |
 
-- **Dependency Graphs**: Build call relationships
-- **Complexity Metrics**: Count external dependencies
-- **Dead Code Detection**: Find uncalled functions
-- **Impact Analysis**: What calls this function?
+## Implementation
 
-## Integration Ideas
+- **Location**: `src/sql_macros/tree_navigation.sql`
+- **Signatures**: `ast_get_calls(source, language := NULL)`, `ast_call_graph(source, language := NULL)`
+- **Caller attribution**: O(1) via `scope.function` hash join (not range-join)
+- **Method detection**: AST structural check on first child node type (no LIKE patterns)
+- **Related**: `ast_callees`/`ast_callers` in `scope_resolution.sql` provide simpler caller/callee pairs without call-type classification
 
-```sql
--- Build a call graph
-WITH call_data AS (
-    SELECT 
-        f.name as caller,
-        c.called_name as callee
-    FROM read_ast_objects('**/*.py', 'python') f,
-         LATERAL ast_get_calls(f.node_id) c
-    WHERE f.type = 'function_definition'
-)
--- Find most called functions
-SELECT 
-    callee,
-    COUNT(DISTINCT caller) as caller_count
-FROM call_data
-GROUP BY callee
-ORDER BY caller_count DESC;
-```
+## Test Coverage
 
-## Next Steps
-
-1. Implement basic call extraction
-2. Classify call types (internal/external/method)
-3. Add as annotation option
-4. Create call graph visualization helpers
+- **Test file**: `test/sql/tree_navigation/call_extraction.test`
+- **Assertions**: 392 across Python, JavaScript, Rust, Go
+- **Fixtures**: `test/data/call_extraction/calls.{py,js,rs,go}`
+- **Scenarios**: Function calls, method calls, constructor calls, chained calls, macro calls, nested calls, module-level calls, call graph aggregation

--- a/tracker/roadmap/phase2-performance-and-ux.md
+++ b/tracker/roadmap/phase2-performance-and-ux.md
@@ -28,7 +28,7 @@ Based on peer review feedback, Phase 2 should focus on performance optimization 
 - [x] `ast_definitions()` — list all functions/classes/variables
 - [x] `ast_function_metrics()` — complexity metrics
 - [x] `ast_source_of()` — find and extract function source
-- [ ] `code_find_callers()` - Find function callers — tracked as #017
+- [x] `ast_get_calls()` / `ast_call_graph()` — call extraction with type classification (#017)
 - [ ] `code_find_implementations()` - Find interface implementations
 - [x] `ast_nesting_analysis()` — nesting complexity
 


### PR DESCRIPTION
## Summary

- **Bug #010**: Fix C# method name extraction — `method_declaration` nodes with non-primitive return types (e.g. `Task`, `Task<string>`) now correctly extract the method name instead of the return type, using tree-sitter's field API (`ts_node_child_by_field_name`).
- **Feature #014**: Add `max_depth` and `prune` parameters to `read_ast()` for parse-time filtering with full tree healing.
  - `max_depth := N` — depth cutoff during DFS traversal; nodes at max_depth are emitted but their children are not.
  - `prune := ['syntax', 'comments', ...]` — named node-removal policies compiled at bind time into flag masks + SemanticFilter vectors. 9 policies: syntax, comments, literals, imports, types, punctuation, unnamed, leaves, internal.
  - Tree healing: pruned nodes are removed and the tree structure is repaired — parent_id, children_count, descendant_count, and sibling_index all remain consistent.

## Test plan

- [ ] 20 assertions in `test/sql/parse_time_filtering.test` covering:
  - Parameter validation (invalid policy error)
  - max_depth edge cases (0, 1, -1 default)
  - Prune policies (syntax, comments, composition)
  - Tree consistency (parent_id validity, contiguous sibling indices, descendant_count accuracy)
  - Combined max_depth + prune
  - Integration with existing macros (ast_definitions, ast_get_calls)
- [ ] C# bug fix test: `test/sql/bugs/010_csharp_name_extraction.test` (5 method names verified)
- [ ] Full regression suite: 6016/6018 pass (2 pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)