### PR TITLE
docs: build prerequisites — parallelism, vcpkg-not-required, duckdb pin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+# NOTE: the pinned commit (gitlink) is authoritative — currently duckdb v1.5.x.
+# `branch = main` only affects `git submodule update --remote`; a normal
+# `clone --recursive` / `submodule update` checks out the pinned commit, not main's HEAD.
 [submodule "duckdb"]
 	path = duckdb
 	url = https://github.com/duckdb/duckdb

--- a/README.md
+++ b/README.md
@@ -107,8 +107,12 @@ Each doc includes extraction quality ratings, implementation notes, and known li
 git clone --recursive https://github.com/teaguesterling/sitting_duck.git
 cd sitting_duck
 
-# Build the extension
-make
+# Build the extension.
+# NOTE: a bare `make` builds single-threaded. To use all cores, set the cmake
+# parallel level (the build invokes `cmake --build` without -j):
+CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+# (Alternatively `GEN=ninja make` if ninja is installed — ninja parallelizes by default.)
+# vcpkg is NOT required: vcpkg.json declares no dependencies.
 
 # Test it works
 ./build/release/duckdb -c "LOAD './build/release/extension/sitting_duck/sitting_duck.duckdb_extension'; SELECT COUNT(*) FROM read_ast('README.md');"

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -18,8 +18,10 @@ Guidelines for contributing to Sitting Duck.
 git clone --recursive https://github.com/teaguesterling/sitting_duck.git
 cd sitting_duck
 
-# Build
-make
+# Build. A bare `make` is single-threaded (it runs `cmake --build` without -j).
+# Use all cores by setting the cmake parallel level:
+CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
+# (or `GEN=ninja make` if ninja is installed). vcpkg is not required — vcpkg.json has no deps.
 
 # Run tests
 make test


### PR DESCRIPTION
Verified by a fresh `git clone --recursive` + `make` on a clean host:

- **Bare `make` is single-threaded** (release target runs `cmake --build` with no -j). Document `CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make` (or `GEN=ninja make`) so multi-core machines aren't stuck serial.
- **vcpkg is not required** (`vcpkg.json` has no deps) — cmake configure succeeds without `VCPKG_TOOLCHAIN_PATH`. Preempts a common assumption.
- **`.gitmodules`**: clarify the duckdb pin (gitlink, v1.5.x) is authoritative; `branch = main` only affects `submodule update --remote`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)