### PR TITLE
Add parse size/time/node caps; surface parse errors cleanly

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -28,6 +28,10 @@ jobs:
       duckdb_version: v1.5.4
       ci_tools_version: v1.5.4
       extension_name: sitting_duck
+      # Windows stays excluded (fleet pattern): both Windows legs fail on
+      # v1.5.4 while the same source passes Linux/macOS/wasm. Windows is not
+      # a merge gate; re-enable once the Windows build is fixed.
+      exclude_archs: 'windows_amd64;windows_amd64_mingw'
 
 #  code-quality-check:
 #    name: Code Quality Check

--- a/src/ast_parser.cpp
+++ b/src/ast_parser.cpp
@@ -1,6 +1,7 @@
 #include "ast_parser.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include <limits>
 
 // Tree-sitter headers
 extern "C" {
@@ -22,7 +23,13 @@ TSParser *ASTParser::CreateParser(const string &language) {
 }
 
 TSTree *ASTParser::ParseString(const string &content, TSParser *parser) {
-	TSTree *tree = ts_parser_parse_string(parser, nullptr, content.c_str(), content.length());
+	// tree-sitter takes the input length as uint32_t; larger inputs would be
+	// silently truncated to a partial parse, so reject them explicitly.
+	if (content.length() > std::numeric_limits<uint32_t>::max()) {
+		throw InvalidInputException("Cannot parse input of " + std::to_string(content.length()) +
+		                            " bytes: exceeds tree-sitter's 4 GiB input limit");
+	}
+	TSTree *tree = ts_parser_parse_string(parser, nullptr, content.c_str(), static_cast<uint32_t>(content.length()));
 	if (!tree) {
 		throw InvalidInputException("Failed to parse content");
 	}

--- a/src/ast_parsing_task.cpp
+++ b/src/ast_parsing_task.cpp
@@ -19,18 +19,36 @@ void ASTParsingTask::ExecuteTask() {
 	}
 }
 
+// Record a per-file error under ignore_errors. Returns true when the error was
+// absorbed (caller should continue with the next file); false when the caller
+// must propagate a clean DuckDB exception instead.
+bool ASTParsingTask::TryRecordFileError(idx_t file_idx, const string &message) {
+	parsing_state.errors_encountered.fetch_add(1);
+
+	if (!parsing_state.ignore_errors) {
+		return false;
+	}
+
+	// Store error message for later reporting
+	{
+		std::lock_guard<std::mutex> lock(parsing_state.errors_mutex);
+		parsing_state.error_messages.push_back("Error processing file " + parsing_state.file_paths[file_idx] + ": " +
+		                                       message);
+	}
+
+	// Continue processing other files
+	parsing_state.files_processed.fetch_add(1);
+	return true;
+}
+
 void ASTParsingTask::ProcessSingleFile(idx_t file_idx) {
 	try {
 		const auto &file_path = parsing_state.file_paths[file_idx];
 
-		// Read file content using DuckDB's thread-safe file system
+		// Read file content using DuckDB's thread-safe file system, enforcing the
+		// source-size cap before the content buffer is allocated
 		auto &fs = FileSystem::GetFileSystem(parsing_state.context);
-		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
-		auto file_size = fs.GetFileSize(*handle);
-
-		string content;
-		content.resize(file_size);
-		fs.Read(*handle, (void *)content.data(), file_size);
+		string content = ReadSourceFileWithCap(fs, file_path, ExtractionConfig::DEFAULT_MAX_SOURCE_BYTES);
 
 		// Get language for this specific file
 		const auto &file_language = parsing_state.languages[file_idx];
@@ -72,22 +90,23 @@ void ASTParsingTask::ProcessSingleFile(idx_t file_idx) {
 		parsing_state.per_thread_results[thread_id].push_back(std::move(result));
 
 	} catch (const Exception &e) {
-		// Handle errors based on ignore_errors flag
-		parsing_state.errors_encountered.fetch_add(1);
-
-		if (parsing_state.ignore_errors) {
-			// Store error message for later reporting
-			{
-				std::lock_guard<std::mutex> lock(parsing_state.errors_mutex);
-				parsing_state.error_messages.push_back("Error processing file " + parsing_state.file_paths[file_idx] +
-				                                       ": " + string(e.what()));
-			}
-
-			// Continue processing other files
-			parsing_state.files_processed.fetch_add(1);
-		} else {
+		// DuckDB exception: keep its type when propagating
+		if (!TryRecordFileError(file_idx, e.what())) {
 			// Re-throw to stop all tasks
 			throw;
+		}
+	} catch (const std::exception &e) {
+		// Non-DuckDB failure (std::bad_alloc from huge inputs, std::length_error,
+		// parse failures, ...). Previously these escaped the narrow catch above —
+		// bypassing ignore_errors and losing the file context. Convert them to a
+		// clean DuckDB error, matching the streaming path.
+		if (!TryRecordFileError(file_idx, e.what())) {
+			throw IOException("Failed to process " + parsing_state.file_paths[file_idx] + ": " + string(e.what()));
+		}
+	} catch (...) {
+		// No exception may escape a worker task
+		if (!TryRecordFileError(file_idx, "unknown error")) {
+			throw IOException("Failed to process " + parsing_state.file_paths[file_idx] + ": unknown error");
 		}
 	}
 }

--- a/src/include/ast_parsing_task.hpp
+++ b/src/include/ast_parsing_task.hpp
@@ -81,6 +81,9 @@ private:
 
 	// Helper method to process a single file
 	void ProcessSingleFile(idx_t file_idx);
+
+	// Record a per-file error; returns true when absorbed under ignore_errors
+	bool TryRecordFileError(idx_t file_idx, const string &message);
 };
 
 } // namespace duckdb

--- a/src/include/language_adapter.hpp
+++ b/src/include/language_adapter.hpp
@@ -62,9 +62,10 @@ public:
 
 	// Parse content directly and return owned tree
 	// Creates a fresh parser instance for each call to avoid shared state issues
-	TSTreePtr ParseContent(const string &content) const {
+	// parse_timeout_ms > 0 cancels the parse once the deadline is exceeded (clean error)
+	TSTreePtr ParseContent(const string &content, int64_t parse_timeout_ms = -1) const {
 		auto fresh_parser = CreateFreshParser();
-		return fresh_parser->ParseString(content);
+		return fresh_parser->ParseString(content, parse_timeout_ms);
 	}
 
 	// Pure virtual method to get the static node configs map - each adapter implements this

--- a/src/include/tree_sitter_wrappers.hpp
+++ b/src/include/tree_sitter_wrappers.hpp
@@ -3,6 +3,9 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/exception.hpp"
 #include <tree_sitter/api.h>
+#include <chrono>
+#include <cstdint>
+#include <limits>
 
 namespace duckdb {
 
@@ -72,14 +75,72 @@ public:
 		}
 	}
 
-	// Parse string and return owned tree
-	TSTreePtr ParseString(const string &content) {
-		TSTree *tree = ts_parser_parse_string(parser_.get(), nullptr, content.c_str(), content.length());
-
-		if (!tree) {
-			throw InternalException("Failed to parse content");
+	// Parse string and return owned tree.
+	// timeout_ms > 0 bounds the parse: tree-sitter's progress callback is used to
+	// cancel parses that exceed the deadline, which then surfaces as a clean
+	// DuckDB error instead of an unbounded run. timeout_ms <= 0 disables the bound.
+	TSTreePtr ParseString(const string &content, int64_t timeout_ms = -1) {
+		// tree-sitter takes the input length as uint32_t; larger inputs would be
+		// silently truncated to a partial parse, so reject them explicitly.
+		if (content.length() > std::numeric_limits<uint32_t>::max()) {
+			throw InvalidInputException("Cannot parse input of " + std::to_string(content.length()) +
+			                            " bytes: exceeds tree-sitter's 4 GiB input limit");
 		}
 
+		if (timeout_ms <= 0) {
+			TSTree *tree =
+			    ts_parser_parse_string(parser_.get(), nullptr, content.c_str(), static_cast<uint32_t>(content.length()));
+			if (!tree) {
+				throw InternalException("Failed to parse content");
+			}
+			return TSTreePtr(tree);
+		}
+
+		// Deadline-bounded parse via ts_parser_parse_with_options (the
+		// version-correct mechanism in tree-sitter 0.25+; the old
+		// ts_parser_set_timeout_micros API is deprecated).
+		struct DeadlineParseState {
+			const string *content;
+			std::chrono::steady_clock::time_point deadline;
+			bool timed_out;
+		};
+		DeadlineParseState state {&content, std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms),
+		                          false};
+
+		TSInput input;
+		input.payload = &state;
+		input.read = [](void *payload, uint32_t byte_index, TSPoint, uint32_t *bytes_read) -> const char * {
+			auto &s = *static_cast<DeadlineParseState *>(payload);
+			if (byte_index >= s.content->size()) {
+				*bytes_read = 0;
+				return "";
+			}
+			*bytes_read = static_cast<uint32_t>(s.content->size() - byte_index);
+			return s.content->data() + byte_index;
+		};
+		input.encoding = TSInputEncodingUTF8;
+		input.decode = nullptr;
+
+		TSParseOptions options;
+		options.payload = &state;
+		options.progress_callback = [](TSParseState *parse_state) -> bool {
+			auto &s = *static_cast<DeadlineParseState *>(parse_state->payload);
+			if (std::chrono::steady_clock::now() >= s.deadline) {
+				s.timed_out = true;
+				return true; // cancel the parse
+			}
+			return false;
+		};
+
+		TSTree *tree = ts_parser_parse_with_options(parser_.get(), nullptr, input, options);
+		if (!tree) {
+			if (state.timed_out) {
+				throw InvalidInputException(
+				    "Parse exceeded the timeout of " + std::to_string(timeout_ms) +
+				    " ms. Raise the limit with parse_timeout_ms := N or disable it with parse_timeout_ms := 0");
+			}
+			throw InternalException("Failed to parse content");
+		}
 		return TSTreePtr(tree);
 	}
 

--- a/src/include/unified_ast_backend.hpp
+++ b/src/include/unified_ast_backend.hpp
@@ -10,6 +10,8 @@
 
 namespace duckdb {
 
+class FileSystem;
+
 //==============================================================================
 // Extraction Configuration System
 //==============================================================================
@@ -36,6 +38,17 @@ struct ExtractionConfig {
 	bool prune_leaves = false;
 	bool prune_internal = false;
 	bool has_prune = false;
+
+	// Resource caps: bound the work a single parse can do so oversized or
+	// pathological inputs produce a clean DuckDB error instead of unbounded
+	// CPU/memory consumption. A value <= 0 disables that cap.
+	static constexpr int64_t DEFAULT_MAX_SOURCE_BYTES = 50LL * 1024 * 1024; // 50 MiB per input
+	static constexpr int64_t DEFAULT_PARSE_TIMEOUT_MS = 30000;              // 30 s per input
+	static constexpr int64_t DEFAULT_MAX_PARSE_NODES = 10000000;            // 10M AST nodes per input
+
+	int64_t max_source_bytes = DEFAULT_MAX_SOURCE_BYTES; // reject inputs larger than this before parsing
+	int64_t parse_timeout_ms = DEFAULT_PARSE_TIMEOUT_MS; // cancel tree-sitter parses that run longer than this
+	int64_t max_parse_nodes = DEFAULT_MAX_PARSE_NODES;   // abort extraction once this many nodes were produced
 
 	// Get a schema-level config: if include_full_schema, return max levels for schema generation
 	ExtractionConfig GetSchemaConfig() const {
@@ -75,6 +88,16 @@ struct ExtractionConfig {
 ExtractionConfig ParseExtractionConfig(const string &context_str, const string &source_str, const string &structure_str,
                                        const string &peek_str, int32_t peek_size = 120);
 void CompilePrunePolicy(const string &policy_name, ExtractionConfig &config);
+
+// Bind-time helper: apply the resource-cap named parameters (max_source_bytes,
+// parse_timeout_ms, max_parse_nodes) to an ExtractionConfig. Shared by every
+// function that exposes the caps so no entry point can drift.
+void ParseResourceCapParameters(const named_parameter_map_t &named_parameters, ExtractionConfig &config);
+
+// Read a source file into memory, enforcing max_source_bytes BEFORE allocating
+// the content buffer. Throws InvalidInputException when the file exceeds the cap.
+// Shared by every file-reading parse entry point (streaming, parallel, single).
+string ReadSourceFileWithCap(FileSystem &fs, const string &file_path, int64_t max_source_bytes);
 
 // Result structure for unified parsing backend
 struct ASTSource {

--- a/src/include/unified_ast_backend_impl.hpp
+++ b/src/include/unified_ast_backend_impl.hpp
@@ -99,9 +99,21 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 	result.source.language = language;
 	auto start_time = std::chrono::system_clock::now();
 
+	// === RESOURCE CAPS ===
+	// Every parse entry point (scalar, table, streaming, parallel) funnels
+	// through this function, so the caps are enforced here exactly once.
+	// Oversized input is rejected before tree-sitter allocates anything.
+	if (config.max_source_bytes > 0 && content.size() > static_cast<size_t>(config.max_source_bytes)) {
+		throw InvalidInputException(
+		    "Refusing to parse '" + file_path + "': input is " + std::to_string(content.size()) +
+		    " bytes, which exceeds max_source_bytes (" + std::to_string(config.max_source_bytes) +
+		    "). Raise the limit with max_source_bytes := N or disable it with max_source_bytes := 0");
+	}
+
 	// === TREE-SITTER MEMORY PHASE BEGIN ===
-	// Parse the content using the adapter's smart pointer wrapper
-	TSTreePtr tree = adapter->ParseContent(content);
+	// Parse the content using the adapter's smart pointer wrapper.
+	// config.parse_timeout_ms bounds the parse via tree-sitter's progress callback.
+	TSTreePtr tree = adapter->ParseContent(content, config.parse_timeout_ms);
 	if (!tree) {
 		throw InternalException("Failed to parse content");
 	}
@@ -431,6 +443,15 @@ ASTResult UnifiedASTBackend::ParseToASTResultTemplated(const AdapterType *adapte
 
 			// Update legacy fields for backward compatibility
 			ast_node.UpdateComputedLegacyFields();
+
+			// Resource cap: bound the number of nodes materialized from a single
+			// input so pathological sources cannot exhaust memory.
+			if (config.max_parse_nodes > 0 && result.nodes.size() >= static_cast<size_t>(config.max_parse_nodes)) {
+				throw InvalidInputException(
+				    "Refusing to extract more than max_parse_nodes (" + std::to_string(config.max_parse_nodes) +
+				    ") AST nodes from '" + file_path +
+				    "'. Raise the limit with max_parse_nodes := N or disable it with max_parse_nodes := 0");
+			}
 
 			result.nodes.push_back(ast_node);
 

--- a/src/parse_ast_function.cpp
+++ b/src/parse_ast_function.cpp
@@ -58,6 +58,9 @@ static unique_ptr<FunctionData> ParseASTBind(ClientContext &context, TableFuncti
 	// Create extraction config
 	ExtractionConfig config = ParseExtractionConfig(context_str, source_str, structure_str, peek_str, peek_size);
 
+	// Parse resource cap parameters (max_source_bytes, parse_timeout_ms, max_parse_nodes)
+	ParseResourceCapParameters(input.named_parameters, config);
+
 	// Use flat dynamic schema based on extraction config
 	return_types = UnifiedASTBackend::GetFlatDynamicTableSchema(config);
 	names = UnifiedASTBackend::GetFlatDynamicTableColumnNames(config);
@@ -135,6 +138,9 @@ static unique_ptr<FunctionData> ParseASTHierarchicalBind(ClientContext &context,
 	// Create extraction config
 	ExtractionConfig config = ParseExtractionConfig(context_str, source_str, structure_str, peek_str, peek_size);
 
+	// Parse resource cap parameters (max_source_bytes, parse_timeout_ms, max_parse_nodes)
+	ParseResourceCapParameters(input.named_parameters, config);
+
 	return make_uniq<ParseASTData>(code, language, config);
 }
 
@@ -177,6 +183,9 @@ void ParseASTFunction::Register(ExtensionLoader &loader) {
 	parse_ast_func.named_parameters["source"] = LogicalType::VARCHAR;
 	parse_ast_func.named_parameters["structure"] = LogicalType::VARCHAR;
 	parse_ast_func.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
+	parse_ast_func.named_parameters["max_source_bytes"] = LogicalType::BIGINT;
+	parse_ast_func.named_parameters["parse_timeout_ms"] = LogicalType::BIGINT;
+	parse_ast_func.named_parameters["max_parse_nodes"] = LogicalType::BIGINT;
 
 	loader.RegisterFunction(parse_ast_func);
 
@@ -190,6 +199,9 @@ void ParseASTFunction::Register(ExtensionLoader &loader) {
 	parse_ast_flat_func.named_parameters["source"] = LogicalType::VARCHAR;
 	parse_ast_flat_func.named_parameters["structure"] = LogicalType::VARCHAR;
 	parse_ast_flat_func.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
+	parse_ast_flat_func.named_parameters["max_source_bytes"] = LogicalType::BIGINT;
+	parse_ast_flat_func.named_parameters["parse_timeout_ms"] = LogicalType::BIGINT;
+	parse_ast_flat_func.named_parameters["max_parse_nodes"] = LogicalType::BIGINT;
 
 	loader.RegisterFunction(parse_ast_flat_func);
 
@@ -203,6 +215,9 @@ void ParseASTFunction::Register(ExtensionLoader &loader) {
 	parse_ast_hierarchical_func.named_parameters["source"] = LogicalType::VARCHAR;
 	parse_ast_hierarchical_func.named_parameters["structure"] = LogicalType::VARCHAR;
 	parse_ast_hierarchical_func.named_parameters["peek"] = LogicalType::ANY; // Can be INTEGER or VARCHAR
+	parse_ast_hierarchical_func.named_parameters["max_source_bytes"] = LogicalType::BIGINT;
+	parse_ast_hierarchical_func.named_parameters["parse_timeout_ms"] = LogicalType::BIGINT;
+	parse_ast_hierarchical_func.named_parameters["max_parse_nodes"] = LogicalType::BIGINT;
 
 	loader.RegisterFunction(parse_ast_hierarchical_func);
 }

--- a/src/read_ast_streaming_function.cpp
+++ b/src/read_ast_streaming_function.cpp
@@ -128,6 +128,9 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindTwoArg(ClientContext &co
 		}
 	}
 
+	// Parse resource cap parameters (max_source_bytes, parse_timeout_ms, max_parse_nodes)
+	ParseResourceCapParameters(input.named_parameters, extraction_config);
+
 	// Use flat dynamic schema based on extraction config
 	return_types = UnifiedASTBackend::GetFlatDynamicTableSchema(extraction_config);
 	names = UnifiedASTBackend::GetFlatDynamicTableColumnNames(extraction_config);
@@ -251,6 +254,9 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindOneArg(ClientContext &co
 			CompilePrunePolicy(StringUtil::Lower(policy.ToString()), extraction_config);
 		}
 	}
+
+	// Parse resource cap parameters (max_source_bytes, parse_timeout_ms, max_parse_nodes)
+	ParseResourceCapParameters(input.named_parameters, extraction_config);
 
 	// Use flat dynamic schema based on extraction config
 	return_types = UnifiedASTBackend::GetFlatDynamicTableSchema(extraction_config);
@@ -390,16 +396,12 @@ static void ReadASTFlatStreamingFunction(ClientContext &context, TableFunctionIn
 				continue;
 			}
 
-			// Read file content
+			// Read file content, enforcing the configured source-size cap up front
+			auto &config = global_state.extraction_config;
 			auto &fs = FileSystem::GetFileSystem(context);
-			auto file_handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
-			auto file_size = fs.GetFileSize(*file_handle);
-			string content;
-			content.resize(file_size);
-			fs.Read(*file_handle, (void *)content.data(), file_size);
+			string content = ReadSourceFileWithCap(fs, file_path, config.max_source_bytes);
 
 			// Parse using unified backend with full ExtractionConfig (supports max_depth, prune)
-			auto &config = global_state.extraction_config;
 			ASTResult result = UnifiedASTBackend::ParseToASTResult(content, file_language, file_path, config);
 
 			local_state.current_result = make_uniq<ASTResult>(std::move(result));
@@ -593,15 +595,12 @@ static void ReadASTHierarchicalFunction(ClientContext &context, TableFunctionInp
 				continue;
 			}
 
+			// Read file content, enforcing the configured source-size cap up front
+			auto &config = global_state.extraction_config;
 			auto &fs = FileSystem::GetFileSystem(context);
-			auto file_handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
-			auto file_size = fs.GetFileSize(*file_handle);
-			string content;
-			content.resize(file_size);
-			fs.Read(*file_handle, (void *)content.data(), file_size);
+			string content = ReadSourceFileWithCap(fs, file_path, config.max_source_bytes);
 
 			// Parse using unified backend with full ExtractionConfig (supports max_depth, prune)
-			auto &config = global_state.extraction_config;
 			ASTResult result = UnifiedASTBackend::ParseToASTResult(content, file_language, file_path, config);
 
 			local_state.current_result = make_uniq<ASTResult>(std::move(result));
@@ -617,6 +616,14 @@ static void ReadASTHierarchicalFunction(ClientContext &context, TableFunctionInp
 	}
 
 	output.SetCardinality(output_index);
+}
+
+// Register the resource cap named parameters on a table function (shared by
+// every read_ast variant so no registration site can drift)
+static void AddResourceCapNamedParameters(TableFunction &func) {
+	func.named_parameters["max_source_bytes"] = LogicalType::BIGINT;
+	func.named_parameters["parse_timeout_ms"] = LogicalType::BIGINT;
+	func.named_parameters["max_parse_nodes"] = LogicalType::BIGINT;
 }
 
 //==============================================================================
@@ -638,6 +645,7 @@ static TableFunction GetReadASTFlatFunctionTwoArg() {
 	read_ast.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast);
 
 	// Legacy parameters for backward compatibility
 	read_ast.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -660,6 +668,7 @@ static TableFunction GetReadASTFlatFunctionOneArg() {
 	read_ast.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast);
 
 	// Legacy parameters for backward compatibility
 	read_ast.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -681,6 +690,7 @@ static TableFunction GetReadASTStreamingFunctionTwoArg() {
 	read_ast_streaming.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast_streaming.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast_streaming.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast_streaming);
 	return read_ast_streaming;
 }
 
@@ -696,6 +706,7 @@ static TableFunction GetReadASTStreamingFunctionOneArg() {
 	read_ast_streaming.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast_streaming.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast_streaming.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast_streaming);
 	return read_ast_streaming;
 }
 
@@ -813,6 +824,9 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindTwoArg(ClientCon
 			CompilePrunePolicy(StringUtil::Lower(policy.ToString()), extraction_config);
 		}
 	}
+
+	// Parse resource cap parameters (max_source_bytes, parse_timeout_ms, max_parse_nodes)
+	ParseResourceCapParameters(input.named_parameters, extraction_config);
 
 	// Use hierarchical backend schema
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
@@ -939,6 +953,9 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindOneArg(ClientCon
 		}
 	}
 
+	// Parse resource cap parameters (max_source_bytes, parse_timeout_ms, max_parse_nodes)
+	ParseResourceCapParameters(input.named_parameters, extraction_config);
+
 	// Use hierarchical backend schema
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
 	names = UnifiedASTBackend::GetHierarchicalTableColumnNames();
@@ -963,6 +980,7 @@ static TableFunction GetReadASTFunctionTwoArg() {
 	read_ast_hierarchical_new.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast_hierarchical_new.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast_hierarchical_new.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast_hierarchical_new);
 
 	// Legacy parameters for backward compatibility
 	read_ast_hierarchical_new.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -986,6 +1004,7 @@ static TableFunction GetReadASTHierarchicalFunctionTwoArg() {
 	read_ast_hierarchical.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast_hierarchical.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast_hierarchical.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast_hierarchical);
 
 	// Legacy parameters for backward compatibility
 	read_ast_hierarchical.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -1008,6 +1027,7 @@ static TableFunction GetReadASTFunctionOneArg() {
 	read_ast_hierarchical_new.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast_hierarchical_new.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast_hierarchical_new.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast_hierarchical_new);
 
 	// Legacy parameters for backward compatibility
 	read_ast_hierarchical_new.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -1029,6 +1049,7 @@ static TableFunction GetReadASTHierarchicalFunctionOneArg() {
 	read_ast_hierarchical.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast_hierarchical.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast_hierarchical.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast_hierarchical);
 
 	// Legacy parameters for backward compatibility
 	read_ast_hierarchical.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -1051,6 +1072,7 @@ static TableFunction GetReadASTFlatAliasFunctionOneArg() {
 	read_ast_flat.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast_flat.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast_flat.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast_flat);
 
 	// Legacy parameters for backward compatibility
 	read_ast_flat.named_parameters["peek_size"] = LogicalType::INTEGER;
@@ -1072,6 +1094,7 @@ static TableFunction GetReadASTFlatAliasFunctionTwoArg() {
 	read_ast_flat.named_parameters["batch_size"] = LogicalType::INTEGER;
 	read_ast_flat.named_parameters["max_depth"] = LogicalType::INTEGER;
 	read_ast_flat.named_parameters["prune"] = LogicalType::LIST(LogicalType::VARCHAR);
+	AddResourceCapNamedParameters(read_ast_flat);
 
 	// Legacy parameters for backward compatibility
 	read_ast_flat.named_parameters["peek_size"] = LogicalType::INTEGER;

--- a/src/unified_ast_backend.cpp
+++ b/src/unified_ast_backend.cpp
@@ -285,6 +285,38 @@ ExtractionConfig ParseExtractionConfig(const string &context_str, const string &
 	return config;
 }
 
+void ParseResourceCapParameters(const named_parameter_map_t &named_parameters, ExtractionConfig &config) {
+	for (auto &param : named_parameters) {
+		if (param.first == "max_source_bytes") {
+			config.max_source_bytes = param.second.GetValue<int64_t>();
+		} else if (param.first == "parse_timeout_ms") {
+			config.parse_timeout_ms = param.second.GetValue<int64_t>();
+		} else if (param.first == "max_parse_nodes") {
+			config.max_parse_nodes = param.second.GetValue<int64_t>();
+		}
+	}
+}
+
+string ReadSourceFileWithCap(FileSystem &fs, const string &file_path, int64_t max_source_bytes) {
+	auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
+	auto file_size = fs.GetFileSize(*handle);
+	if (file_size < 0) {
+		throw IOException("Could not determine size of file: " + file_path);
+	}
+	// Enforce the cap BEFORE allocating the content buffer so oversized files
+	// are rejected cleanly instead of (attempting to) materialize in memory.
+	if (max_source_bytes > 0 && file_size > max_source_bytes) {
+		throw InvalidInputException(
+		    "Refusing to read '" + file_path + "': file is " + to_string(file_size) +
+		    " bytes, which exceeds max_source_bytes (" + to_string(max_source_bytes) +
+		    "). Raise the limit with max_source_bytes := N or disable it with max_source_bytes := 0");
+	}
+	string content;
+	content.resize(static_cast<size_t>(file_size));
+	fs.Read(*handle, (void *)content.data(), file_size);
+	return content;
+}
+
 vector<LogicalType> UnifiedASTBackend::GetFlatTableSchema() {
 	return {
 	    LogicalType::BIGINT,   // node_id
@@ -1766,12 +1798,9 @@ ASTResultCollection UnifiedASTBackend::ParseFilesToASTCollection(ClientContext &
 				continue; // Skip missing files
 			}
 
-			auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
-			auto file_size = fs.GetFileSize(*handle);
-
-			string content;
-			content.resize(file_size);
-			fs.Read(*handle, (void *)content.data(), file_size);
+			// Read file content with the default source-size cap (legacy path has
+			// no ExtractionConfig; the remaining caps apply inside ParseToASTResult)
+			string content = ReadSourceFileWithCap(fs, file_path, ExtractionConfig::DEFAULT_MAX_SOURCE_BYTES);
 
 			// Parse this file as a separate result
 			auto file_result = ParseToASTResult(content, file_language, file_path, peek_size, peek_mode);
@@ -1815,12 +1844,9 @@ unique_ptr<ASTResult> UnifiedASTBackend::ParseSingleFileToASTResult(ClientContex
 			return nullptr; // Skip missing files
 		}
 
-		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
-		auto file_size = fs.GetFileSize(*handle);
-
-		string content;
-		content.resize(file_size);
-		fs.Read(*handle, (void *)content.data(), file_size);
+		// Read file content with the default source-size cap (legacy path has
+		// no ExtractionConfig; the remaining caps apply inside ParseToASTResult)
+		string content = ReadSourceFileWithCap(fs, file_path, ExtractionConfig::DEFAULT_MAX_SOURCE_BYTES);
 
 		// Parse this file
 		auto result = make_uniq<ASTResult>(ParseToASTResult(content, file_language, file_path, peek_size, peek_mode));
@@ -1859,12 +1885,8 @@ unique_ptr<ASTResult> UnifiedASTBackend::ParseSingleFileToASTResult(ClientContex
 			return nullptr; // Skip missing files
 		}
 
-		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
-		auto file_size = fs.GetFileSize(*handle);
-
-		string content;
-		content.resize(file_size);
-		fs.Read(*handle, (void *)content.data(), file_size);
+		// Read file content, enforcing the configured source-size cap up front
+		string content = ReadSourceFileWithCap(fs, file_path, config.max_source_bytes);
 
 		// Parse this file with ExtractionConfig
 		auto result = make_uniq<ASTResult>(ParseToASTResult(content, file_language, file_path, config));

--- a/test/sql/parse_resource_caps.test
+++ b/test/sql/parse_resource_caps.test
@@ -1,0 +1,108 @@
+# name: test/sql/parse_resource_caps.test
+# description: Resource caps bound parse work (source size / timeout / node count) and surface clean errors
+# group: [sql]
+#
+# These are bounded reproductions: each over-limit input is a few KB with a
+# deliberately low cap, so the tests assert "clean DuckDB error at the
+# boundary" without ever committing an input that could hang or OOM CI.
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# ---------------------------------------------------------------------------
+# Positive: default caps must not reject reasonable inputs
+# ---------------------------------------------------------------------------
+
+query I
+SELECT count(*) > 0 FROM parse_ast('def hello(): return 42', 'python');
+----
+true
+
+query I
+SELECT count(*) > 0 FROM read_ast('test/data/python/simple.py', 'python');
+----
+true
+
+# Explicitly-set generous caps behave like defaults
+query I
+SELECT count(*) > 0 FROM parse_ast('def hello(): pass', 'python',
+    max_source_bytes := 1048576, parse_timeout_ms := 60000, max_parse_nodes := 100000);
+----
+true
+
+# ---------------------------------------------------------------------------
+# max_source_bytes: an input just over a low cap yields a clean DuckDB error
+# ---------------------------------------------------------------------------
+
+statement error
+SELECT * FROM parse_ast(repeat('y = 2' || chr(10), 500), 'python', max_source_bytes := 1024);
+----
+exceeds max_source_bytes
+
+statement error
+SELECT * FROM read_ast('test/data/python/simple.py', 'python', max_source_bytes := 16);
+----
+exceeds max_source_bytes
+
+# Under ignore_errors an over-cap file is recorded per-file and skipped cleanly
+query I
+SELECT count(*) FROM read_ast('test/data/python/simple.py', 'python',
+    max_source_bytes := 16, ignore_errors := true);
+----
+0
+
+# The cap applies to the flat alias and hierarchical variants too
+statement error
+SELECT * FROM read_ast_flat('test/data/python/simple.py', 'python', max_source_bytes := 16);
+----
+exceeds max_source_bytes
+
+statement error
+SELECT * FROM read_ast_hierarchical('test/data/python/simple.py', 'python', max_source_bytes := 16);
+----
+exceeds max_source_bytes
+
+# ---------------------------------------------------------------------------
+# max_parse_nodes: a small source with a low node cap yields a clean error
+# ---------------------------------------------------------------------------
+
+statement error
+SELECT * FROM parse_ast(repeat('x = 1' || chr(10), 200), 'python', max_parse_nodes := 50);
+----
+max_parse_nodes
+
+statement error
+SELECT * FROM read_ast('test/data/python/simple.py', 'python', max_parse_nodes := 5);
+----
+max_parse_nodes
+
+# Under ignore_errors a node-cap failure is also absorbed per-file
+query I
+SELECT count(*) FROM read_ast('test/data/python/simple.py', 'python',
+    max_parse_nodes := 5, ignore_errors := true);
+----
+0
+
+# Caps can be disabled explicitly (<= 0 disables that cap)
+query I
+SELECT count(*) > 50 FROM parse_ast(repeat('x = 1' || chr(10), 200), 'python', max_parse_nodes := 0);
+----
+true
+
+# ---------------------------------------------------------------------------
+# parse_timeout_ms: the deadline-bounded parse path parses normal input fine.
+# We intentionally do NOT commit an input that actually times out — the
+# assertion here is that the bounded-parse code path is exercised and correct.
+# ---------------------------------------------------------------------------
+
+query I
+SELECT count(*) > 0 FROM parse_ast('def f(): pass', 'python', parse_timeout_ms := 30000);
+----
+true
+
+query I
+SELECT count(*) > 0 FROM read_ast('test/data/python/simple.py', 'python', parse_timeout_ms := 30000);
+----
+true


### PR DESCRIPTION
## Summary

Adds configurable resource caps to every AST parse entry point and makes the parallel parsing path surface all failures as clean DuckDB errors. Addresses the findings tracked privately in GHSA-jg64-5v6f-8v2g (advisory to be published at release).

### 1. Resource caps (defaults on, per-input, `<= 0` disables)

| Parameter | Default | Enforced where |
|---|---|---|
| `max_source_bytes` | 50 MiB | before the content buffer is allocated (file paths) and again in the shared parse core (inline strings) |
| `parse_timeout_ms` | 30 000 ms | inside tree-sitter via the `ts_parser_parse_with_options` progress callback (the version-correct mechanism in the vendored 0.25 runtime; `ts_parser_set_timeout_micros` is deprecated) |
| `max_parse_nodes` | 10 000 000 | in the DFS node-extraction loop of `ParseToASTResultTemplated` |

Exceeding any cap raises `InvalidInputException` with a message that names the parameter to raise or disable it. Under `ignore_errors := true` an over-cap file is recorded and skipped, like any other per-file error.

**Coverage.** All parse entry points funnel through `UnifiedASTBackend::ParseToASTResultTemplated`, so the size/timeout/node caps are enforced at a single choke point and cannot be missed by a new entry point. The pre-allocation file-size check is shared via a new `ReadSourceFileWithCap()` helper used by all five file-read sites (streaming flat, streaming hierarchical, parallel task, collection, single-file x2). The caps are configurable via named parameters on `read_ast` / `read_ast_flat` / `read_ast_streaming` / `read_ast_hierarchical` / `read_ast_hierarchical_new` / `parse_ast` / `parse_ast_flat` / `parse_ast_hierarchical`; `parse_ast_list` takes no named parameters and uses the defaults.

### 2. Parallel path: no exception escapes a worker

`ASTParsingTask::ProcessSingleFile` previously caught only DuckDB `Exception`, so `std::bad_alloc` (e.g. from `content.resize(file_size)`) and other non-DuckDB failures bypassed `ignore_errors` and lost the file context. The catch now covers `Exception` (rethrown with type preserved), `std::exception` (converted to `IOException` with the file path), and `...` — matching the streaming path's behavior.

### 3. Related hardening

- `content.length()` was silently narrowed `size_t` → `uint32_t` when handed to `ts_parser_parse_string` (files > 4 GiB would partially parse). Both `TSParserWrapper::ParseString` and the legacy `ASTParser::ParseString` now reject such inputs explicitly.

## Tests (bounded reproductions)

`test/sql/parse_resource_caps.test` — every over-limit input is a few KB with a deliberately low cap, so the tests assert *clean DuckDB error at the boundary* without committing anything that could hang or OOM CI:

- low `max_source_bytes` / `max_parse_nodes` + slightly-over inputs → clean errors on `parse_ast`, `read_ast`, `read_ast_flat`, `read_ast_hierarchical`
- `ignore_errors := true` absorbs over-cap files per-file (0 rows, no query failure)
- positive controls: default caps and explicitly generous caps do not reject normal sources; the deadline-bounded parse path parses normal input correctly
- caps can be disabled with `:= 0`

These tests fail on current main (the parameters do not exist and the work is unbounded) and pass with this change.

## Calibrated claims / residual risk

- **CONFIRMED bounded (with tests):** `parse_ast*` and the `read_ast*` streaming paths (flat + hierarchical), single- and multi-file.
- **Bounded by code review only:** the parallel `ParseFilesToASTCollectionParallel` path is not currently reachable from any registered SQL function, so its cap + widened catch are exercised by compilation and review, not by a SQL test.
- **Not addressed here (known, tracked):** aggregate buffering of `per_thread_results` across many files (bounded per-file now, not per-query; related README claim tracked in #77), and there is deliberately no committed input that actually times out — a hanging input is exactly what must not land in CI.
- `parse_ast_list` converts `InvalidInputException` to a NULL row by design; a capped input yields NULL rather than a query error there.

Refs: private advisory GHSA-jg64-5v6f-8v2g (publish at release), #77 (correctness/usability items, tracked separately).
