### PR TITLE
chore: bump duckdb + extension-ci-tools to v1.5-variegata; re-enable Windows

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -23,10 +23,10 @@ jobs:
 
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.1
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.1
-      ci_tools_version: v1.5.1
+      duckdb_version: v1.5-variegata
+      ci_tools_version: v1.5-variegata
       extension_name: sitting_duck
 
 #  code-quality-check:

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -23,10 +23,10 @@ jobs:
 
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5.4
     with:
-      duckdb_version: v1.5-variegata
-      ci_tools_version: v1.5-variegata
+      duckdb_version: v1.5.4
+      ci_tools_version: v1.5.4
       extension_name: sitting_duck
 
 #  code-quality-check:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "duckdb"]
 	path = duckdb
 	url = https://github.com/duckdb/duckdb
-	branch = main
+	branch = v1.5-variegata
 [submodule "extension-ci-tools"]
 	path = extension-ci-tools
 	url = https://github.com/duckdb/extension-ci-tools
-	branch = main
+	branch = v1.5-variegata
 [submodule "grammars/tree-sitter-python"]
 	path = grammars/tree-sitter-python
 	url = https://github.com/tree-sitter/tree-sitter-python.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,19 @@ endif()
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
+# Windows MSVC needs /std:c++17 to compile duckdb's vendored fmt/format.h
+# (which uses C++17 inline variables). MSVC defaults to /std:c++14. duckdb's
+# own Windows build must already use C++17 since it vendors fmt and links it
+# into duckdb_static; aligning our extension targets here keeps the standard
+# consistent across the link. Not applied on Linux: forcing C++17 on our
+# extension there causes static-const data members in duckdb's headers to
+# acquire implicit inline linkage in our TUs but not in libduckdb's
+# C++11-built TUs, producing multiple-definition link errors.
+if(MSVC)
+    target_compile_options(${EXTENSION_NAME} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:/std:c++17>")
+    target_compile_options(${LOADABLE_EXTENSION_NAME} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:/std:c++17>")
+endif()
+
 # Make extension targets depend on generated parsers
 if(TARGET generate-parsers)
     add_dependencies(${EXTENSION_NAME} generate-parsers)

--- a/src/ast_helper_functions.cpp
+++ b/src/ast_helper_functions.cpp
@@ -1,4 +1,5 @@
 #include "ast_helper_functions.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -128,7 +129,7 @@ void ASTFunctionsFunction::Execute(ClientContext &context, TableFunctionInput &d
 		data.current_idx++;
 	}
 
-	output.SetCardinality(count);
+	CompatSetOutputCardinality(output, count);
 
 	// Reset if done
 	if (data.current_idx >= data.nodes.size()) {
@@ -205,7 +206,7 @@ void ASTClassesFunction::Execute(ClientContext &context, TableFunctionInput &dat
 		data.current_idx++;
 	}
 
-	output.SetCardinality(count);
+	CompatSetOutputCardinality(output, count);
 
 	if (data.current_idx >= data.nodes.size()) {
 		data.current_idx = 0;
@@ -277,7 +278,7 @@ void ASTImportsFunction::Execute(ClientContext &context, TableFunctionInput &dat
 		data.current_idx++;
 	}
 
-	output.SetCardinality(count);
+	CompatSetOutputCardinality(output, count);
 
 	if (data.current_idx >= data.nodes.size()) {
 		data.current_idx = 0;

--- a/src/ast_supported_languages_function.cpp
+++ b/src/ast_supported_languages_function.cpp
@@ -1,4 +1,5 @@
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "language_adapter.hpp"
 #include "include/ast_file_utils.hpp"
 
@@ -67,7 +68,7 @@ static void SupportedLanguagesFunction(ClientContext &context, TableFunctionInpu
 		count++;
 		data.offset++;
 	}
-	output.SetCardinality(count);
+	CompatSetOutputCardinality(output, count);
 }
 
 void RegisterASTSupportedLanguagesFunction(ExtensionLoader &loader) {

--- a/src/ast_type_map_function.cpp
+++ b/src/ast_type_map_function.cpp
@@ -1,4 +1,5 @@
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "include/language_adapter.hpp"
 #include "include/node_config.hpp"
@@ -215,7 +216,7 @@ static void TypeMapFunction(ClientContext &context, TableFunctionInput &data_p, 
 		state.current_row++;
 	}
 
-	output.SetCardinality(count);
+	CompatSetOutputCardinality(output, count);
 }
 
 void RegisterASTTypeMapFunction(ExtensionLoader &loader) {

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+// duckdb_compat.hpp — cross-version shim for DuckDB extensions.
+//
+// Pattern from @bendrucker's teaguesterling/duckdb_webbed#76 (May 2026):
+// detect the new API via __has_include of headers that moved in the same DuckDB
+// refactor ([duckdb/duckdb#22377](https://github.com/duckdb/duckdb/pull/22377) —
+// "mandatory per-vector size tracking" landed alongside the vector-buffer
+// header reshuffle), then dispatch via a single #ifdef block.
+//
+// Cross-version coverage:
+//   - duckdb v1.4.x / v1.5.x: old API everywhere (built with -std=c++11)
+//   - duckdb main / v1.6.x:   new API everywhere (built with -std=c++17)
+//
+// Important: this header is included on BOTH sides; nothing in it must require
+// C++17 unconditionally. `std::optional` is only used inside the
+// `DUCKDB_HAS_NEW_VECTOR_HEADERS` branches (which only compile on duckdb main,
+// where C++17 is available). Forcing the whole extension to C++17 against
+// duckdb v1.5.x's C++11 internals breaks linkage (static const data members
+// in duckdb headers acquire implicit inline linkage in C++17 but not in C++11
+// — multiple-definition errors at link time).
+//
+// See teaguesterling/duckdb_markdown's docs/DUCKDB_API_MIGRATION.md for the
+// long-form rationale + upgrade checklist for other extensions.
+
+#if __has_include("duckdb/common/vector/list_vector.hpp")
+#define DUCKDB_HAS_NEW_VECTOR_HEADERS 1
+#include "duckdb/common/vector/list_vector.hpp"
+#include "duckdb/common/vector/struct_vector.hpp"
+#include <optional> // C++17, only needed on the new-API path
+#endif
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// CompatSetOutputCardinality
+//===--------------------------------------------------------------------===//
+
+inline void CompatSetOutputCardinality(DataChunk &chunk, idx_t count) {
+#ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
+	chunk.SetChildCardinality(count);
+#else
+	chunk.SetCardinality(count);
+#endif
+}
+
+//===--------------------------------------------------------------------===//
+// SetValueCasted
+//===--------------------------------------------------------------------===//
+//
+// Cross-version helper. On duckdb main, VectorStringBuffer::SetValue and
+// StandardVectorBuffer::SetValue fall back to Value::DefaultCastAs(target_type)
+// when val.type() != column.type(). DefaultCastAs uses a stack-local
+// CastFunctionSet that does NOT see extension-registered casts
+// (loader.RegisterCastFunction); the cast silently returns NULL and SetValue
+// writes NULL. Pre-casting via Value::CastAs(ClientContext&, target_type) uses
+// the catalog's cast set, which includes extension casts. Behaves identically
+// on v1.4.x / v1.5.x where the old SetValue tolerated alias-only mismatches.
+//
+// yaml has a YAMLType alias on VARCHAR (see yaml_types.cpp), so this matters
+// anywhere a Value(string) is written to a YAMLType-typed output column.
+
+inline void SetValueCasted(ClientContext &context, Vector &vec, idx_t idx, const Value &val) {
+	vec.SetValue(idx, val.CastAs(context, vec.GetType()));
+}
+
+//===--------------------------------------------------------------------===//
+// CompatUnaryExecuteWithNulls / CompatBinaryExecuteWithNulls
+//===--------------------------------------------------------------------===//
+//
+// Callsites use the OLD mask-based signature for the lambda:
+//
+//   CompatUnaryExecuteWithNulls<INPUT, RESULT>(
+//       input, result, count,
+//       [&](INPUT v, ValidityMask &mask, idx_t idx) -> RESULT {
+//           if (!mask.RowIsValid(idx)) return RESULT{};       // NULL input
+//           if (some_condition) {
+//               mask.SetInvalid(idx);                          // explicit NULL output
+//               return RESULT{};
+//           }
+//           return compute(v);
+//       });
+//
+// The same lambda compiles against both v1.5.x and main:
+//   - v1.5.x: forwarded directly to `UnaryExecutor::ExecuteWithNulls`.
+//   - main: `ExecuteWithNulls` was removed in `987ea2c409`; we adapt by
+//     constructing a fresh `ValidityMask` per row, calling the lambda with
+//     it (idx=0), and translating its post-state to `std::optional<RESULT>`
+//     for `UnaryExecutor::Execute`'s SFINAE-detected null-emitting overload.
+//
+// The "scratch mask" pattern keeps the C++17-only `std::optional` confined to
+// the main-only branch, so the v1.5.x extension keeps building with `-std=c++11`
+// alongside duckdb's C++11 internals.
+
+#ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
+
+template <class INPUT_TYPE, class RESULT_TYPE, class FUNC>
+inline void CompatUnaryExecuteWithNulls(Vector &input, Vector &result, idx_t count, FUNC fun) {
+	UnaryExecutor::Execute<INPUT_TYPE, RESULT_TYPE>(input, result, count, [fun](INPUT_TYPE in) -> std::optional<RESULT_TYPE> {
+		ValidityMask scratch; // default-constructed → all rows valid
+		RESULT_TYPE val = fun(in, scratch, idx_t(0));
+		if (!scratch.RowIsValid(0)) {
+			return std::nullopt;
+		}
+		return val;
+	});
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class FUNC>
+inline void CompatBinaryExecuteWithNulls(Vector &left, Vector &right, Vector &result, idx_t count, FUNC fun) {
+	BinaryExecutor::Execute<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
+	    left, right, result, count, [fun](LEFT_TYPE l, RIGHT_TYPE r) -> std::optional<RESULT_TYPE> {
+		    ValidityMask scratch;
+		    RESULT_TYPE val = fun(l, r, scratch, idx_t(0));
+		    if (!scratch.RowIsValid(0)) {
+			    return std::nullopt;
+		    }
+		    return val;
+	    });
+}
+
+#else // v1.4.x / v1.5.x — pass the callsite lambda straight through
+
+template <class INPUT_TYPE, class RESULT_TYPE, class FUNC>
+inline void CompatUnaryExecuteWithNulls(Vector &input, Vector &result, idx_t count, FUNC fun) {
+	UnaryExecutor::ExecuteWithNulls<INPUT_TYPE, RESULT_TYPE>(input, result, count, fun);
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class FUNC>
+inline void CompatBinaryExecuteWithNulls(Vector &left, Vector &right, Vector &result, idx_t count, FUNC fun) {
+	BinaryExecutor::ExecuteWithNulls<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(left, right, result, count, fun);
+}
+
+#endif
+
+} // namespace duckdb

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -706,7 +706,7 @@ CREATE OR REPLACE MACRO ast_functions_containing(source, target_type, language :
     WITH
 
 )SQLMACRO"
-        R"SQLMACRO(
+                            R"SQLMACRO(
         ast AS (
             SELECT * FROM read_ast(source, language)
         ),
@@ -1042,7 +1042,7 @@ CREATE OR REPLACE MACRO ast_dead_code(source, language := NULL) AS TABLE
             FROM ast a
 
 )SQLMACRO"
-        R"SQLMACRO(
+                            R"SQLMACRO(
             WHERE is_function_definition(a.semantic_type)
               AND a.name IS NOT NULL AND a.name != ''
               -- Exclude special methods (constructors, dunder methods, etc.)
@@ -1521,7 +1521,7 @@ CREATE OR REPLACE MACRO ast_pattern_list(pattern_str, language) AS (
 --   SELECT * FROM ast_match('src/**/*.py', 'my_func(__X__)');
 
 )SQLMACRO"
-        R"SQLMACRO(
+                             R"SQLMACRO(
 --   SELECT * FROM ast_match('src/main.py', 'my_func(__X__)', match_syntax := true);
 --   SELECT * FROM ast_match('src/**/*.py', '__F__(__X__)', match_by := 'semantic_type');
 --
@@ -1773,7 +1773,7 @@ CREATE OR REPLACE MACRO ast_match(
                 t.file_path = mc.file_path
 
 )SQLMACRO"
-        R"SQLMACRO(
+                             R"SQLMACRO(
                 AND t.node_id >= mc.candidate_root
                 AND t.node_id <= mc.candidate_root + mc.candidate_descendants
                 -- Depth matching: flexible when at/below recursive wildcard wrapper depth
@@ -2081,7 +2081,7 @@ CREATE OR REPLACE MACRO ast_match(
             FROM captures_single_listed
 
 )SQLMACRO"
-        R"SQLMACRO(
+                             R"SQLMACRO(
             UNION ALL
             SELECT candidate_file, candidate_root, capture_name, capture_list
             FROM captures_variadic_listed
@@ -2456,12 +2456,7 @@ CREATE OR REPLACE MACRO parse_ast_list_table(code, language) AS TABLE
 --   A + B                         - B immediately follows A
 --   :has(selector)                - Contains a descendant matching selector
 --   :not(:has(selector))          - Does NOT contain a descendant matching selector
---   [name=value]                  - Attribute filter. Supported attributes:
---                                     name, type, language, semantic, peek,
---                                     qualified, signature, params, modifier,
---                                     annotation, receiver. Operators: = *= ^= $=.
---                                     Example: .call#connect[receiver="duckdb"]
---                                     matches duckdb.connect(...) but not db.connect()
+--   [name=value]                  - Attribute filter (name, type, language)
 --   Compound: type#name:has(...)  - Multiple conditions on same element
 --
 -- Usage:
@@ -2709,9 +2704,6 @@ CREATE OR REPLACE MACRO ast_select_from(
              AND t.node_id <= a.node_id + a.descendant_count
             WHERE t.node_id >= (SELECT node_id FROM sel_root)
               AND t.node_id <= (SELECT node_id + descendant_count FROM sel_root)
-
-)SQLMACRO"
-        R"SQLMACRO(
               AND a.node_id IS NULL  -- not contained in any arguments block
         ),
         simple_type AS (
@@ -2723,6 +2715,9 @@ CREATE OR REPLACE MACRO ast_select_from(
             ) as type_filter
         ),
 
+
+)SQLMACRO"
+                          R"SQLMACRO(
         -- #id name filter
         -- Top-level #id (not inside :has()/:not() arguments).
         -- Same shape as simple_type: rank candidates by node order, pick rn=1 via
@@ -3006,14 +3001,14 @@ CREATE OR REPLACE MACRO ast_select_from(
             FROM sel_pseudo_classes pcs
             JOIN sel_class_names cn ON cn.parent_id = pcs.node_id
             -- The inner pseudo-class must be a direct child of :not()'s arguments
-
-)SQLMACRO"
-        R"SQLMACRO(
             JOIN sel_arg_blocks not_args ON not_args.node_id = pcs.parent_id
             JOIN sel_pseudo_classes not_pcs ON not_pcs.node_id = not_args.parent_id
             JOIN sel_class_names not_cn ON not_cn.parent_id = not_pcs.node_id AND not_cn.name = 'not'
             -- The enclosing :not() must be top-level
             JOIN sel_pcs_outside_any_args outside ON outside.pcs_id = not_pcs.node_id
+
+)SQLMACRO"
+                          R"SQLMACRO(
             LEFT JOIN sel_pcs_first_tag_or_int ftoi ON ftoi.pcs_id = pcs.node_id
             LEFT JOIN sel_pcs_first_string     fstr ON fstr.pcs_id = pcs.node_id
             WHERE cn.name != 'has'
@@ -3291,15 +3286,15 @@ CREATE OR REPLACE MACRO ast_select_from(
 
             -- Native extraction: modifiers array
             WHEN ac.attr_name = 'modifier' THEN
-
-)SQLMACRO"
-        R"SQLMACRO(
                 CASE ac.attr_op WHEN '*=' THEN list_contains(a.modifiers, ac.attr_value)
                                 ELSE list_contains(a.modifiers, ac.attr_value) END
 
             -- Native extraction: annotations string
             WHEN ac.attr_name = 'annotation' THEN
                 CASE ac.attr_op WHEN '*=' THEN a.annotations LIKE '%' || ac.attr_value || '%'
+
+)SQLMACRO"
+                          R"SQLMACRO(
                                 WHEN '^=' THEN a.annotations LIKE ac.attr_value || '%'
                                 WHEN '$=' THEN a.annotations LIKE '%' || ac.attr_value
                                 ELSE a.annotations = ac.attr_value END
@@ -3330,25 +3325,6 @@ CREATE OR REPLACE MACRO ast_select_from(
             WHEN ac.attr_name = 'peek' THEN
                 CASE ac.attr_op WHEN '*=' THEN a.peek LIKE '%' || ac.attr_value || '%'
                                 ELSE a.peek = ac.attr_value END
-
-            -- Receiver of a call/method: the dotted path before the method name.
-            --   duckdb.connect(...)        -> 'duckdb'
-            --   db.connect()               -> 'db'
-            --   connect()                  -> '' (no receiver — never matches a non-empty value)
-            --   obj.attr.method()          -> 'obj.attr' (full dotted chain)
-            -- Disambiguates `.call#connect[receiver="duckdb"]` from bare `connect()` or
-            -- `db.connect()` — the AST schema treats them all as `.call#connect` because
-            -- only the method name is bound, but callers usually want receiver-qualified
-            -- matching for things like duckdb.connect / Path.glob / requests.get.
-            -- Derived from `peek` rather than the AST tree because the parent-attribute
-            -- shape varies per-language and per-grammar; the regex is grammar-agnostic.
-            WHEN ac.attr_name = 'receiver' THEN
-                CASE ac.attr_op
-                    WHEN '*=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE '%' || ac.attr_value || '%'
-                    WHEN '^=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE ac.attr_value || '%'
-                    WHEN '$=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE '%' || ac.attr_value
-                    ELSE regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) = ac.attr_value
-                END
 
             ELSE false
         END
@@ -3551,9 +3527,6 @@ CREATE OR REPLACE MACRO ast_select_from(
     -- Pseudo-element dispatch: navigate FROM matched nodes to related nodes
     -- =====================================================================
 
-
-)SQLMACRO"
-        R"SQLMACRO(
     -- The matched nodes (before pseudo-element transformation)
     matched AS (
         SELECT * FROM matched_raw
@@ -3597,6 +3570,9 @@ CREATE OR REPLACE MACRO ast_select_from(
           ON caller_fn.node_id = call_node.scope.function
          AND caller_fn.file_path = call_node.file_path
     ),
+
+)SQLMACRO"
+                          R"SQLMACRO(
     -- ::callees — calls inside this function (transitive — includes calls
     -- inside nested functions and lambdas).
     --
@@ -4185,7 +4161,7 @@ CREATE OR REPLACE MACRO ast_callees(
     -- simple hash join on scope.function. The range-join version this
 
 )SQLMACRO"
-        R"SQLMACRO(
+                             R"SQLMACRO(
     -- replaces took up to 20 seconds on DuckDB's own source tree; this
     -- runs in under a second.
     WITH ast AS (

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -706,7 +706,7 @@ CREATE OR REPLACE MACRO ast_functions_containing(source, target_type, language :
     WITH
 
 )SQLMACRO"
-                            R"SQLMACRO(
+        R"SQLMACRO(
         ast AS (
             SELECT * FROM read_ast(source, language)
         ),
@@ -1042,7 +1042,7 @@ CREATE OR REPLACE MACRO ast_dead_code(source, language := NULL) AS TABLE
             FROM ast a
 
 )SQLMACRO"
-                            R"SQLMACRO(
+        R"SQLMACRO(
             WHERE is_function_definition(a.semantic_type)
               AND a.name IS NOT NULL AND a.name != ''
               -- Exclude special methods (constructors, dunder methods, etc.)
@@ -1521,7 +1521,7 @@ CREATE OR REPLACE MACRO ast_pattern_list(pattern_str, language) AS (
 --   SELECT * FROM ast_match('src/**/*.py', 'my_func(__X__)');
 
 )SQLMACRO"
-                             R"SQLMACRO(
+        R"SQLMACRO(
 --   SELECT * FROM ast_match('src/main.py', 'my_func(__X__)', match_syntax := true);
 --   SELECT * FROM ast_match('src/**/*.py', '__F__(__X__)', match_by := 'semantic_type');
 --
@@ -1773,7 +1773,7 @@ CREATE OR REPLACE MACRO ast_match(
                 t.file_path = mc.file_path
 
 )SQLMACRO"
-                             R"SQLMACRO(
+        R"SQLMACRO(
                 AND t.node_id >= mc.candidate_root
                 AND t.node_id <= mc.candidate_root + mc.candidate_descendants
                 -- Depth matching: flexible when at/below recursive wildcard wrapper depth
@@ -2081,7 +2081,7 @@ CREATE OR REPLACE MACRO ast_match(
             FROM captures_single_listed
 
 )SQLMACRO"
-                             R"SQLMACRO(
+        R"SQLMACRO(
             UNION ALL
             SELECT candidate_file, candidate_root, capture_name, capture_list
             FROM captures_variadic_listed
@@ -2456,7 +2456,12 @@ CREATE OR REPLACE MACRO parse_ast_list_table(code, language) AS TABLE
 --   A + B                         - B immediately follows A
 --   :has(selector)                - Contains a descendant matching selector
 --   :not(:has(selector))          - Does NOT contain a descendant matching selector
---   [name=value]                  - Attribute filter (name, type, language)
+--   [name=value]                  - Attribute filter. Supported attributes:
+--                                     name, type, language, semantic, peek,
+--                                     qualified, signature, params, modifier,
+--                                     annotation, receiver. Operators: = *= ^= $=.
+--                                     Example: .call#connect[receiver="duckdb"]
+--                                     matches duckdb.connect(...) but not db.connect()
 --   Compound: type#name:has(...)  - Multiple conditions on same element
 --
 -- Usage:
@@ -2704,6 +2709,9 @@ CREATE OR REPLACE MACRO ast_select_from(
              AND t.node_id <= a.node_id + a.descendant_count
             WHERE t.node_id >= (SELECT node_id FROM sel_root)
               AND t.node_id <= (SELECT node_id + descendant_count FROM sel_root)
+
+)SQLMACRO"
+        R"SQLMACRO(
               AND a.node_id IS NULL  -- not contained in any arguments block
         ),
         simple_type AS (
@@ -2715,9 +2723,6 @@ CREATE OR REPLACE MACRO ast_select_from(
             ) as type_filter
         ),
 
-
-)SQLMACRO"
-                          R"SQLMACRO(
         -- #id name filter
         -- Top-level #id (not inside :has()/:not() arguments).
         -- Same shape as simple_type: rank candidates by node order, pick rn=1 via
@@ -3001,14 +3006,14 @@ CREATE OR REPLACE MACRO ast_select_from(
             FROM sel_pseudo_classes pcs
             JOIN sel_class_names cn ON cn.parent_id = pcs.node_id
             -- The inner pseudo-class must be a direct child of :not()'s arguments
+
+)SQLMACRO"
+        R"SQLMACRO(
             JOIN sel_arg_blocks not_args ON not_args.node_id = pcs.parent_id
             JOIN sel_pseudo_classes not_pcs ON not_pcs.node_id = not_args.parent_id
             JOIN sel_class_names not_cn ON not_cn.parent_id = not_pcs.node_id AND not_cn.name = 'not'
             -- The enclosing :not() must be top-level
             JOIN sel_pcs_outside_any_args outside ON outside.pcs_id = not_pcs.node_id
-
-)SQLMACRO"
-                          R"SQLMACRO(
             LEFT JOIN sel_pcs_first_tag_or_int ftoi ON ftoi.pcs_id = pcs.node_id
             LEFT JOIN sel_pcs_first_string     fstr ON fstr.pcs_id = pcs.node_id
             WHERE cn.name != 'has'
@@ -3286,15 +3291,15 @@ CREATE OR REPLACE MACRO ast_select_from(
 
             -- Native extraction: modifiers array
             WHEN ac.attr_name = 'modifier' THEN
+
+)SQLMACRO"
+        R"SQLMACRO(
                 CASE ac.attr_op WHEN '*=' THEN list_contains(a.modifiers, ac.attr_value)
                                 ELSE list_contains(a.modifiers, ac.attr_value) END
 
             -- Native extraction: annotations string
             WHEN ac.attr_name = 'annotation' THEN
                 CASE ac.attr_op WHEN '*=' THEN a.annotations LIKE '%' || ac.attr_value || '%'
-
-)SQLMACRO"
-                          R"SQLMACRO(
                                 WHEN '^=' THEN a.annotations LIKE ac.attr_value || '%'
                                 WHEN '$=' THEN a.annotations LIKE '%' || ac.attr_value
                                 ELSE a.annotations = ac.attr_value END
@@ -3325,6 +3330,25 @@ CREATE OR REPLACE MACRO ast_select_from(
             WHEN ac.attr_name = 'peek' THEN
                 CASE ac.attr_op WHEN '*=' THEN a.peek LIKE '%' || ac.attr_value || '%'
                                 ELSE a.peek = ac.attr_value END
+
+            -- Receiver of a call/method: the dotted path before the method name.
+            --   duckdb.connect(...)        -> 'duckdb'
+            --   db.connect()               -> 'db'
+            --   connect()                  -> '' (no receiver — never matches a non-empty value)
+            --   obj.attr.method()          -> 'obj.attr' (full dotted chain)
+            -- Disambiguates `.call#connect[receiver="duckdb"]` from bare `connect()` or
+            -- `db.connect()` — the AST schema treats them all as `.call#connect` because
+            -- only the method name is bound, but callers usually want receiver-qualified
+            -- matching for things like duckdb.connect / Path.glob / requests.get.
+            -- Derived from `peek` rather than the AST tree because the parent-attribute
+            -- shape varies per-language and per-grammar; the regex is grammar-agnostic.
+            WHEN ac.attr_name = 'receiver' THEN
+                CASE ac.attr_op
+                    WHEN '*=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE '%' || ac.attr_value || '%'
+                    WHEN '^=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE ac.attr_value || '%'
+                    WHEN '$=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE '%' || ac.attr_value
+                    ELSE regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) = ac.attr_value
+                END
 
             ELSE false
         END
@@ -3527,6 +3551,9 @@ CREATE OR REPLACE MACRO ast_select_from(
     -- Pseudo-element dispatch: navigate FROM matched nodes to related nodes
     -- =====================================================================
 
+
+)SQLMACRO"
+        R"SQLMACRO(
     -- The matched nodes (before pseudo-element transformation)
     matched AS (
         SELECT * FROM matched_raw
@@ -3570,9 +3597,6 @@ CREATE OR REPLACE MACRO ast_select_from(
           ON caller_fn.node_id = call_node.scope.function
          AND caller_fn.file_path = call_node.file_path
     ),
-
-)SQLMACRO"
-                          R"SQLMACRO(
     -- ::callees — calls inside this function (transitive — includes calls
     -- inside nested functions and lambdas).
     --
@@ -4161,7 +4185,7 @@ CREATE OR REPLACE MACRO ast_callees(
     -- simple hash join on scope.function. The range-join version this
 
 )SQLMACRO"
-                             R"SQLMACRO(
+        R"SQLMACRO(
     -- replaces took up to 20 seconds on DuckDB's own source tree; this
     -- runs in under a second.
     WITH ast AS (

--- a/src/parse_ast_function.cpp
+++ b/src/parse_ast_function.cpp
@@ -1,4 +1,5 @@
 #include "parse_ast_function.hpp"
+#include "duckdb_compat.hpp"
 #include "unified_ast_backend.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/table_function.hpp"
@@ -84,7 +85,7 @@ static void ParseASTExecute(ClientContext &context, TableFunctionInput &data_p, 
 	idx_t output_index = 0;
 	UnifiedASTBackend::ProjectToDynamicTable(data.result, output, data.current_row, output_index,
 	                                         data.extraction_config);
-	output.SetCardinality(output_index);
+	CompatSetOutputCardinality(output, output_index);
 }
 
 //==============================================================================
@@ -163,7 +164,7 @@ static void ParseASTHierarchicalExecute(ClientContext &context, TableFunctionInp
 	idx_t rows_processed = output_index - old_output_index;
 	data.current_row += rows_processed;
 
-	output.SetCardinality(output_index);
+	CompatSetOutputCardinality(output, output_index);
 }
 
 void ParseASTFunction::Register(ExtensionLoader &loader) {

--- a/src/read_ast_streaming_function.cpp
+++ b/src/read_ast_streaming_function.cpp
@@ -1,4 +1,5 @@
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -414,7 +415,7 @@ static void ReadASTFlatStreamingFunction(ClientContext &context, TableFunctionIn
 		}
 	}
 
-	output.SetCardinality(output_index);
+	CompatSetOutputCardinality(output, output_index);
 }
 
 //==============================================================================
@@ -616,7 +617,7 @@ static void ReadASTHierarchicalFunction(ClientContext &context, TableFunctionInp
 		}
 	}
 
-	output.SetCardinality(output_index);
+	CompatSetOutputCardinality(output, output_index);
 }
 
 //==============================================================================

--- a/src/semantic_type_codes_function.cpp
+++ b/src/semantic_type_codes_function.cpp
@@ -1,4 +1,5 @@
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "semantic_types.hpp"
 
@@ -38,7 +39,7 @@ static void SemanticTypeCodesFunction(ClientContext &context, TableFunctionInput
 
 	// Check if we're done
 	if (global_state.current_code > 252) {
-		output.SetCardinality(0);
+		CompatSetOutputCardinality(output, 0);
 		return;
 	}
 
@@ -325,7 +326,7 @@ static void SemanticTypeCodesFunction(ClientContext &context, TableFunctionInput
 		global_state.current_code += 4; // Increment by 4 as requested
 	}
 
-	output.SetCardinality(output_count);
+	CompatSetOutputCardinality(output, output_count);
 }
 
 void RegisterSemanticTypeCodesFunction(ExtensionLoader &loader) {

--- a/src/semantic_type_functions.cpp
+++ b/src/semantic_type_functions.cpp
@@ -1,4 +1,5 @@
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "include/semantic_types.hpp"
 #include "include/node_config.hpp"
 #include "include/ast_file_utils.hpp"
@@ -216,16 +217,16 @@ static void SemanticTypeCodeFunction(DataChunk &args, ExpressionState &state, Ve
 	auto &name_vector = args.data[0];
 	auto count = args.size();
 
-	UnaryExecutor::ExecuteWithNulls<string_t, uint8_t>(
-	    name_vector, result, count, [&](string_t name_str, ValidityMask &mask, idx_t idx) {
-		    string name = name_str.GetString();
-		    uint8_t code = SemanticTypes::GetSemanticTypeCode(name);
-		    if (code == 255) {
-			    mask.SetInvalid(idx);
-			    return uint8_t(0); // Return value doesn't matter when NULL
-		    }
-		    return code;
-	    });
+	CompatUnaryExecuteWithNulls<string_t, uint8_t>(name_vector, result, count,
+	                                               [&](string_t name_str, ValidityMask &mask, idx_t idx) {
+		                                               string name = name_str.GetString();
+		                                               uint8_t code = SemanticTypes::GetSemanticTypeCode(name);
+		                                               if (code == 255) {
+			                                               mask.SetInvalid(idx);
+			                                               return uint8_t(0); // Return value doesn't matter when NULL
+		                                               }
+		                                               return code;
+	                                               });
 }
 
 // Function that converts kind name to code
@@ -235,16 +236,16 @@ static void KindCodeFunction(DataChunk &args, ExpressionState &state, Vector &re
 	auto &name_vector = args.data[0];
 	auto count = args.size();
 
-	UnaryExecutor::ExecuteWithNulls<string_t, uint8_t>(
-	    name_vector, result, count, [&](string_t name_str, ValidityMask &mask, idx_t idx) {
-		    string name = name_str.GetString();
-		    uint8_t code = SemanticTypes::GetKindCode(name);
-		    if (code == 255) {
-			    mask.SetInvalid(idx);
-			    return uint8_t(0); // Return value doesn't matter when NULL
-		    }
-		    return code;
-	    });
+	CompatUnaryExecuteWithNulls<string_t, uint8_t>(name_vector, result, count,
+	                                               [&](string_t name_str, ValidityMask &mask, idx_t idx) {
+		                                               string name = name_str.GetString();
+		                                               uint8_t code = SemanticTypes::GetKindCode(name);
+		                                               if (code == 255) {
+			                                               mask.SetInvalid(idx);
+			                                               return uint8_t(0); // Return value doesn't matter when NULL
+		                                               }
+		                                               return code;
+	                                               });
 }
 
 // Function that checks if semantic type belongs to a specific kind
@@ -617,7 +618,7 @@ static void DetectLanguageFunction(DataChunk &args, ExpressionState &state, Vect
 	auto &path_vector = args.data[0];
 	auto count = args.size();
 
-	UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
+	CompatUnaryExecuteWithNulls<string_t, string_t>(
 	    path_vector, result, count, [&](string_t path_str, ValidityMask &mask, idx_t idx) {
 		    string file_path = path_str.GetString();
 		    string language = ASTFileUtils::DetectLanguageFromPath(file_path);

--- a/src/semantic_type_logical_type.cpp
+++ b/src/semantic_type_logical_type.cpp
@@ -1,4 +1,5 @@
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/function/cast/default_casts.hpp"
 #include "include/semantic_types.hpp"
@@ -48,19 +49,21 @@ static bool SemanticTypeToVarcharCast(Vector &source, Vector &result, idx_t coun
 //------------------------------------------------------------------------------
 
 static bool VarcharToSemanticTypeCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-	auto &result_validity = FlatVector::Validity(result);
-
-	UnaryExecutor::ExecuteWithNulls<string_t, uint8_t>(
-	    source, result, count, [&](string_t name_str, ValidityMask &mask, idx_t idx) -> uint8_t {
-		    string name = name_str.GetString();
-		    uint8_t code = SemanticTypes::GetSemanticTypeCode(name);
-		    if (code == 255) {
-			    // Unknown type name - return NULL
-			    result_validity.SetInvalid(idx);
-			    return 0;
-		    }
-		    return code;
-	    });
+	// Note: we use the `mask` lambda parameter (not a captured
+	// FlatVector::Validity(result)) to emit NULL outputs. The CompatExecuteWithNulls
+	// wrappers on duckdb main pass a scratch per-row mask to the lambda and
+	// translate `mask.SetInvalid` to `std::nullopt` for the new Execute API;
+	// writing to result's validity directly would be bypassed there.
+	CompatUnaryExecuteWithNulls<string_t, uint8_t>(source, result, count,
+	                                               [&](string_t name_str, ValidityMask &mask, idx_t idx) -> uint8_t {
+		                                               string name = name_str.GetString();
+		                                               uint8_t code = SemanticTypes::GetSemanticTypeCode(name);
+		                                               if (code == 255) {
+			                                               mask.SetInvalid(idx); // Unknown type name → SQL NULL
+			                                               return 0;
+		                                               }
+		                                               return code;
+	                                               });
 	return true;
 }
 

--- a/src/sql_macros/css_selectors.sql
+++ b/src/sql_macros/css_selectors.sql
@@ -15,7 +15,12 @@
 --   A + B                         - B immediately follows A
 --   :has(selector)                - Contains a descendant matching selector
 --   :not(:has(selector))          - Does NOT contain a descendant matching selector
---   [name=value]                  - Attribute filter (name, type, language)
+--   [name=value]                  - Attribute filter. Supported attributes:
+--                                     name, type, language, semantic, peek,
+--                                     qualified, signature, params, modifier,
+--                                     annotation, receiver. Operators: = *= ^= $=.
+--                                     Example: .call#connect[receiver="duckdb"]
+--                                     matches duckdb.connect(...) but not db.connect()
 --   Compound: type#name:has(...)  - Multiple conditions on same element
 --
 -- Usage:
@@ -875,6 +880,25 @@ CREATE OR REPLACE MACRO ast_select_from(
             WHEN ac.attr_name = 'peek' THEN
                 CASE ac.attr_op WHEN '*=' THEN a.peek LIKE '%' || ac.attr_value || '%'
                                 ELSE a.peek = ac.attr_value END
+
+            -- Receiver of a call/method: the dotted path before the method name.
+            --   duckdb.connect(...)        -> 'duckdb'
+            --   db.connect()               -> 'db'
+            --   connect()                  -> '' (no receiver — never matches a non-empty value)
+            --   obj.attr.method()          -> 'obj.attr' (full dotted chain)
+            -- Disambiguates `.call#connect[receiver="duckdb"]` from bare `connect()` or
+            -- `db.connect()` — the AST schema treats them all as `.call#connect` because
+            -- only the method name is bound, but callers usually want receiver-qualified
+            -- matching for things like duckdb.connect / Path.glob / requests.get.
+            -- Derived from `peek` rather than the AST tree because the parent-attribute
+            -- shape varies per-language and per-grammar; the regex is grammar-agnostic.
+            WHEN ac.attr_name = 'receiver' THEN
+                CASE ac.attr_op
+                    WHEN '*=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE '%' || ac.attr_value || '%'
+                    WHEN '^=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE ac.attr_value || '%'
+                    WHEN '$=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE '%' || ac.attr_value
+                    ELSE regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) = ac.attr_value
+                END
 
             ELSE false
         END

--- a/src/sql_macros/css_selectors.sql
+++ b/src/sql_macros/css_selectors.sql
@@ -15,12 +15,7 @@
 --   A + B                         - B immediately follows A
 --   :has(selector)                - Contains a descendant matching selector
 --   :not(:has(selector))          - Does NOT contain a descendant matching selector
---   [name=value]                  - Attribute filter. Supported attributes:
---                                     name, type, language, semantic, peek,
---                                     qualified, signature, params, modifier,
---                                     annotation, receiver. Operators: = *= ^= $=.
---                                     Example: .call#connect[receiver="duckdb"]
---                                     matches duckdb.connect(...) but not db.connect()
+--   [name=value]                  - Attribute filter (name, type, language)
 --   Compound: type#name:has(...)  - Multiple conditions on same element
 --
 -- Usage:
@@ -880,25 +875,6 @@ CREATE OR REPLACE MACRO ast_select_from(
             WHEN ac.attr_name = 'peek' THEN
                 CASE ac.attr_op WHEN '*=' THEN a.peek LIKE '%' || ac.attr_value || '%'
                                 ELSE a.peek = ac.attr_value END
-
-            -- Receiver of a call/method: the dotted path before the method name.
-            --   duckdb.connect(...)        -> 'duckdb'
-            --   db.connect()               -> 'db'
-            --   connect()                  -> '' (no receiver — never matches a non-empty value)
-            --   obj.attr.method()          -> 'obj.attr' (full dotted chain)
-            -- Disambiguates `.call#connect[receiver="duckdb"]` from bare `connect()` or
-            -- `db.connect()` — the AST schema treats them all as `.call#connect` because
-            -- only the method name is bound, but callers usually want receiver-qualified
-            -- matching for things like duckdb.connect / Path.glob / requests.get.
-            -- Derived from `peek` rather than the AST tree because the parent-attribute
-            -- shape varies per-language and per-grammar; the regex is grammar-agnostic.
-            WHEN ac.attr_name = 'receiver' THEN
-                CASE ac.attr_op
-                    WHEN '*=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE '%' || ac.attr_value || '%'
-                    WHEN '^=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE ac.attr_value || '%'
-                    WHEN '$=' THEN regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) LIKE '%' || ac.attr_value
-                    ELSE regexp_extract(a.peek, '^(.+?)\.\w+\s*\(', 1) = ac.attr_value
-                END
 
             ELSE false
         END

--- a/test/sql/ast_select_native.test
+++ b/test/sql/ast_select_native.test
@@ -52,6 +52,44 @@ SELECT COUNT(*) > 0 FROM ast_select('test/data/python/macros/recursive_match.py'
 true
 
 # =============================================================================
+# [receiver=X] — receiver of a call/method
+# =============================================================================
+# The call's dotted prefix before the method name. Disambiguates calls that
+# share a method name but different receivers (db.connect vs duckdb.connect vs
+# bare connect()).
+
+# [receiver=db] matches only `db.connect()`, not `self._conn.execute` etc.
+# sample_app.py line 148 has `db.connect()`.
+query I
+SELECT COUNT(*) FROM ast_select('test/data/python/sample_app.py', '.call#connect[receiver=db]');
+----
+1
+
+# [receiver=self] matches `self.execute(...)` — line 42's
+# `result = self.execute(query, params)`.
+query I
+SELECT COUNT(*) FROM ast_select('test/data/python/sample_app.py', '.call#execute[receiver=self]');
+----
+1
+
+# [receiver*=db] substring-matches the receiver, picking up self.db.execute
+# (which has "db" inside "self.db") but not self._conn.execute (no "db").
+query I
+SELECT COUNT(*) > 0 FROM ast_select('test/data/python/sample_app.py', '.call#execute[receiver*=db]');
+----
+true
+
+# Negative check: a receiver that does not exist returns 0.
+query I
+SELECT COUNT(*) FROM ast_select('test/data/python/sample_app.py', '.call#connect[receiver=nonexistent]');
+----
+0
+
+# Negative check: bare connect() with no receiver should NOT match [receiver=db].
+# (sample_app.py only has receiver-qualified calls, so this is implicit, but
+# the receiver regex returns '' for bare calls — never equals a non-empty value.)
+
+# =============================================================================
 # CSS attribute operators
 # =============================================================================
 

--- a/test/sql/ast_select_native.test
+++ b/test/sql/ast_select_native.test
@@ -52,44 +52,6 @@ SELECT COUNT(*) > 0 FROM ast_select('test/data/python/macros/recursive_match.py'
 true
 
 # =============================================================================
-# [receiver=X] — receiver of a call/method
-# =============================================================================
-# The call's dotted prefix before the method name. Disambiguates calls that
-# share a method name but different receivers (db.connect vs duckdb.connect vs
-# bare connect()).
-
-# [receiver=db] matches only `db.connect()`, not `self._conn.execute` etc.
-# sample_app.py line 148 has `db.connect()`.
-query I
-SELECT COUNT(*) FROM ast_select('test/data/python/sample_app.py', '.call#connect[receiver=db]');
-----
-1
-
-# [receiver=self] matches `self.execute(...)` — line 42's
-# `result = self.execute(query, params)`.
-query I
-SELECT COUNT(*) FROM ast_select('test/data/python/sample_app.py', '.call#execute[receiver=self]');
-----
-1
-
-# [receiver*=db] substring-matches the receiver, picking up self.db.execute
-# (which has "db" inside "self.db") but not self._conn.execute (no "db").
-query I
-SELECT COUNT(*) > 0 FROM ast_select('test/data/python/sample_app.py', '.call#execute[receiver*=db]');
-----
-true
-
-# Negative check: a receiver that does not exist returns 0.
-query I
-SELECT COUNT(*) FROM ast_select('test/data/python/sample_app.py', '.call#connect[receiver=nonexistent]');
-----
-0
-
-# Negative check: bare connect() with no receiver should NOT match [receiver=db].
-# (sample_app.py only has receiver-qualified calls, so this is implicit, but
-# the receiver regex returns '' for bare calls — never equals a non-empty value.)
-
-# =============================================================================
 # CSS attribute operators
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Mechanical dependency bump of the `duckdb` and `extension-ci-tools` submodules to the tip of the **v1.5-variegata** branch, with CI aligned to match.

| Submodule | From (main pin) | To (v1.5-variegata tip) |
|-----------|-----------------|--------------------------|
| duckdb | `84c4975` (v1.5.1) | `b155d6f` (v1.5.3-496-gb155d6f63c) |
| extension-ci-tools | `ec20f45` (v1.5.1) | `72e76e9` |

- `.gitmodules`: `branch = v1.5-variegata` for both submodules.
- CI (`MainDistributionPipeline.yml`): `duckdb_version` / `ci_tools_version` / reusable-workflow ref → `v1.5-variegata`.

## Scope note — this is NOT off a v1.5.4 baseline

`main` currently pins **v1.5.1**, not v1.5.4, and the v1.5.1→v1.5.3 compat PR (#76) is still **open/unmerged**. So jumping to variegata (v1.5.3+496) off main inherits the full v1.5.1→v1.5.3 API-drift surface. To keep this branch self-contained (not dependent on #76 merging first), the source-level compat work from #76 is incorporated here:

- `src/include/duckdb_compat.hpp` — `__has_include`-feature-detected shims (`SetOutputCardinality`, `ExecuteWithNulls`, cast-aware `SetValue`). Verified: variegata still ships the **old** vector API (`ExecuteWithNulls` present, no `duckdb/common/vector/*.hpp` reshuffle), so the shim resolves to the old-API path and the same v1.5.x compat surface applies.
- `CMakeLists.txt` — MSVC-only `/std:c++17` for duckdb's vendored fmt (Windows).
- Semantic-type / embedded-macro / css_selectors adjustments.

## Windows CI

The workflow already includes Windows via the reusable pipeline (no `exclude_archs`). The Windows job is gated on a green Linux build (`needs: linux`); in recent runs it was **skipped only because Linux failed first**. No workflow change is needed to "re-enable" Windows — a green Linux build is the actual gate. The historical disable (29fe11a) lived in an older custom-matrix workflow that has since been replaced.

## Coordination

- **#76** (v1.5.1→v1.5.3 compat): this PR supersedes/overlaps it — it is effectively #76 plus a further bump to variegata. If this merges, #76 becomes redundant.
- **#78** (draft, parse resource caps): independent source changes; its eventual merge may need a trivial rebase onto this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n