### PR TITLE
fix: from-source dev builds fail to LOAD — remove core_functions deps from macro registration (#82)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -32,6 +32,39 @@ jobs:
             exit 1
           fi
 
+  # Guard for issue #82: a from-source dev build (no OVERRIDE_GIT_DESCRIBE)
+  # must produce an extension that LOADs in the bundled dev shell. During
+  # sitting_duck's LoadInternal, core_functions is NOT available: sitting_duck
+  # is loaded first at startup (extension_config.cmake order), and the
+  # best-effort autoload resolves ~/.duckdb/extensions/<version stamp>/... —
+  # empty on a fresh runner, and nonexistent for dev-stamped builds on dev
+  # machines. Anything that binds at CREATE MACRO time (scalar macro bodies;
+  # e.g. bitwise `&`/`|`/`<<`, or the `list()` aggregate, all core_functions-
+  # only on DuckDB v1.5+) aborts registration and makes LOAD fail. Table-macro
+  # bodies bind at use time, when core_functions is available in any practical
+  # shell. This job proves the README "test it works" one-liner holds for
+  # exactly such a build.
+  from-source-load:
+    name: From-source dev build LOADs without core_functions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install ninja
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+      - name: Build release WITHOUT OVERRIDE_GIT_DESCRIBE
+        run: GEN=ninja make release
+      - name: LOAD the extension in the bundled dev shell (README one-liner)
+        run: |
+          ./build/release/duckdb -c "LOAD './build/release/extension/sitting_duck/sitting_duck.duckdb_extension'; SELECT COUNT(*) FROM read_ast('README.md');"
+      - name: Confirm core_functions was not needed (bitwise ops absent or autoloaded later)
+        run: |
+          # The dev shell auto-loads sitting_duck at startup; if macro
+          # registration needed core_functions this command would have failed
+          # before -c even ran. Record what the shell reports for diagnosis.
+          ./build/release/duckdb -c "SELECT extension_name, loaded FROM duckdb_extensions() WHERE extension_name IN ('sitting_duck','core_functions');"
+
   duckdb-next-build:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -1303,9 +1303,14 @@ CREATE OR REPLACE MACRO wildcard_capture_name(name) AS
 
 -- Mask off language-specific bits (0-1) for cross-language semantic type comparison
 -- Semantic type layout: [ ss kk tt ll ] where ll = language-specific bits
--- 0xFC = 11111100 masks off the last 2 bits
+-- Clearing the low 2 bits == flooring to a multiple of 4: (x // 4) * 4 equals
+-- x & 0xFC for the whole UTINYINT domain (0-255).
+-- Deliberately arithmetic, NOT bitwise: on DuckDB v1.5+ `&` lives in the
+-- core_functions extension, which is not loaded while sitting_duck registers
+-- its embedded macros in a from-source dev shell — a `&` here makes the
+-- extension fail to LOAD (issue #82).
 CREATE OR REPLACE MACRO semantic_type_base(sem_type) AS
-    (sem_type::INTEGER & 252)::UTINYINT;
+    ((sem_type::INTEGER // 4) * 4)::UTINYINT;
 
 -- =============================================================================
 -- Extended Wildcard Preprocessor
@@ -1359,30 +1364,14 @@ CREATE OR REPLACE MACRO parse_html_wildcard(html_str) AS {
 -- Legacy Syntax Support
 -- =============================================================================
 
--- Extract rules from legacy %__NAME<rules>__% syntax
-CREATE OR REPLACE MACRO extract_wildcard_rules(pattern_str) AS (
-    WITH
-    matches AS (
-        SELECT regexp_extract_all(pattern_str, '%__([A-Z][A-Z0-9_]*)?<([^>]+)>__%') as all_matches
-    ),
-    unnested AS (
-        SELECT unnest(all_matches) as match_text FROM matches
-    )
-    SELECT list({
-        name: NULLIF(regexp_extract(match_text, '%__([A-Z][A-Z0-9_]*)?<', 1), ''),
-        rules_raw: regexp_extract(match_text, '<([^>]+)>', 1),
-        is_variadic: regexp_extract(match_text, '<([^>]+)>', 1) LIKE '%*%'
-                  OR regexp_extract(match_text, '<([^>]+)>', 1) LIKE '%+%',
-        variadic_min: CASE
-            WHEN regexp_extract(match_text, '<([^>]+)>', 1) LIKE '%+%' THEN 1
-            WHEN regexp_extract(match_text, '<([^>]+)>', 1) LIKE '%*%' THEN 0
-            ELSE NULL
-        END,
-        type_constraint: regexp_extract(match_text, 'type=([a-z_]+)', 1)
-    }) as wildcards
-    FROM unnested
-    WHERE match_text IS NOT NULL AND match_text != ''
-);
+-- NOTE (issue #82): the former helper macros extract_wildcard_rules() and
+-- get_variadic_names() were removed here. They were unused (no callers in any
+-- SQL macro, C++ code, test, or doc — the parse_pattern pipeline does its
+-- variadic/recursive detection inline via pattern_has_variadic(),
+-- pattern_has_recursive() and position() checks below), and their `list()`
+-- aggregate is core_functions-only on DuckDB v1.5+, which made scalar-macro
+-- registration — and therefore LOAD of the whole extension — fail in a
+-- from-source dev shell where core_functions is not yet loaded.
 
 -- =============================================================================
 -- Pattern Cleaning (handles both syntaxes)
@@ -1422,16 +1411,6 @@ CREATE OR REPLACE MACRO pattern_has_recursive(pattern_str) AS
     regexp_matches(pattern_str, '%__[A-Z]*<\*\*>__%')
     -- HTML syntax: ** as modifier inside %__<...>__%
     OR regexp_matches(pattern_str, '%__<[A-Z_]*\*\*[^*>]*>__%');
-
--- Get list of variadic wildcard names
-CREATE OR REPLACE MACRO get_variadic_names(pattern_str) AS (
-    SELECT COALESCE(
-        (SELECT list(w.name)
-         FROM (SELECT unnest(extract_wildcard_rules(pattern_str)) as w)
-         WHERE w.is_variadic),
-        []::VARCHAR[]
-    )
-);
 
 -- =============================================================================
 -- Pattern Parsing (Table Macro - for inspection)
@@ -1519,9 +1498,6 @@ CREATE OR REPLACE MACRO ast_pattern_list(pattern_str, language) AS (
 -- Find AST nodes matching a pattern
 -- Usage:
 --   SELECT * FROM ast_match('src/**/*.py', 'my_func(__X__)');
-
-)SQLMACRO"
-        R"SQLMACRO(
 --   SELECT * FROM ast_match('src/main.py', 'my_func(__X__)', match_syntax := true);
 --   SELECT * FROM ast_match('src/**/*.py', '__F__(__X__)', match_by := 'semantic_type');
 --
@@ -1529,6 +1505,9 @@ CREATE OR REPLACE MACRO ast_pattern_list(pattern_str, language) AS (
 --   source       - File path or glob pattern to parse
 --   pattern_str  - Code pattern with __WILDCARDS__ (e.g., 'my_func(__X__)')
 --   language     - Language for parsing source and pattern (default: 'python')
+
+)SQLMACRO"
+        R"SQLMACRO(
 --   match_syntax - If true, punctuation must match exactly (default: false)
 --   match_by     - 'type' for tree-sitter types, 'semantic_type' for cross-language (default: 'type')
 --
@@ -1771,15 +1750,15 @@ CREATE OR REPLACE MACRO ast_match(
             CROSS JOIN pattern p
             JOIN ast t ON
                 t.file_path = mc.file_path
-
-)SQLMACRO"
-        R"SQLMACRO(
                 AND t.node_id >= mc.candidate_root
                 AND t.node_id <= mc.candidate_root + mc.candidate_descendants
                 -- Depth matching: flexible when at/below recursive wildcard wrapper depth
                 AND CASE
                     WHEN p.pattern_has_recursive
                          AND p.rel_depth >= (SELECT depth FROM recursive_threshold)
+
+)SQLMACRO"
+        R"SQLMACRO(
                     THEN (t.depth::INTEGER - mc.candidate_depth::INTEGER) >= p.rel_depth::INTEGER
                     ELSE ABS((t.depth::INTEGER - mc.candidate_depth::INTEGER) - p.rel_depth::INTEGER) <= depth_fuzz
                 END
@@ -2079,9 +2058,6 @@ CREATE OR REPLACE MACRO ast_match(
         captures_all AS (
             SELECT candidate_file, candidate_root, capture_name, capture_list
             FROM captures_single_listed
-
-)SQLMACRO"
-        R"SQLMACRO(
             UNION ALL
             SELECT candidate_file, candidate_root, capture_name, capture_list
             FROM captures_variadic_listed
@@ -2090,6 +2066,9 @@ CREATE OR REPLACE MACRO ast_match(
             FROM captures_variadic_empty
             UNION ALL
             SELECT candidate_file, candidate_root, capture_name, capture_list
+
+)SQLMACRO"
+        R"SQLMACRO(
             FROM captures_recursive_listed
             UNION ALL
             SELECT candidate_file, candidate_root, capture_name, capture_list

--- a/src/sitting_duck_extension.cpp
+++ b/src/sitting_duck_extension.cpp
@@ -42,20 +42,18 @@ static void PragmaEnableDynamicPredicates(ClientContext &context, const Function
 }
 
 static void LoadInternal(ExtensionLoader &loader) {
-	// Force-load core_functions before we register our SQL macros. In
-	// DuckDB v1.5+ the bitwise operators (`&`, `|`, `<<`, etc.) live in
-	// core_functions, and pattern_matching.sql uses `&` when comparing
-	// masked-off semantic type bits. If core_functions isn't loaded yet
-	// the macro registration fails at parse time with
-	//   Catalog Error: Scalar Function with name "&" is not in the catalog,
-	//     but it exists in the core_functions extension.
-	//
-	// NOTE: this call alone is not yet sufficient to make `LOAD sitting_duck`
-	// work on a vanilla CLI without `LOAD core_functions` first — deferred
-	// investigation. Kept in place as the starting point for the follow-up.
+	// Best-effort load of core_functions for the user's convenience (bitwise
+	// operators etc. in DuckDB v1.5+ live there). Our own embedded SQL macros
+	// deliberately do NOT depend on it (issue #82): this call resolves
+	// core_functions from ~/.duckdb/extensions/<version>/<platform>/, which
+	// only works when the running version stamp matches an installed release
+	// (e.g. a clean-tag or OVERRIDE_GIT_DESCRIBE build). In a from-source dev
+	// build the stamp is a git-describe string (or the v0.0.1 shallow-clone
+	// fallback), no such directory exists, and this call silently no-ops —
+	// so anything registered in LoadInternal must use always-available
+	// functions only. CI enforces that via the from-source-load job.
 	// TryAutoLoadAvailableExtension is noexcept and doesn't respect the user's
-	// autoload_known_extensions setting (unlike TryAutoLoadExtension), so it's
-	// the right API shape even if more plumbing is still needed.
+	// autoload_known_extensions setting (unlike TryAutoLoadExtension).
 	ExtensionHelper::TryAutoLoadAvailableExtension(loader.GetDatabaseInstance(), "core_functions");
 
 	// Register SEMANTIC_TYPE logical type and its cast functions (must be first)

--- a/src/sql_macros/pattern_matching.sql
+++ b/src/sql_macros/pattern_matching.sql
@@ -74,9 +74,14 @@ CREATE OR REPLACE MACRO wildcard_capture_name(name) AS
 
 -- Mask off language-specific bits (0-1) for cross-language semantic type comparison
 -- Semantic type layout: [ ss kk tt ll ] where ll = language-specific bits
--- 0xFC = 11111100 masks off the last 2 bits
+-- Clearing the low 2 bits == flooring to a multiple of 4: (x // 4) * 4 equals
+-- x & 0xFC for the whole UTINYINT domain (0-255).
+-- Deliberately arithmetic, NOT bitwise: on DuckDB v1.5+ `&` lives in the
+-- core_functions extension, which is not loaded while sitting_duck registers
+-- its embedded macros in a from-source dev shell — a `&` here makes the
+-- extension fail to LOAD (issue #82).
 CREATE OR REPLACE MACRO semantic_type_base(sem_type) AS
-    (sem_type::INTEGER & 252)::UTINYINT;
+    ((sem_type::INTEGER // 4) * 4)::UTINYINT;
 
 -- =============================================================================
 -- Extended Wildcard Preprocessor
@@ -130,30 +135,14 @@ CREATE OR REPLACE MACRO parse_html_wildcard(html_str) AS {
 -- Legacy Syntax Support
 -- =============================================================================
 
--- Extract rules from legacy %__NAME<rules>__% syntax
-CREATE OR REPLACE MACRO extract_wildcard_rules(pattern_str) AS (
-    WITH
-    matches AS (
-        SELECT regexp_extract_all(pattern_str, '%__([A-Z][A-Z0-9_]*)?<([^>]+)>__%') as all_matches
-    ),
-    unnested AS (
-        SELECT unnest(all_matches) as match_text FROM matches
-    )
-    SELECT list({
-        name: NULLIF(regexp_extract(match_text, '%__([A-Z][A-Z0-9_]*)?<', 1), ''),
-        rules_raw: regexp_extract(match_text, '<([^>]+)>', 1),
-        is_variadic: regexp_extract(match_text, '<([^>]+)>', 1) LIKE '%*%'
-                  OR regexp_extract(match_text, '<([^>]+)>', 1) LIKE '%+%',
-        variadic_min: CASE
-            WHEN regexp_extract(match_text, '<([^>]+)>', 1) LIKE '%+%' THEN 1
-            WHEN regexp_extract(match_text, '<([^>]+)>', 1) LIKE '%*%' THEN 0
-            ELSE NULL
-        END,
-        type_constraint: regexp_extract(match_text, 'type=([a-z_]+)', 1)
-    }) as wildcards
-    FROM unnested
-    WHERE match_text IS NOT NULL AND match_text != ''
-);
+-- NOTE (issue #82): the former helper macros extract_wildcard_rules() and
+-- get_variadic_names() were removed here. They were unused (no callers in any
+-- SQL macro, C++ code, test, or doc — the parse_pattern pipeline does its
+-- variadic/recursive detection inline via pattern_has_variadic(),
+-- pattern_has_recursive() and position() checks below), and their `list()`
+-- aggregate is core_functions-only on DuckDB v1.5+, which made scalar-macro
+-- registration — and therefore LOAD of the whole extension — fail in a
+-- from-source dev shell where core_functions is not yet loaded.
 
 -- =============================================================================
 -- Pattern Cleaning (handles both syntaxes)
@@ -193,16 +182,6 @@ CREATE OR REPLACE MACRO pattern_has_recursive(pattern_str) AS
     regexp_matches(pattern_str, '%__[A-Z]*<\*\*>__%')
     -- HTML syntax: ** as modifier inside %__<...>__%
     OR regexp_matches(pattern_str, '%__<[A-Z_]*\*\*[^*>]*>__%');
-
--- Get list of variadic wildcard names
-CREATE OR REPLACE MACRO get_variadic_names(pattern_str) AS (
-    SELECT COALESCE(
-        (SELECT list(w.name)
-         FROM (SELECT unnest(extract_wildcard_rules(pattern_str)) as w)
-         WHERE w.is_variadic),
-        []::VARCHAR[]
-    )
-);
 
 -- =============================================================================
 -- Pattern Parsing (Table Macro - for inspection)

--- a/test/sql/semantic_type_base.test
+++ b/test/sql/semantic_type_base.test
@@ -1,0 +1,47 @@
+# name: test/sql/semantic_type_base.test
+# group: [sql]
+
+# Row-pinned semantics for semantic_type_base() (issue #82).
+#
+# semantic_type_base must clear the low two (language-specific) bits of a
+# semantic type — the same result as `sem_type & 0xFC` — but the macro itself
+# MUST NOT use bitwise operators: on DuckDB v1.5+ `&`/`|`/`~`/`<<`/`>>` live in
+# the core_functions extension, which is not loaded while sitting_duck registers
+# its embedded SQL macros in a from-source dev shell (sitting_duck is loaded
+# first at startup, and a dev-stamped build cannot autoload core_functions from
+# the extension directory). A bitwise operator in any embedded macro therefore
+# makes the extension fail to LOAD.
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# Pinned flag values across the UTINYINT domain edges and a mixed-bit value.
+# Layout: [ss kk tt ll] where ll = language-specific bits 0-1.
+query IIIIIIII
+SELECT semantic_type_base(0::UTINYINT),
+       semantic_type_base(1::UTINYINT),
+       semantic_type_base(3::UTINYINT),
+       semantic_type_base(4::UTINYINT),
+       semantic_type_base(115::UTINYINT),
+       semantic_type_base(252::UTINYINT),
+       semantic_type_base(253::UTINYINT),
+       semantic_type_base(255::UTINYINT);
+----
+0	0	0	4	112	252	252	252
+
+# Return type is unchanged by the arithmetic rewrite.
+query I
+SELECT typeof(semantic_type_base(255::UTINYINT));
+----
+UTINYINT
+
+# Exhaustive equivalence with the original bitwise definition over the whole
+# UTINYINT domain. (`&` is available here because the test harness links
+# core_functions; the macro definition itself must not rely on it.)
+query I
+SELECT count(*) FROM range(256) t(x)
+WHERE semantic_type_base(x::UTINYINT) IS DISTINCT FROM ((x & 252)::UTINYINT);
+----
+0


### PR DESCRIPTION
Fixes the from-source LOAD failure in #82 (do not auto-close until merged — closes #82 on merge).

## Root cause — confirmed mechanism

#82's hypothesis (autoload availability tied to the duckdb version stamp) is confirmed, with the precise chain:

1. The bundled dev shell statically links **sitting_duck first, core_functions second** (`extension_config.cmake` order), so `LoadInternal` runs before core_functions exists in the catalog.
2. `LoadInternal` calls `ExtensionHelper::TryAutoLoadAvailableExtension(db, "core_functions")` → `LoadExternalExtension`, which resolves `~/.duckdb/extensions/<version stamp>/<platform>/core_functions.duckdb_extension` (`duckdb/src/main/extension/extension_helper.cpp:257`). The version stamp is the duckdb submodule's `git describe`.
   - Clean-tag pins (v1.5.3) or `OVERRIDE_GIT_DESCRIBE=v1.5.4` → stamp matches a directory populated by official-release `INSTALL`s on the dev machine, metadata version-matches → core_functions loads → macros register. This is exactly why the v1.5.3-tag build in #82 "worked" (`~/.duckdb/extensions/v1.5.3/linux_amd64/core_functions.duckdb_extension` exists locally).
   - Dev stamps (`v1.5.4-154-g…`, or the `v0.0.1` shallow-clone fallback) → no such directory → the `noexcept` call silently no-ops → registration proceeds without core_functions.
3. Scalar-macro bodies **bind at CREATE time** (only `PARAMETER_NOT_RESOLVED` errors are tolerated — `bind_create.cpp`), so any core_functions-only name in a scalar macro aborts registration and kills the shell at startup. Table-macro bodies bind at use time, when core_functions is loaded in every practical shell (statically, right after sitting_duck).
4. CI never caught it because the sqllogictest harness loads sitting_duck via `require` after core_functions is already up.

The fix **removes the registration-time dependency** rather than fixing autoload: rebuilt without `OVERRIDE_GIT_DESCRIBE`, the autoload call still no-ops (stamp `v0.0.1` here, `duckdb_extensions()` shows core_functions `STATICALLY_LINKED`, not directory-loaded), yet LOAD now succeeds.

## Registration-time offenders (complete list, found empirically)

A temporary continue-on-error probe over all 9 embedded macro files surfaced every failure at once:

- `semantic_type_base()` — `sem_type::INTEGER & 252` (pattern_matching.sql:79). **The only bitwise operator in any macro** (`|`, `~`, `xor`, `<<`, `>>` appear only inside string literals/regexes/comments). Rewritten as `((sem_type::INTEGER // 4) * 4)::UTINYINT` — clearing the low 2 bits == flooring to a multiple of 4, identical to `& 0xFC` over the whole UTINYINT domain (exhaustive 0–255 equivalence + row-pinned values + `typeof` pinned in `test/sql/semantic_type_base.test`; all six call sites only compare base values for equality).
- `extract_wildcard_rules()` / `get_variadic_names()` — used the core_functions `list()` aggregate and were **entirely unused** (no callers in any SQL macro, C++, test, or doc; `parse_pattern` does variadic/recursive detection inline via `pattern_has_variadic()`/`position()`). Removed.

Other core_functions-only names in the macros (`string_agg`, `printf`, `format`, `generate_series`, `list_transform`, `list_aggregate`, `map_from_entries`, `list(...)` in table macros) either sit in table macros or in scalar macros whose binding aborts early on an unresolved parameter — none block registration, and all work at use time since core_functions loads immediately after sitting_duck.

## Before / after (identical config: `GEN=ninja make release`, no `OVERRIDE_GIT_DESCRIBE`)

Before (origin/main):
```
$ ./build/release/duckdb -c "LOAD './build/release/extension/sitting_duck/sitting_duck.duckdb_extension'; SELECT COUNT(*) FROM read_ast('README.md');"
Invalid Input Error: Failed to register macro from pattern_matching.sql (statement 3/13): ...
Error: Catalog Error: Scalar Function with name "&" is not in the catalog, but it exists in the core_functions extension.
# even `SELECT version()` fails — the shell is unusable
```

After (this branch):
```
$ ./build/release/duckdb -c "LOAD '...sitting_duck.duckdb_extension'; SELECT COUNT(*) FROM read_ast('README.md');"
count_star() = 4600
$ SELECT 5 & 3;            -- works (core_functions statically loaded after sitting_duck)
$ ast_definitions / ast_select / ast_match smoke queries all pass in the dev shell
```

The README "test it works" one-liner is now true for dev builds as written (no doc change needed; no OVERRIDE workaround was documented).

## Regression guard

New `from-source-load` CI job in `MainDistributionPipeline.yml` (style follows `embedded-header-sync`): checkout with submodules, `GEN=ninja make release` **without** `OVERRIDE_GIT_DESCRIBE`, then run the README one-liner. On a fresh runner `~/.duckdb/extensions` is empty, so core_functions can never be directory-autoloaded during registration — exactly the #82 failing condition, permanently.

## Tests

- Full release suite: **110/110 test cases, 6148 assertions, all passing** (includes new `test/sql/semantic_type_base.test`).
- `embedded_sql_macros.hpp` regenerated and committed (embed script idempotent; `embedded-header-sync` will pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mKzPp2FxHQaP3djX597C6