### PR TITLE
Uniform #name binding on call nodes + can't-answer selector guards (#88, #89)

### DIFF
--- a/docs/reference/css-attributes.md
+++ b/docs/reference/css-attributes.md
@@ -11,6 +11,13 @@ Use `[attr operator value]` syntax to query AST nodes by their metadata fields. 
 | `^=` | Starts with | `[name^=test_]` |
 | `$=` | Ends with | `[name$=_handler]` |
 
+Not every operator applies to every attribute: the text attributes (`name`,
+`annotation`, `qualified`, `signature`, `peek`) support all four;
+`type`/`language`/`semantic`/`params` support `=` only; `modifier` supports
+`=` and `*=` (both mean "has this modifier" — modifiers is a list). An
+unsupported combination (or an unknown attribute name) raises an error rather
+than silently returning wrong or empty results (issue #89).
+
 ## Core Attributes
 
 These correspond to columns in the `read_ast()` output.

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -2459,7 +2459,15 @@ CREATE OR REPLACE MACRO parse_ast_list_table(code, language) AS TABLE
 --   [name=value]                  - Attribute filter. Supported attributes:
 --                                     name, type, language, semantic, peek,
 --                                     qualified, signature, params, modifier,
---                                     annotation. Operators: = *= ^= $=.
+--                                     annotation.
+--                                     Operators = *= ^= $= are supported for
+--                                     name, annotation, qualified, signature,
+--                                     peek. type/language/semantic/params take
+--                                     = only; modifier takes = or *= (both mean
+--                                     "has this modifier"). Unknown attributes
+--                                     and unsupported operator combinations
+--                                     raise an error (issue #89) instead of
+--                                     silently returning wrong/empty results.
 --                                     Example: .func[signature^=int] matches
 --                                     functions whose return type starts with "int"
 --   Compound: type#name:has(...)  - Multiple conditions on same element
@@ -2693,6 +2701,9 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Left = first tag_name child of sel_root, Right = last tag_name child.
         -- Refactored to use sel_tag_names + a single window pass instead of two
         -- correlated LIMIT 1 scalar subqueries on sel.
+
+)SQLMACRO"
+        R"SQLMACRO(
         combinator_parts AS (
             SELECT
                 MAX(name) FILTER (WHERE first_rn = 1) AS left_type,
@@ -2707,9 +2718,6 @@ CREATE OR REPLACE MACRO ast_select_from(
         ),
 
         -- For simple/compound selectors: extract type, #name, .class filters.
-
-)SQLMACRO"
-        R"SQLMACRO(
         -- Type filter: find the tag_name in the selector tree (may be nested in compound selectors).
         -- Exclude tag_names inside :has()/:not() arguments — those are descendant filters, not the base type.
         --
@@ -2986,6 +2994,9 @@ CREATE OR REPLACE MACRO ast_select_from(
                 SELECT fname.name AS attr_name,
                        COALESCE(fplain.name, fstr.name, fint.name) AS attr_value,
                        CASE
+
+)SQLMACRO"
+        R"SQLMACRO(
                            WHEN starswith.attr_id IS NOT NULL THEN '*='
                            WHEN caret.attr_id    IS NOT NULL THEN '^='
                            WHEN dollar.attr_id   IS NOT NULL THEN '$='
@@ -2995,9 +3006,6 @@ CREATE OR REPLACE MACRO ast_select_from(
                 JOIN sel_attr_outside_args outside ON outside.attr_id = s.node_id
                 LEFT JOIN sel_attr_first_name  fname  ON fname.attr_id  = s.node_id
                 LEFT JOIN sel_attr_first_plain fplain ON fplain.attr_id = s.node_id
-
-)SQLMACRO"
-        R"SQLMACRO(
                 LEFT JOIN sel_attr_first_str   fstr   ON fstr.attr_id   = s.node_id
                 LEFT JOIN sel_attr_first_int   fint   ON fint.attr_id   = s.node_id
                 LEFT JOIN (
@@ -3152,6 +3160,105 @@ CREATE OR REPLACE MACRO ast_select_from(
             END AS ok
         ),
 
+        -- Attribute filter validation (issue #89): reject documented-looking but
+        -- unsupported attribute filters at query time instead of silently
+        -- matching nothing (unknown attribute names fell through to `ELSE false`
+        -- in the dispatch CASE) or silently ignoring the operator (the type/
+        -- language/semantic/params arms only implement exact match; modifier
+        -- implements = and *= as list containment). "Can't answer" must be an
+        -- error, never an empty result.
+        known_attribute_names(name) AS (
+            VALUES ('name'), ('type'), ('language'), ('semantic'),
+                   ('modifier'), ('annotation'), ('qualified'), ('signature'),
+                   ('params'), ('peek')
+        ),
+        attr_filter_validation AS (
+            SELECT CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM attr_conditions ac
+                    WHERE ac.attr_name IS NOT NULL
+                      AND ac.attr_name NOT IN (SELECT name FROM known_attribute_names)
+                ) THEN error(format(
+                    'ast_select: unknown attribute "[{}...]". Supported attributes: '
+                    'name, type, language, semantic, modifier, annotation, qualified, '
+                    'signature, params, peek.',
+                    (SELECT ac.attr_name FROM attr_conditions ac
+                     WHERE ac.attr_name IS NOT NULL
+                       AND ac.attr_name NOT IN (SELECT name FROM known_attribute_names)
+                     LIMIT 1)
+                ))
+                WHEN EXISTS (
+                    SELECT 1 FROM attr_conditions ac
+                    WHERE ac.attr_op != '=' AND ac.attr_name IN ('type', 'language', 'semantic', 'params')
+                ) THEN error(format(
+                    'ast_select: attribute "{}" only supports exact match (=), not "{}". '
+                    'For prefix/suffix/substring matching on node types use a bare type '
+                    'selector (e.g. `call` matches call_expression), or filter the '
+                    'result rows in SQL.',
+                    (SELECT ac.attr_name FROM attr_conditions ac
+                     WHERE ac.attr_op != '=' AND ac.attr_name IN ('type', 'language', 'semantic', 'params')
+                     LIMIT 1),
+                    (SELECT ac.attr_op FROM attr_conditions ac
+                     WHERE ac.attr_op != '=' AND ac.attr_name IN ('type', 'language', 'semantic', 'params')
+                     LIMIT 1)
+                ))
+                WHEN EXISTS (
+                    SELECT 1 FROM attr_conditions ac
+                    WHERE ac.attr_op IN ('^=', '$=') AND ac.attr_name = 'modifier'
+                ) THEN error(
+                    'ast_select: attribute "modifier" supports = and *= (both meaning '
+                    '"has this modifier" — modifiers is a list), not ^= or $=.'
+                )
+                ELSE true
+            END AS ok
+        ),
+
+        -- #name-on-call binding guard (issues #88/#89): a selector that binds a
+        -- name to CALL-semantic nodes (`.call#foo`, `.call[name=foo]`,
+        -- `:has(.call#foo)`, `:not(:has(.call#foo))`) requires call nodes to
+        -- carry their callee's name. Extraction self-names calls for the
+        -- registered grammars (FIND_CALL_TARGET), but some call-semantic nodes
+        -- have no single callee (bash command_substitution) and future grammars
+        -- may not be covered. If the source HAS call nodes but NONE of them are
+        -- named, the selector cannot bind — raise instead of returning 0 rows
+        -- (or, for the :not(:has()) form, matching everything).
+        -- When only SOME calls are unnamed this stays silent: mixed sources are
+        -- legitimate and per-row errors would drown real results (#89: no false
+        -- alarms where all-NULL is not the whole story).
+        call_name_binding_validation AS (
+            SELECT CASE
+                WHEN (
+                    (UPPER(COALESCE((SELECT class_filter FROM simple_class), ''))
+                         IN ('CALL', 'INVOKE', 'COMPUTATION_CALL')
+                     AND ((SELECT name_filter FROM simple_id) IS NOT NULL
+                          OR EXISTS (SELECT 1 FROM attr_conditions WHERE attr_name = 'name')))
+                    OR EXISTS (SELECT 1 FROM has_conditions h
+                               WHERE h.has_name IS NOT NULL
+                                 AND UPPER(h.has_class) IN ('CALL', 'INVOKE', 'COMPUTATION_CALL'))
+                    OR EXISTS (SELECT 1 FROM not_has_conditions nh
+                               WHERE nh.not_has_name IS NOT NULL
+                                 AND UPPER(nh.not_has_class) IN ('CALL', 'INVOKE', 'COMPUTATION_CALL'))
+                )
+                AND EXISTS (SELECT 1 FROM ast WHERE is_semantic_type(semantic_type, 'CALL'))
+                AND NOT EXISTS (SELECT 1 FROM ast
+
+)SQLMACRO"
+        R"SQLMACRO(
+                                WHERE is_semantic_type(semantic_type, 'CALL')
+                                  AND name IS NOT NULL AND name != '')
+                THEN error(
+                    'ast_select: the selector binds a name to call nodes (e.g. .call#foo) '
+                    'but no call node in this source carries a callee name. Either the '
+                    'grammar''s call nodes are not covered by callee-name extraction, or '
+                    'the table was parsed without name extraction. Query the callee '
+                    'structurally instead: join the call node''s children via parent_id '
+                    '(see read_ast docs), and please report the language so extraction '
+                    'can be extended.'
+                )
+                ELSE true
+            END AS ok
+        ),
+
         -- Detect pseudo-element (::callers, ::callees, etc.).
         -- Finds the LAST tag_name child of any pseudo_element_selector.
         -- Refactored to use typed CTEs + window function — avoids the correlated
@@ -3164,6 +3271,78 @@ CREATE OR REPLACE MACRO ast_select_from(
         ),
         pseudo_element AS (
             SELECT (SELECT name FROM sel_pe_tag_names_ranked WHERE rn = 1) AS element_name
+        ),
+
+        -- Unknown pseudo-elements error (issue #89): the final routing UNION
+        -- only has arms for the known names, so an unrecognized ::element fell
+        -- through every arm and silently returned 0 rows.
+        known_pseudo_element_names(name) AS (
+            VALUES ('parent'), ('parent-definition'), ('scope'),
+                   ('next-sibling'), ('prev-sibling'), ('previous-sibling'),
+                   ('callers'), ('callees')
+        ),
+        pseudo_element_validation AS (
+            SELECT CASE
+                WHEN (SELECT element_name FROM pseudo_element) IS NOT NULL
+                     AND (SELECT element_name FROM pseudo_element) NOT IN
+                         (SELECT name FROM known_pseudo_element_names)
+                THEN error(format(
+                    'ast_select: unknown pseudo-element "::{}". Supported: ::parent, '
+                    '::parent-definition, ::scope, ::next-sibling, ::prev-sibling, '
+                    '::callers, ::callees.',
+                    (SELECT element_name FROM pseudo_element)
+                ))
+                ELSE true
+            END AS ok
+        ),
+
+        -- :has() argument validation (issue #89): has_conditions extracts only
+        -- a type, an #id, and a .class from the :has(...) argument. Attribute
+        -- filters, pseudo-classes, and combinators inside the argument were
+        -- silently DROPPED — the :has matched more than the user asked for
+        -- (silently wrong results, the same failure family as silent empties).
+        -- Reject them until the engine can honor them.
+        sel_has_arg_blocks AS (
+            SELECT pa.args_id, pa.args_descendants
+            FROM sel_pcs_to_args pa
+            JOIN sel_class_names cn ON cn.parent_id = pa.pcs_id AND cn.name = 'has'
+        ),
+        has_args_validation AS (
+            SELECT CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM sel_attribute_selectors s
+                    JOIN sel_has_arg_blocks hb
+                      ON s.node_id > hb.args_id
+                     AND s.node_id <= hb.args_id + hb.args_descendants
+                ) THEN error(
+                    'ast_select: attribute filters inside :has(...) are not supported '
+                    '(only a type, #name, and .class are honored there). Filter the '
+                    'attribute in SQL over the result, or chain ast_select calls.'
+                )
+                WHEN EXISTS (
+                    SELECT 1 FROM sel_pseudo_classes pcs
+                    JOIN sel_has_arg_blocks hb
+                      ON pcs.node_id > hb.args_id
+                     AND pcs.node_id <= hb.args_id + hb.args_descendants
+                ) THEN error(
+                    'ast_select: pseudo-classes inside :has(...) are not supported '
+                    '(only a type, #name, and .class are honored there). Chain '
+                    'ast_select calls to compose conditions.'
+                )
+                WHEN EXISTS (
+                    SELECT 1 FROM sel c
+                    JOIN sel_has_arg_blocks hb
+                      ON c.node_id > hb.args_id
+                     AND c.node_id <= hb.args_id + hb.args_descendants
+                    WHERE c.type IN ('child_selector', 'descendant_selector',
+                                     'sibling_selector', 'adjacent_sibling_selector')
+                ) THEN error(
+                    'ast_select: combinators inside :has(...) are not supported '
+                    '(only a type, #name, and .class are honored there). Chain '
+                    'ast_select calls to compose structural conditions.'
+                )
+                ELSE true
+            END AS ok
         ),
 
         -- :match("code") / :contains("code") — structural code pattern.
@@ -3206,7 +3385,15 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Apply selector: single scan with CASE dispatch (no UNION ALL)
         -- =====================================================================
 
-        -- Precompute selector properties as scalars
+        -- Precompute selector properties as scalars.
+        -- validations_ok folds ALL "can't answer" guards (#89) into the one-row
+        -- CTE that every matched_base branch cross-joins. This is deliberate:
+        -- the guards must fire even when the branch's row filters match ZERO
+        -- rows (the guarded situations — e.g. `.call#foo` over unnamed call
+        -- nodes — produce exactly that empty base). A join build side is
+        -- materialized regardless of probe cardinality, so error() here cannot
+        -- be skipped; a filter in matched_raw's WHERE would never be evaluated
+        -- over an already-empty base.
         sel_props AS (
             SELECT
                 (SELECT type FROM root_type) as sel_type,
@@ -3217,7 +3404,13 @@ CREATE OR REPLACE MACRO ast_select_from(
                 (SELECT left_type FROM combinator_parts) as left_type,
                 (SELECT left_type || '_%' FROM combinator_parts) as left_type_like,
                 (SELECT right_type FROM combinator_parts) as right_type,
-                (SELECT right_type || '_%' FROM combinator_parts) as right_type_like
+                (SELECT right_type || '_%' FROM combinator_parts) as right_type_like,
+                ((SELECT ok FROM pseudo_class_validation)
+                 AND (SELECT ok FROM peek_filter_validation)
+                 AND (SELECT ok FROM attr_filter_validation)
+                 AND (SELECT ok FROM call_name_binding_validation)
+                 AND (SELECT ok FROM pseudo_element_validation)
+                 AND (SELECT ok FROM has_args_validation)) as validations_ok
         ),
 
     -- Dispatch by sel_type using UNION ALL instead of a single CASE.
@@ -3236,7 +3429,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Bare type matching: `if` matches `if` and `if_statement`, `if_clause`, etc.
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type IN ('tag_name', 'id_selector', 'class_selector',
+        WHERE sp.validations_ok
+          AND sp.sel_type IN ('tag_name', 'id_selector', 'class_selector',
                               'attribute_selector', 'pseudo_class_selector')
           AND (sp.type_filter IS NULL OR a.type = sp.type_filter OR a.type LIKE sp.type_filter_like)
           AND (sp.name_filter IS NULL OR a.name = sp.name_filter)
@@ -3249,15 +3443,13 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Descendant combinator: A B
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type = 'descendant_selector'
+        WHERE sp.validations_ok
+          AND sp.sel_type = 'descendant_selector'
           AND (a.type = sp.right_type OR a.type LIKE sp.right_type_like)
           AND EXISTS (
               SELECT 1 FROM ast anc
               WHERE anc.file_path = a.file_path
                 AND a.node_id > anc.node_id
-
-)SQLMACRO"
-        R"SQLMACRO(
                 AND a.node_id <= anc.node_id + anc.descendant_count
                 AND (anc.type = sp.left_type OR anc.type LIKE sp.left_type_like)
           )
@@ -3267,7 +3459,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Child combinator: A > B
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type = 'child_selector'
+        WHERE sp.validations_ok
+          AND sp.sel_type = 'child_selector'
           AND (a.type = sp.right_type OR a.type LIKE sp.right_type_like)
           AND EXISTS (
               SELECT 1 FROM ast par
@@ -3280,7 +3473,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- General sibling: A ~ B
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type = 'sibling_selector'
+        WHERE sp.validations_ok
+          AND sp.sel_type = 'sibling_selector'
           AND (a.type = sp.right_type OR a.type LIKE sp.right_type_like)
           AND EXISTS (
               SELECT 1 FROM ast sib
@@ -3295,7 +3489,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Adjacent sibling: A + B
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type = 'adjacent_sibling_selector'
+        WHERE sp.validations_ok
+          AND sp.sel_type = 'adjacent_sibling_selector'
           AND (a.type = sp.right_type OR a.type LIKE sp.right_type_like)
           AND EXISTS (
               SELECT 1 FROM ast adj
@@ -3334,6 +3529,9 @@ CREATE OR REPLACE MACRO ast_select_from(
               AND d.node_id <= a.node_id + a.descendant_count
               AND (nh.not_has_type IS NULL OR d.type = nh.not_has_type)
               AND (nh.not_has_name IS NULL OR d.name = nh.not_has_name)
+
+)SQLMACRO"
+        R"SQLMACRO(
               AND (nh.not_has_class IS NULL
                    OR is_semantic_type(d.semantic_type, UPPER(nh.not_has_class)))
         )
@@ -3403,7 +3601,11 @@ CREATE OR REPLACE MACRO ast_select_from(
             ELSE false
         END, false)
     )
-    AND (SELECT ok FROM peek_filter_validation)
+    -- NOTE: the "can't answer" validations (pseudo_class / peek / attribute /
+    -- call-name binding) are evaluated in sel_props.validations_ok, which every
+    -- matched_base branch checks. They must NOT live here: this WHERE clause is
+    -- only evaluated for rows that survived matched_base, and the guarded
+    -- failure modes produce an EMPTY base — a guard here would never fire.
     -- Additional pseudo-class filters
     -- Each pseudo-class in the selector must be satisfied.
     -- For non-negated pcs: satisfied iff CASE is true.
@@ -3417,7 +3619,6 @@ CREATE OR REPLACE MACRO ast_select_from(
     -- same defect as the attribute-filter site above). NULL pseudo-class
     -- evaluations must count as "not satisfied": :async over NULL modifiers
     -- matches nothing, :not(:async) matches the node.
-    AND (SELECT ok FROM pseudo_class_validation)
     AND NOT EXISTS (
         SELECT 1 FROM pseudo_classes pc
         WHERE pc.negated = COALESCE(CASE pc.pseudo_name
@@ -3530,9 +3731,6 @@ CREATE OR REPLACE MACRO ast_select_from(
 
             -- :contains("code") — some descendant of the current node is the
             -- root of the parsed pattern. Equivalent to :has(:match(...)).
-
-)SQLMACRO"
-        R"SQLMACRO(
             -- Iterates descendants in the DFS node array and runs the same
             -- contiguity check as :match at each candidate root.
             WHEN 'contains' THEN (SELECT len FROM ast_pattern_len) > 0 AND EXISTS (
@@ -3576,6 +3774,9 @@ CREATE OR REPLACE MACRO ast_select_from(
                                 AND a.node_id <= nested.node_id + nested.descendant_count
                                 AND (nested.type = pc.pseudo_arg
                                      OR nested.type LIKE pc.pseudo_arg || '_%')
+
+)SQLMACRO"
+        R"SQLMACRO(
                           )
                     )
                 END

--- a/src/language_adapter.cpp
+++ b/src/language_adapter.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/helper.hpp"
 #include <cstring>
+#include <functional>
 
 namespace duckdb {
 
@@ -421,6 +422,14 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 	case ExtractionStrategy::FIND_CALL_TARGET: {
 		// Extract method/function name from call expressions
 		// Handles: simple calls (print), method calls (obj.method), qualified calls (pkg.func)
+		//
+		// The callee's node anatomy varies per grammar (issue #88): some grammars
+		// put an identifier-like leaf directly under the call node (C, Python,
+		// PHP function_call), others wrap the callee in a member-access node
+		// whose method name may itself be nested one level deeper (Kotlin/Swift
+		// navigation_suffix). The type sets below cover all registered grammars;
+		// keeping them uniform here is what makes `.call#name` selectors work
+		// identically across languages.
 		if (ts_node_child_count(node) == 0) {
 			return "";
 		}
@@ -430,22 +439,63 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 			return "";
 		}
 
+		// Identifier-like leaf types that can carry a callee name:
+		//   identifier            — most grammars
+		//   property_identifier   — JS/TS member access
+		//   field_identifier      — C++/Rust member access
+		//   simple_identifier     — Kotlin, Swift
+		//   name                  — PHP
+		auto is_callee_identifier = [](const string &t) {
+			return t == "identifier" || t == "property_identifier" || t == "field_identifier" ||
+			       t == "simple_identifier" || t == "name";
+		};
+		// Argument containers: sibling scans must stop here so we never mistake
+		// an argument for the callee.
+		auto is_argument_container = [](const string &t) {
+			return t == "argument_list" || t == "arguments" || t == "call_suffix" || t == "value_arguments";
+		};
+		// Rightmost identifier-like descendant of n, preferring later children
+		// (the method name in a member chain is the last leaf: obj.a().b -> b).
+		// Never descends into argument containers. Depth-bounded for safety.
+		std::function<string(TSNode, int)> find_rightmost_identifier = [&](TSNode n, int depth) -> string {
+			if (depth > 6) {
+				return "";
+			}
+			uint32_t cc = ts_node_child_count(n);
+			for (int i = static_cast<int>(cc) - 1; i >= 0; i--) {
+				TSNode c = ts_node_child(n, static_cast<uint32_t>(i));
+				string ct = ts_node_type(c);
+				if (is_callee_identifier(ct)) {
+					return ExtractNodeText(c, content);
+				}
+				if (is_argument_container(ct)) {
+					continue;
+				}
+				string r = find_rightmost_identifier(c, depth + 1);
+				if (!r.empty()) {
+					return r;
+				}
+			}
+			return "";
+		};
+
 		string first_child_type = ts_node_type(first_child);
 
-		// Simple function call: first child is identifier
-		// But in Java method_invocation, the first identifier is the object, not the method.
-		// Check if there's a later identifier sibling (before argument_list) which would be the method name.
-		if (first_child_type == "identifier") {
+		// Simple function call: first child is an identifier-like leaf.
+		// But in Java method_invocation (obj.bar()), the first identifier is the
+		// object, not the method; in PHP scoped_call_expression (Cls::baz()) the
+		// first `name` is the class. Check for a later identifier sibling
+		// (before the argument container) which would be the method name.
+		if (is_callee_identifier(first_child_type)) {
 			uint32_t node_child_count = ts_node_child_count(node);
 			for (uint32_t i = 1; i < node_child_count; i++) {
 				TSNode sibling = ts_node_child(node, i);
 				string sibling_type = ts_node_type(sibling);
 				// Stop at argument containers
-				if (sibling_type == "argument_list" || sibling_type == "arguments") {
+				if (is_argument_container(sibling_type)) {
 					break;
 				}
-				if (sibling_type == "identifier" || sibling_type == "property_identifier" ||
-				    sibling_type == "field_identifier" || sibling_type == "simple_identifier") {
+				if (is_callee_identifier(sibling_type)) {
 					return ExtractNodeText(sibling, content);
 				}
 			}
@@ -456,43 +506,62 @@ string LanguageAdapter::ExtractByStrategy(TSNode node, const string &content, Ex
 		// Method/member call patterns: find the rightmost identifier (method name)
 		// Python: attribute (obj.method), JS/TS: member_expression, C++: field_expression
 		// Go: selector_expression, Rust: field_expression, Java: field_access
+		// Kotlin/Swift: navigation_expression, C#: member_access_expression
+		// Lua: method_index_expression (obj:bar), PHP: variable_name ($obj->bar)
 		if (first_child_type == "attribute" || first_child_type == "member_expression" ||
 		    first_child_type == "field_expression" || first_child_type == "selector_expression" ||
 		    first_child_type == "field_access" || first_child_type == "scoped_identifier" ||
-		    first_child_type == "qualified_identifier") {
+		    first_child_type == "qualified_identifier" || first_child_type == "navigation_expression" ||
+		    first_child_type == "member_access_expression" || first_child_type == "method_index_expression" ||
+		    first_child_type == "variable_name") {
 			// Java method_invocation has a special structure: the method name is a sibling
 			// of field_access, not inside it. E.g., System.out.println():
 			//   method_invocation -> field_access("System.out"), ".", identifier("println"), argument_list
+			// PHP member_call_expression is the same shape:
+			//   member_call_expression -> variable_name("$obj"), "->", name("bar"), arguments
 			// Check for an identifier sibling after the first child (the object expression)
 			uint32_t node_child_count = ts_node_child_count(node);
 			for (uint32_t i = 1; i < node_child_count; i++) {
 				TSNode sibling = ts_node_child(node, i);
 				string sibling_type = ts_node_type(sibling);
-				if (sibling_type == "identifier" || sibling_type == "property_identifier" ||
-				    sibling_type == "field_identifier" || sibling_type == "simple_identifier") {
+				if (is_argument_container(sibling_type)) {
+					break;
+				}
+				if (is_callee_identifier(sibling_type)) {
 					return ExtractNodeText(sibling, content);
 				}
 			}
 
-			// Fallback: find the last identifier inside the first child
-			// (Python attribute, JS member_expression, etc.)
-			uint32_t child_count = ts_node_child_count(first_child);
-			for (int i = child_count - 1; i >= 0; i--) {
-				TSNode child = ts_node_child(first_child, i);
-				string child_type = ts_node_type(child);
-
-				if (child_type == "identifier" || child_type == "property_identifier" ||
-				    child_type == "field_identifier" || child_type == "simple_identifier") {
-					return ExtractNodeText(child, content);
-				}
+			// Fallback: rightmost identifier-like descendant of the first child.
+			// Direct children handle Python attribute / JS member_expression;
+			// the recursive descent handles Kotlin/Swift navigation_expression,
+			// where the method name lives inside a navigation_suffix wrapper.
+			string nested = find_rightmost_identifier(first_child, 0);
+			if (!nested.empty()) {
+				return nested;
 			}
 
 			// Fallback: return the full expression text
 			return ExtractNodeText(first_child, content);
 		}
 
-		// Other patterns (subscript calls, etc.): try to find any identifier
-		return FindChildByType(node, content, "identifier");
+		// Other patterns (subscript calls, new-expressions, etc.): first
+		// identifier-like direct child (e.g. PHP object_creation_expression:
+		// `new` keyword, then name("Widget"), then arguments).
+		{
+			uint32_t node_child_count = ts_node_child_count(node);
+			for (uint32_t i = 0; i < node_child_count; i++) {
+				TSNode child = ts_node_child(node, i);
+				string child_type = ts_node_type(child);
+				if (is_argument_container(child_type)) {
+					break;
+				}
+				if (is_callee_identifier(child_type)) {
+					return ExtractNodeText(child, content);
+				}
+			}
+		}
+		return "";
 	}
 	case ExtractionStrategy::CUSTOM:
 		// Will be overridden by specific language adapters

--- a/src/sql_macros/css_selectors.sql
+++ b/src/sql_macros/css_selectors.sql
@@ -18,7 +18,15 @@
 --   [name=value]                  - Attribute filter. Supported attributes:
 --                                     name, type, language, semantic, peek,
 --                                     qualified, signature, params, modifier,
---                                     annotation. Operators: = *= ^= $=.
+--                                     annotation.
+--                                     Operators = *= ^= $= are supported for
+--                                     name, annotation, qualified, signature,
+--                                     peek. type/language/semantic/params take
+--                                     = only; modifier takes = or *= (both mean
+--                                     "has this modifier"). Unknown attributes
+--                                     and unsupported operator combinations
+--                                     raise an error (issue #89) instead of
+--                                     silently returning wrong/empty results.
 --                                     Example: .func[signature^=int] matches
 --                                     functions whose return type starts with "int"
 --   Compound: type#name:has(...)  - Multiple conditions on same element
@@ -705,6 +713,102 @@ CREATE OR REPLACE MACRO ast_select_from(
             END AS ok
         ),
 
+        -- Attribute filter validation (issue #89): reject documented-looking but
+        -- unsupported attribute filters at query time instead of silently
+        -- matching nothing (unknown attribute names fell through to `ELSE false`
+        -- in the dispatch CASE) or silently ignoring the operator (the type/
+        -- language/semantic/params arms only implement exact match; modifier
+        -- implements = and *= as list containment). "Can't answer" must be an
+        -- error, never an empty result.
+        known_attribute_names(name) AS (
+            VALUES ('name'), ('type'), ('language'), ('semantic'),
+                   ('modifier'), ('annotation'), ('qualified'), ('signature'),
+                   ('params'), ('peek')
+        ),
+        attr_filter_validation AS (
+            SELECT CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM attr_conditions ac
+                    WHERE ac.attr_name IS NOT NULL
+                      AND ac.attr_name NOT IN (SELECT name FROM known_attribute_names)
+                ) THEN error(format(
+                    'ast_select: unknown attribute "[{}...]". Supported attributes: '
+                    'name, type, language, semantic, modifier, annotation, qualified, '
+                    'signature, params, peek.',
+                    (SELECT ac.attr_name FROM attr_conditions ac
+                     WHERE ac.attr_name IS NOT NULL
+                       AND ac.attr_name NOT IN (SELECT name FROM known_attribute_names)
+                     LIMIT 1)
+                ))
+                WHEN EXISTS (
+                    SELECT 1 FROM attr_conditions ac
+                    WHERE ac.attr_op != '=' AND ac.attr_name IN ('type', 'language', 'semantic', 'params')
+                ) THEN error(format(
+                    'ast_select: attribute "{}" only supports exact match (=), not "{}". '
+                    'For prefix/suffix/substring matching on node types use a bare type '
+                    'selector (e.g. `call` matches call_expression), or filter the '
+                    'result rows in SQL.',
+                    (SELECT ac.attr_name FROM attr_conditions ac
+                     WHERE ac.attr_op != '=' AND ac.attr_name IN ('type', 'language', 'semantic', 'params')
+                     LIMIT 1),
+                    (SELECT ac.attr_op FROM attr_conditions ac
+                     WHERE ac.attr_op != '=' AND ac.attr_name IN ('type', 'language', 'semantic', 'params')
+                     LIMIT 1)
+                ))
+                WHEN EXISTS (
+                    SELECT 1 FROM attr_conditions ac
+                    WHERE ac.attr_op IN ('^=', '$=') AND ac.attr_name = 'modifier'
+                ) THEN error(
+                    'ast_select: attribute "modifier" supports = and *= (both meaning '
+                    '"has this modifier" — modifiers is a list), not ^= or $=.'
+                )
+                ELSE true
+            END AS ok
+        ),
+
+        -- #name-on-call binding guard (issues #88/#89): a selector that binds a
+        -- name to CALL-semantic nodes (`.call#foo`, `.call[name=foo]`,
+        -- `:has(.call#foo)`, `:not(:has(.call#foo))`) requires call nodes to
+        -- carry their callee's name. Extraction self-names calls for the
+        -- registered grammars (FIND_CALL_TARGET), but some call-semantic nodes
+        -- have no single callee (bash command_substitution) and future grammars
+        -- may not be covered. If the source HAS call nodes but NONE of them are
+        -- named, the selector cannot bind — raise instead of returning 0 rows
+        -- (or, for the :not(:has()) form, matching everything).
+        -- When only SOME calls are unnamed this stays silent: mixed sources are
+        -- legitimate and per-row errors would drown real results (#89: no false
+        -- alarms where all-NULL is not the whole story).
+        call_name_binding_validation AS (
+            SELECT CASE
+                WHEN (
+                    (UPPER(COALESCE((SELECT class_filter FROM simple_class), ''))
+                         IN ('CALL', 'INVOKE', 'COMPUTATION_CALL')
+                     AND ((SELECT name_filter FROM simple_id) IS NOT NULL
+                          OR EXISTS (SELECT 1 FROM attr_conditions WHERE attr_name = 'name')))
+                    OR EXISTS (SELECT 1 FROM has_conditions h
+                               WHERE h.has_name IS NOT NULL
+                                 AND UPPER(h.has_class) IN ('CALL', 'INVOKE', 'COMPUTATION_CALL'))
+                    OR EXISTS (SELECT 1 FROM not_has_conditions nh
+                               WHERE nh.not_has_name IS NOT NULL
+                                 AND UPPER(nh.not_has_class) IN ('CALL', 'INVOKE', 'COMPUTATION_CALL'))
+                )
+                AND EXISTS (SELECT 1 FROM ast WHERE is_semantic_type(semantic_type, 'CALL'))
+                AND NOT EXISTS (SELECT 1 FROM ast
+                                WHERE is_semantic_type(semantic_type, 'CALL')
+                                  AND name IS NOT NULL AND name != '')
+                THEN error(
+                    'ast_select: the selector binds a name to call nodes (e.g. .call#foo) '
+                    'but no call node in this source carries a callee name. Either the '
+                    'grammar''s call nodes are not covered by callee-name extraction, or '
+                    'the table was parsed without name extraction. Query the callee '
+                    'structurally instead: join the call node''s children via parent_id '
+                    '(see read_ast docs), and please report the language so extraction '
+                    'can be extended.'
+                )
+                ELSE true
+            END AS ok
+        ),
+
         -- Detect pseudo-element (::callers, ::callees, etc.).
         -- Finds the LAST tag_name child of any pseudo_element_selector.
         -- Refactored to use typed CTEs + window function — avoids the correlated
@@ -717,6 +821,78 @@ CREATE OR REPLACE MACRO ast_select_from(
         ),
         pseudo_element AS (
             SELECT (SELECT name FROM sel_pe_tag_names_ranked WHERE rn = 1) AS element_name
+        ),
+
+        -- Unknown pseudo-elements error (issue #89): the final routing UNION
+        -- only has arms for the known names, so an unrecognized ::element fell
+        -- through every arm and silently returned 0 rows.
+        known_pseudo_element_names(name) AS (
+            VALUES ('parent'), ('parent-definition'), ('scope'),
+                   ('next-sibling'), ('prev-sibling'), ('previous-sibling'),
+                   ('callers'), ('callees')
+        ),
+        pseudo_element_validation AS (
+            SELECT CASE
+                WHEN (SELECT element_name FROM pseudo_element) IS NOT NULL
+                     AND (SELECT element_name FROM pseudo_element) NOT IN
+                         (SELECT name FROM known_pseudo_element_names)
+                THEN error(format(
+                    'ast_select: unknown pseudo-element "::{}". Supported: ::parent, '
+                    '::parent-definition, ::scope, ::next-sibling, ::prev-sibling, '
+                    '::callers, ::callees.',
+                    (SELECT element_name FROM pseudo_element)
+                ))
+                ELSE true
+            END AS ok
+        ),
+
+        -- :has() argument validation (issue #89): has_conditions extracts only
+        -- a type, an #id, and a .class from the :has(...) argument. Attribute
+        -- filters, pseudo-classes, and combinators inside the argument were
+        -- silently DROPPED — the :has matched more than the user asked for
+        -- (silently wrong results, the same failure family as silent empties).
+        -- Reject them until the engine can honor them.
+        sel_has_arg_blocks AS (
+            SELECT pa.args_id, pa.args_descendants
+            FROM sel_pcs_to_args pa
+            JOIN sel_class_names cn ON cn.parent_id = pa.pcs_id AND cn.name = 'has'
+        ),
+        has_args_validation AS (
+            SELECT CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM sel_attribute_selectors s
+                    JOIN sel_has_arg_blocks hb
+                      ON s.node_id > hb.args_id
+                     AND s.node_id <= hb.args_id + hb.args_descendants
+                ) THEN error(
+                    'ast_select: attribute filters inside :has(...) are not supported '
+                    '(only a type, #name, and .class are honored there). Filter the '
+                    'attribute in SQL over the result, or chain ast_select calls.'
+                )
+                WHEN EXISTS (
+                    SELECT 1 FROM sel_pseudo_classes pcs
+                    JOIN sel_has_arg_blocks hb
+                      ON pcs.node_id > hb.args_id
+                     AND pcs.node_id <= hb.args_id + hb.args_descendants
+                ) THEN error(
+                    'ast_select: pseudo-classes inside :has(...) are not supported '
+                    '(only a type, #name, and .class are honored there). Chain '
+                    'ast_select calls to compose conditions.'
+                )
+                WHEN EXISTS (
+                    SELECT 1 FROM sel c
+                    JOIN sel_has_arg_blocks hb
+                      ON c.node_id > hb.args_id
+                     AND c.node_id <= hb.args_id + hb.args_descendants
+                    WHERE c.type IN ('child_selector', 'descendant_selector',
+                                     'sibling_selector', 'adjacent_sibling_selector')
+                ) THEN error(
+                    'ast_select: combinators inside :has(...) are not supported '
+                    '(only a type, #name, and .class are honored there). Chain '
+                    'ast_select calls to compose structural conditions.'
+                )
+                ELSE true
+            END AS ok
         ),
 
         -- :match("code") / :contains("code") — structural code pattern.
@@ -759,7 +935,15 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Apply selector: single scan with CASE dispatch (no UNION ALL)
         -- =====================================================================
 
-        -- Precompute selector properties as scalars
+        -- Precompute selector properties as scalars.
+        -- validations_ok folds ALL "can't answer" guards (#89) into the one-row
+        -- CTE that every matched_base branch cross-joins. This is deliberate:
+        -- the guards must fire even when the branch's row filters match ZERO
+        -- rows (the guarded situations — e.g. `.call#foo` over unnamed call
+        -- nodes — produce exactly that empty base). A join build side is
+        -- materialized regardless of probe cardinality, so error() here cannot
+        -- be skipped; a filter in matched_raw's WHERE would never be evaluated
+        -- over an already-empty base.
         sel_props AS (
             SELECT
                 (SELECT type FROM root_type) as sel_type,
@@ -770,7 +954,13 @@ CREATE OR REPLACE MACRO ast_select_from(
                 (SELECT left_type FROM combinator_parts) as left_type,
                 (SELECT left_type || '_%' FROM combinator_parts) as left_type_like,
                 (SELECT right_type FROM combinator_parts) as right_type,
-                (SELECT right_type || '_%' FROM combinator_parts) as right_type_like
+                (SELECT right_type || '_%' FROM combinator_parts) as right_type_like,
+                ((SELECT ok FROM pseudo_class_validation)
+                 AND (SELECT ok FROM peek_filter_validation)
+                 AND (SELECT ok FROM attr_filter_validation)
+                 AND (SELECT ok FROM call_name_binding_validation)
+                 AND (SELECT ok FROM pseudo_element_validation)
+                 AND (SELECT ok FROM has_args_validation)) as validations_ok
         ),
 
     -- Dispatch by sel_type using UNION ALL instead of a single CASE.
@@ -789,7 +979,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Bare type matching: `if` matches `if` and `if_statement`, `if_clause`, etc.
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type IN ('tag_name', 'id_selector', 'class_selector',
+        WHERE sp.validations_ok
+          AND sp.sel_type IN ('tag_name', 'id_selector', 'class_selector',
                               'attribute_selector', 'pseudo_class_selector')
           AND (sp.type_filter IS NULL OR a.type = sp.type_filter OR a.type LIKE sp.type_filter_like)
           AND (sp.name_filter IS NULL OR a.name = sp.name_filter)
@@ -802,7 +993,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Descendant combinator: A B
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type = 'descendant_selector'
+        WHERE sp.validations_ok
+          AND sp.sel_type = 'descendant_selector'
           AND (a.type = sp.right_type OR a.type LIKE sp.right_type_like)
           AND EXISTS (
               SELECT 1 FROM ast anc
@@ -817,7 +1009,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Child combinator: A > B
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type = 'child_selector'
+        WHERE sp.validations_ok
+          AND sp.sel_type = 'child_selector'
           AND (a.type = sp.right_type OR a.type LIKE sp.right_type_like)
           AND EXISTS (
               SELECT 1 FROM ast par
@@ -830,7 +1023,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- General sibling: A ~ B
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type = 'sibling_selector'
+        WHERE sp.validations_ok
+          AND sp.sel_type = 'sibling_selector'
           AND (a.type = sp.right_type OR a.type LIKE sp.right_type_like)
           AND EXISTS (
               SELECT 1 FROM ast sib
@@ -845,7 +1039,8 @@ CREATE OR REPLACE MACRO ast_select_from(
         -- Adjacent sibling: A + B
         SELECT a.*
         FROM ast a, sel_props sp
-        WHERE sp.sel_type = 'adjacent_sibling_selector'
+        WHERE sp.validations_ok
+          AND sp.sel_type = 'adjacent_sibling_selector'
           AND (a.type = sp.right_type OR a.type LIKE sp.right_type_like)
           AND EXISTS (
               SELECT 1 FROM ast adj
@@ -953,7 +1148,11 @@ CREATE OR REPLACE MACRO ast_select_from(
             ELSE false
         END, false)
     )
-    AND (SELECT ok FROM peek_filter_validation)
+    -- NOTE: the "can't answer" validations (pseudo_class / peek / attribute /
+    -- call-name binding) are evaluated in sel_props.validations_ok, which every
+    -- matched_base branch checks. They must NOT live here: this WHERE clause is
+    -- only evaluated for rows that survived matched_base, and the guarded
+    -- failure modes produce an EMPTY base — a guard here would never fire.
     -- Additional pseudo-class filters
     -- Each pseudo-class in the selector must be satisfied.
     -- For non-negated pcs: satisfied iff CASE is true.
@@ -967,7 +1166,6 @@ CREATE OR REPLACE MACRO ast_select_from(
     -- same defect as the attribute-filter site above). NULL pseudo-class
     -- evaluations must count as "not satisfied": :async over NULL modifiers
     -- matches nothing, :not(:async) matches the node.
-    AND (SELECT ok FROM pseudo_class_validation)
     AND NOT EXISTS (
         SELECT 1 FROM pseudo_classes pc
         WHERE pc.negated = COALESCE(CASE pc.pseudo_name

--- a/test/data/call_extraction/calls.c
+++ b/test/data/call_extraction/calls.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+
+struct reader {
+    FILE *fp;
+    long (*seek_fn)(FILE *, long);
+};
+
+static long check_offset(long offset) {
+    return offset >= 0 ? offset : -1;
+}
+
+long read_block(struct reader *r, long offset) {
+    if (fseeko(r->fp, check_offset(offset), 0) != 0) {
+        return -1;
+    }
+    return ftello(r->fp);
+}
+
+long skip_block(struct reader *r, long offset) {
+    if (fseeko(r->fp, offset, 1) != 0) {
+        return -1;
+    }
+    return r->seek_fn(r->fp, offset);
+}
+
+int main(void) {
+    struct reader r;
+    long pos = read_block(&r, 100);
+    printf("%ld\n", pos);
+    return (int)skip_block(&r, pos);
+}

--- a/test/data/call_extraction/calls.cs
+++ b/test/data/call_extraction/calls.cs
@@ -1,0 +1,10 @@
+class Widget {
+    static int Helper(int x) {
+        return x + 1;
+    }
+
+    int Render(string s) {
+        var t = s.Trim();
+        return Helper(t.Length);
+    }
+}

--- a/test/data/call_extraction/calls.kt
+++ b/test/data/call_extraction/calls.kt
@@ -1,0 +1,9 @@
+fun helper(x: Int): Int {
+    return x + 1
+}
+
+fun caller(obj: StringBuilder): Int {
+    helper(1)
+    obj.append("x")
+    return helper(2)
+}

--- a/test/data/call_extraction/calls.lua
+++ b/test/data/call_extraction/calls.lua
@@ -1,0 +1,11 @@
+local function helper(x)
+    return x + 1
+end
+
+local obj = {}
+function obj.render(s)
+    return helper(#s)
+end
+
+helper(1)
+obj:render("a")

--- a/test/data/call_extraction/calls.php
+++ b/test/data/call_extraction/calls.php
@@ -1,0 +1,15 @@
+<?php
+function helper($x) {
+    return $x + 1;
+}
+
+class Widget {
+    public function render($data) {
+        return strtoupper($data);
+    }
+}
+
+$w = new Widget();
+helper(1);
+$w->render("a");
+Widget::render("b");

--- a/test/data/call_extraction/calls.sh
+++ b/test/data/call_extraction/calls.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+stamp=$(date +%s)
+echo "$stamp"

--- a/test/data/call_extraction/calls.swift
+++ b/test/data/call_extraction/calls.swift
@@ -1,0 +1,8 @@
+func helper(_ x: Int) -> Int {
+    return x + 1
+}
+
+func caller(text: String) -> Int {
+    let upper = text.uppercased()
+    return helper(upper.count)
+}

--- a/test/sql/bugs/issue_88_89_callee_name_and_guards.test
+++ b/test/sql/bugs/issue_88_89_callee_name_and_guards.test
@@ -1,0 +1,311 @@
+# name: test/sql/bugs/issue_88_89_callee_name_and_guards.test
+# group: [bugs]
+
+# Issue #88: CSS #name on call nodes must bind the CALLEE name uniformly across
+# grammars. The FIND_CALL_TARGET extraction strategy self-names call nodes for
+# C-family (and most grammars), but Kotlin/Swift (simple_identifier +
+# navigation_expression), PHP (name / variable_name), C# member calls
+# (member_access_expression), and Lua method-call wrappers
+# (function_call > method_index_expression) fell through the strategy's type
+# lists and produced UNNAMED call nodes — so `.call#foo` silently returned
+# empty for those languages.
+#
+# Issue #89: where the engine cannot honor a selector's semantics it must say
+# so. Covered here: #name bound to call nodes over a source whose call nodes
+# carry no callee names (bash command_substitution), unknown attribute names,
+# and documented-but-unsupported attribute/operator combos — all raise errors
+# instead of returning silently-wrong/empty results.
+#
+# Row-pinned per the #83 convention: matched rows assert name + start_line,
+# not just COUNT(*).
+
+require sitting_duck
+
+# =============================================================================
+# Section 1: C ground truth — callee names on call_expression (issue #88 repro)
+# =============================================================================
+
+# Every call in the C fixture is named with its callee, including calls through
+# a struct field function pointer (r->seek_fn -> seek_fn).
+query III
+SELECT type, name, start_line
+FROM read_ast('test/data/call_extraction/calls.c')
+WHERE is_semantic_type(semantic_type, 'CALL')
+ORDER BY start_line, node_id;
+----
+call_expression	fseeko	13
+call_expression	check_offset	13
+call_expression	ftello	16
+call_expression	fseeko	20
+call_expression	seek_fn	23
+call_expression	read_block	28
+call_expression	printf	29
+call_expression	skip_block	30
+
+# .call#fseeko binds the callee name (the issue-#88 headline case)
+query II
+SELECT name, start_line
+FROM ast_select('test/data/call_extraction/calls.c', '.call#fseeko')
+ORDER BY start_line;
+----
+fseeko	13
+fseeko	20
+
+# .func:has(.call#fseeko) — the field-report selector — is non-empty and pinned
+query III
+SELECT name, type, start_line
+FROM ast_select('test/data/call_extraction/calls.c', '.func:has(.call#fseeko)')
+ORDER BY start_line;
+----
+read_block	function_definition	12
+skip_block	function_definition	19
+
+# ...and agrees with the raw read_ast parent/child (subtree) join
+query II
+SELECT DISTINCT f.name, f.start_line
+FROM read_ast('test/data/call_extraction/calls.c') f
+JOIN read_ast('test/data/call_extraction/calls.c') c
+  ON c.node_id > f.node_id
+ AND c.node_id <= f.node_id + f.descendant_count
+ AND c.type = 'call_expression'
+ AND c.name = 'fseeko'
+WHERE f.type = 'function_definition'
+ORDER BY f.start_line;
+----
+read_block	12
+skip_block	19
+
+# Legitimately-empty twin (#89 test convention): a callee that does not exist
+# returns 0 rows WITHOUT an error — the C fixture's calls are named, so empty
+# means "searched correctly, not there".
+query I
+SELECT COUNT(*) FROM ast_select('test/data/call_extraction/calls.c', '.call#zz_absent_callee');
+----
+0
+
+query I
+SELECT COUNT(*) FROM ast_select('test/data/call_extraction/calls.c', '.func:has(.call#zz_absent_callee)');
+----
+0
+
+# =============================================================================
+# Section 2: Python parity — the same selector shape on a grammar that always
+# self-named calls (regression in both directions, proving uniformity)
+# =============================================================================
+
+query II
+SELECT name, start_line
+FROM ast_select('test/data/call_extraction/calls.py', '.call#transform')
+ORDER BY start_line;
+----
+transform	8
+transform	29
+
+query III
+SELECT name, type, start_line
+FROM ast_select('test/data/call_extraction/calls.py', '.func:has(.call#transform)')
+ORDER BY start_line;
+----
+process	function_definition	7
+process_all	function_definition	27
+
+# =============================================================================
+# Section 3: previously false-empty grammars now bind callee names (issue #88)
+# Kotlin/Swift: simple_identifier callee + navigation_expression member calls;
+# PHP: name/variable_name callee anatomy (incl. scoped :: calls and `new`);
+# C#: member_access_expression; Lua: function_call > method_index_expression.
+# =============================================================================
+
+query IIII
+SELECT file_path.split('/')[-1] AS f, type, name, start_line
+FROM read_ast(['test/data/call_extraction/calls.kt',
+               'test/data/call_extraction/calls.swift',
+               'test/data/call_extraction/calls.php',
+               'test/data/call_extraction/calls.cs',
+               'test/data/call_extraction/calls.lua'])
+WHERE is_semantic_type(semantic_type, 'CALL')
+ORDER BY f, start_line, node_id;
+----
+calls.cs	invocation_expression	Trim	7
+calls.cs	invocation_expression	Helper	8
+calls.kt	call_expression	helper	6
+calls.kt	call_expression	append	7
+calls.kt	call_expression	helper	8
+calls.lua	function_call	helper	7
+calls.lua	function_call	helper	10
+calls.lua	function_call	render	11
+calls.lua	method_index_expression	render	11
+calls.php	function_call_expression	strtoupper	8
+calls.php	object_creation_expression	Widget	12
+calls.php	function_call_expression	helper	13
+calls.php	member_call_expression	render	14
+calls.php	scoped_call_expression	render	15
+calls.swift	call_expression	uppercased	6
+calls.swift	call_expression	helper	7
+
+# The selector layer over a previously false-empty grammar (Kotlin)
+query II
+SELECT name, start_line
+FROM ast_select('test/data/call_extraction/calls.kt', '.call#helper')
+ORDER BY start_line;
+----
+helper	6
+helper	8
+
+# Member-call callee (was empty: name lived inside navigation_suffix)
+query II
+SELECT name, start_line
+FROM ast_select('test/data/call_extraction/calls.kt', '.func:has(.call#append)')
+ORDER BY start_line;
+----
+caller	5
+
+# =============================================================================
+# Section 4: #89 guards — "can't answer" raises, never a silent empty
+# =============================================================================
+
+# Bash command_substitution is CALL-semantic but carries no single callee name.
+# Binding a #name to call nodes over such a source is unanswerable: error.
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.sh', '.call#date');
+----
+no call node in this source carries a callee name
+
+# Same guard for the :has() composition...
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.sh', 'program:has(.call#date)');
+----
+no call node in this source carries a callee name
+
+# ...and for :not(:has()) — where the failure mode would be matching EVERYTHING
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.sh', 'program:not(:has(.call#date))');
+----
+no call node in this source carries a callee name
+
+# .call WITHOUT a name filter over the same source is answerable and stays quiet
+query I
+SELECT COUNT(*) FROM ast_select('test/data/call_extraction/calls.sh', '.call');
+----
+1
+
+# Unknown attribute names error instead of falling through to `ELSE false`
+# (which silently matched nothing)
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.c', '.call[frobnicate=x]');
+----
+unknown attribute "[frobnicate...]"
+
+# Documented-looking operators the dispatch silently ignored now error:
+# type/language/semantic/params implement exact match only
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.c', '[type^=call]');
+----
+attribute "type" only supports exact match
+
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.c', '[semantic$=CALL]');
+----
+attribute "semantic" only supports exact match
+
+# modifier is a list: = and *= both mean "has this modifier"; ^=/$= are not
+# implementable and used to silently degrade to containment
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.c', '.func[modifier^=sta]');
+----
+attribute "modifier" supports = and *=
+
+# Exact-match forms still work (regression guard for the new validation)
+query I
+SELECT COUNT(*) FROM ast_select('test/data/call_extraction/calls.c', '[type=call_expression]');
+----
+8
+
+# Operators stay supported on name
+query II
+SELECT name, start_line
+FROM ast_select('test/data/call_extraction/calls.c', '.call[name^=fse]')
+ORDER BY start_line;
+----
+fseeko	13
+fseeko	20
+
+# Unknown pseudo-elements error: the routing UNION has no arm for them, so
+# ::bogus silently returned 0 rows
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.c', 'function_definition::bogus');
+----
+unknown pseudo-element "::bogus"
+
+# Known pseudo-elements still route (regression guard), row-pinned
+query II
+SELECT name, start_line
+FROM ast_select('test/data/call_extraction/calls.c', 'function_definition#read_block::callers')
+ORDER BY start_line;
+----
+main	26
+
+# :has() arguments only honor a type, #name, and .class — anything else was
+# silently DROPPED, making :has match more than asked (silently wrong results).
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.c', '.func:has([name=fseeko])');
+----
+attribute filters inside :has(...) are not supported
+
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.c', '.func:has(.call:first-child)');
+----
+pseudo-classes inside :has(...) are not supported
+
+statement error
+SELECT * FROM ast_select('test/data/call_extraction/calls.c', '.func:has(if_statement > call_expression)');
+----
+combinators inside :has(...) are not supported
+
+# The supported :has forms keep working (compound type + #name)
+query II
+SELECT name, start_line
+FROM ast_select('test/data/call_extraction/calls.c', '.func:has(call_expression#ftello)')
+ORDER BY start_line;
+----
+read_block	12
+
+# =============================================================================
+# Section 5: guards fire even when the base match is EMPTY. The #83 peek guard
+# lived in matched_raw's WHERE, which is never evaluated over an empty base —
+# exactly the silent-empty situations being guarded. All validations now gate
+# matched_base via sel_props.validations_ok (a join build side, always
+# materialized).
+# =============================================================================
+
+statement ok
+CREATE TABLE zz_issue89_no_peek AS
+SELECT * FROM read_ast('test/data/call_extraction/calls.c', peek := 'none+schema');
+
+# The type filter matches nothing -> base is empty -> the peek guard must
+# STILL fire (before this fix it silently returned 0 rows).
+statement error
+SELECT * FROM ast_select_from('zz_issue89_no_peek', 'zz_no_such_type[peek*=x]');
+----
+no peek text
+
+statement ok
+DROP TABLE zz_issue89_no_peek;
+
+# =============================================================================
+# Section 6: ast_get_calls over C (was untested for C-family)
+# =============================================================================
+
+query III
+SELECT caller_name, called_name, start_line
+FROM ast_get_calls('test/data/call_extraction/calls.c')
+ORDER BY start_line, called_name;
+----
+read_block	check_offset	13
+read_block	fseeko	13
+read_block	ftello	16
+skip_block	fseeko	20
+skip_block	seek_fn	23
+main	read_block	28
+main	printf	29
+main	skip_block	30


### PR DESCRIPTION
Fixes #88. Advances #89 (call-name binding + attribute validation; the meta-issue stays open for the remaining candidates).

## Ground truth first (what actually carries call names)

The issue-#88 repro does **not** reproduce on current main or on the community binary (`f7b9c60`): C and C++ `call_expression` nodes ARE self-named by `FIND_CALL_TARGET` (verified on the exact field file, `plink-ng/2.0/include/pgenlib_read.cc`: `.call#fseeko` = 18 rows, `.func:has(.call#fseeko)` = 6 functions, matching the `read_ast` self-join). The `38` in the repro counts *all* nodes named `fseeko` (18 call nodes + child identifiers), not 38 unnamed call sites.

Auditing all 27 registered grammars for call-semantic node naming found the real, still-present false-empties — the same failure mode, different grammars:

| Grammar | Call anatomy | Before |
|---|---|---|
| Kotlin | `call_expression > simple_identifier` / `navigation_expression > navigation_suffix > simple_identifier` | **unnamed** |
| Swift | same shape as Kotlin | **unnamed** |
| PHP | `function_call_expression > name`, `member_call_expression > variable_name, ->, name`, `scoped_call_expression`, `object_creation_expression > new, name` | **unnamed** |
| C# | `invocation_expression > member_access_expression` (member calls) | **unnamed** |
| Lua | `function_call > method_index_expression` (the wrapper node) | **unnamed** |
| bash | `command_substitution` — no single callee exists | unnamed (legitimately) |
| dart | grammar has **no call node at all** (calls are flat `identifier + selector` sequences) | not classifiable here — separate classification issue |

## Layer choice: B (extraction uniformity) + A-side guard

**Option B** — `FIND_CALL_TARGET` in `language_adapter.cpp` is the single shared strategy all 27 grammars dispatch through, so extending its type sets fixes every broken grammar at once and keeps `#name`-on-call *a plain column filter* (no per-candidate EXISTS join, zero cost to the selector engine):
- callee-identifier leaf set now includes `simple_identifier` (Kotlin/Swift) and `name` (PHP)
- member-access set now includes `navigation_expression`, `member_access_expression`, `method_index_expression`, `variable_name`
- the member fallback now finds the *rightmost identifier-like descendant* (depth-bounded, never descending into argument containers) — needed because Kotlin/Swift nest the method name inside `navigation_suffix`; degenerates to the old direct-child scan for Python/JS/C++
- sibling scans stop at argument containers (`argument_list`, `arguments`, `call_suffix`, `value_arguments`) so an argument can never be mistaken for the callee

**Option A guard** (#89) — where extraction still can't bind (bash `command_substitution`, future grammars, tables built without name extraction), `#name`-bound-to-call now **errors** instead of returning 0 rows:

> `ast_select: the selector binds a name to call nodes (e.g. .call#foo) but no call node in this source carries a callee name…`

Fires for `.call#x`, `.call[name=x]`, `:has(.call#x)`, and `:not(:has(.call#x))` (where the failure mode is matching *everything*). Stays silent when only *some* calls are unnamed — mixed sources are legitimate (#89's false-alarm asymmetry).

## #89 hardening beyond calls

- **Unknown attribute names error** — `[frobnicate=x]` previously fell through the dispatch CASE to `ELSE false` and silently matched nothing.
- **Documented-but-ignored operators error** — `type`/`language`/`semantic`/`params` only implement `=` (the dispatch ignored `^= $= *=`, silently doing exact match); `modifier` implements `=`/`*=` (list containment) and ignored `^= $=`. All now rejected with targeted messages. Docs updated to match (`docs/reference/css-attributes.md`).
- **Unknown pseudo-elements error** — `::bogus` fell through every arm of the routing UNION and silently returned 0 rows.
- **Unsupported `:has()` arguments error** — `has_conditions` extracts only a type, `#name`, and `.class` from the `:has(...)` argument; attribute filters, pseudo-classes, and combinators inside it were silently *dropped*, making `:has` match more than asked (silently wrong, the same failure family).
- **Guards now fire on empty base matches** — all validations (including #83's `peek_filter_validation`) moved from `matched_raw`'s WHERE into `sel_props.validations_ok`, which every `matched_base` branch checks. A guard in `matched_raw` is only evaluated for rows that *survived* the base filters — and the guarded situations produce an empty base, exactly where DuckDB is free to skip the filter. As a join build side, `sel_props` is materialized regardless of probe cardinality, so `error()` cannot be skipped. (Row-pinned test: `zz_no_such_type[peek*=x]` over a no-peek table now errors; the type filter matching nothing previously made this silently return 0.)
- **NOT guarded** (per #89's asymmetry): all-NULL `signature`/`modifiers`/`annotations` stay silent (legitimate for untyped code), and `.call#absent-name` over *named* calls returns a clean 0 (that's a true "not there"). Tables parsed with `context := 'node_types_only'` drop the `name` column entirely and already fail loudly at bind time.

## #86 (receiver) — deliberately untouched

This PR's machinery resolves the callee *name*; `[receiver=X]` needs the callee's *object subtree*, which is a different extraction product (a new native field or a structural join). Not forced here — but the per-grammar member-access type map added to `FIND_CALL_TARGET` is exactly the node inventory a structural receiver implementation will need.

## Tests

`test/sql/bugs/issue_88_89_callee_name_and_guards.test`, row-pinned per #83:
- C fixture: `.call#fseeko` and `.func:has(.call#fseeko)` pinned by name+line, **and asserted equal to the raw `read_ast` subtree join**
- Python parity twin (self-naming grammar) — same selector shapes, both directions
- per-grammar callee-name pinning for kotlin/swift/php/cs/lua fixtures (every previously-unnamed shape)
- every error path asserts its message; every legitimately-empty path has a pinned positive twin
- unknown pseudo-element, :has-argument, unknown-attribute, and operator-combo rejections each assert their message, with working-form regression twins
- `ast_get_calls` over C (was untested for C-family)

Full suite: **12610 assertions in 220 test cases, 0 failures** (the runner registers each of the 110 test files twice — relative + absolute path; single-pass equivalent 6305, was 6137 at #83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mKzPp2FxHQaP3djX597C6
