### PR TITLE
build: compile-time built-in language selection (SITTING_DUCK_LANGUAGES)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -64,6 +64,31 @@ jobs:
           # registration needed core_functions this command would have failed
           # before -c even ran. Record what the shell reports for diagnosis.
           ./build/release/duckdb -c "SELECT extension_name, loaded FROM duckdb_extensions() WHERE extension_name IN ('sitting_duck','core_functions');"
+  # Built-in languages are compile-time modules selected via
+  # -DSITTING_DUCK_LANGUAGES / -DSITTING_DUCK_EXCLUDE_LANGUAGES (groundwork for
+  # grammar packs / sitting_duckling, issue #87). The default legs above always
+  # build all languages, so this job keeps the subset path honest: build a
+  # two-language subset and verify that compiled-in languages parse, compiled-out
+  # languages fail exactly like unknown ones, and ast_supported_languages()
+  # reflects the subset.
+  language-subset-build:
+    name: Language subset build (python;cpp)
+    runs-on: ubuntu-latest
+    env:
+      GEN: ninja
+      OVERRIDE_GIT_DESCRIBE: v1.5.4
+      EXT_FLAGS: -DSITTING_DUCK_LANGUAGES="python;cpp"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout required submodules
+        # Pre-generated parsers are committed, so grammar submodules are not needed
+        run: git submodule update --init duckdb extension-ci-tools third_party/tree-sitter
+      - name: Install ninja
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+      - name: Build subset
+        run: make release
+      - name: Smoke test subset behavior
+        run: ./scripts/test_language_subset.sh build/release/duckdb
 
   duckdb-next-build:
     name: Build extension binaries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,11 +220,23 @@ if(NOT WASM_LOADABLE_EXTENSIONS)
             ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 endif()
 
+#############################
+# Built-in Language Selection
+#############################
+# Each built-in language (grammar + adapter + semantic config) is a build-time
+# module declared in cmake/BuiltinLanguages.cmake and selected via
+# -DSITTING_DUCK_LANGUAGES / -DSITTING_DUCK_EXCLUDE_LANGUAGES (default: all).
+# Groundwork for grammar packs / sitting_duckling (issue #87).
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/BuiltinLanguages.cmake)
+sitting_duck_configure_languages(${PARSER_SOURCE_DIR})
+
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
 include_directories(src/include)
+# Generated built-in language registration table (sitting_duck_builtin_languages.def)
+include_directories(${SD_LANGUAGE_DEF_INCLUDE_DIR})
 # Include tree-sitter headers - both public API and internal headers
 include_directories(third_party/tree-sitter/lib/include)
 include_directories(third_party/tree-sitter/lib/src)
@@ -274,33 +286,8 @@ set(EXTENSION_SOURCES
     src/sitting_duck_extension.cpp
     src/language_adapter.cpp
     src/language_adapter_registry_init.cpp
-    src/language_adapters/python_adapter.cpp
-    src/language_adapters/javascript_adapter.cpp
-    src/language_adapters/cpp_adapter.cpp
-    src/language_adapters/typescript_adapter.cpp
-    src/language_adapters/sql_adapter.cpp
-    src/language_adapters/duckdb_adapter.cpp
-    src/language_adapters/go_adapter.cpp
-    src/language_adapters/ruby_adapter.cpp
-    src/language_adapters/markdown_adapter.cpp
-    src/language_adapters/java_adapter.cpp
-    src/language_adapters/php_adapter.cpp
-    src/language_adapters/rust_adapter.cpp
-    src/language_adapters/html_adapter.cpp
-    src/language_adapters/css_adapter.cpp
-    src/language_adapters/c_adapter.cpp
-    src/language_adapters/json_adapter.cpp
-    src/language_adapters/bash_adapter.cpp
-    src/language_adapters/swift_adapter.cpp
-    src/language_adapters/r_adapter.cpp
-    src/language_adapters/kotlin_adapter.cpp
-    src/language_adapters/csharp_adapter.cpp
-    src/language_adapters/lua_adapter.cpp
-    src/language_adapters/hcl_adapter.cpp
-    src/language_adapters/graphql_adapter.cpp
-    src/language_adapters/toml_adapter.cpp
-    src/language_adapters/zig_adapter.cpp
-    src/language_adapters/dart_adapter.cpp
+    # Per-language adapter sources for the enabled languages (cmake/BuiltinLanguages.cmake)
+    ${SD_LANGUAGE_ADAPTER_SOURCES}
     src/read_ast_streaming_function.cpp
     # src/read_ast_objects_hybrid.cpp (removed - objects API not used)
     src/ast_sql_macros.cpp
@@ -317,53 +304,9 @@ set(EXTENSION_SOURCES
     src/ast_supported_languages_function.cpp
     src/ast_type_map_function.cpp
     src/native_context_extraction.cpp
-    # Parser source files - from PARSER_SOURCE_DIR (either generated_parsers/ or grammars/)
-    ${PARSER_SOURCE_DIR}/tree-sitter-python/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-python/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-javascript/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-javascript/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-cpp/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-cpp/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-typescript/typescript/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-typescript/typescript/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-sql/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-sql/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-go/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-ruby/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-ruby/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-markdown/tree-sitter-markdown/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-markdown/tree-sitter-markdown/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-java/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-php/php/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-php/php/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-html/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-html/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-css/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-css/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-c/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-rust/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-rust/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-json/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-bash/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-bash/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-swift/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-swift/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-r/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-r/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-kotlin/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-kotlin/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-c-sharp/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-c-sharp/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-lua/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-lua/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-hcl/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-hcl/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-graphql/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-toml/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-toml/src/scanner.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-zig/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-dart/src/parser.c
-    ${PARSER_SOURCE_DIR}/tree-sitter-dart/src/scanner.c
+    # Parser source files for the enabled languages - from PARSER_SOURCE_DIR
+    # (either generated_parsers/ or grammars/), see cmake/BuiltinLanguages.cmake
+    ${SD_LANGUAGE_PARSER_SOURCES}
     )
 
 # For WASM builds, include tree-sitter source directly in the extension sources

--- a/cmake/BuiltinLanguages.cmake
+++ b/cmake/BuiltinLanguages.cmake
@@ -1,0 +1,222 @@
+# Built-in language selection for sitting_duck.
+#
+# Every built-in language is declared once, below, with everything the build
+# needs to include or exclude it as a unit: its adapter translation unit, its
+# vendored tree-sitter parser sources, and the C++ adapter class name used by
+# the generated registration table.
+#
+# Selection is controlled by two cache variables:
+#
+#   -DSITTING_DUCK_LANGUAGES="python;cpp"     build only these languages
+#                                             (default "all"; commas also
+#                                             accepted: "python,cpp")
+#   -DSITTING_DUCK_EXCLUDE_LANGUAGES="dart"   subtract languages from the set
+#
+# Unknown names fail the configure step. The enabled set is emitted as an
+# X-macro table (sitting_duck_builtin_languages.def) consumed by
+# src/language_adapter_registry_init.cpp, so registration and parse dispatch
+# compile only the enabled adapters. Runtime extension/alias maps are filtered
+# through the adapter registry (see src/ast_file_utils.cpp), so an excluded
+# language behaves exactly like an unknown one.
+#
+# This is groundwork for grammar packs / the slim "sitting_duckling" build:
+# https://github.com/teaguesterling/sitting_duck/issues/87
+
+# sitting_duck_language(<name> <AdapterClass> <TS|NATIVE>
+#                       ADAPTER <adapter.cpp>
+#                       [PARSERS <parser sources relative to PARSER_SOURCE_DIR>...])
+macro(sitting_duck_language NAME CLASS KIND)
+    cmake_parse_arguments(_SDL "" "ADAPTER" "PARSERS" ${ARGN})
+    list(APPEND SITTING_DUCK_ALL_LANGUAGES ${NAME})
+    set(SD_LANG_${NAME}_CLASS ${CLASS})
+    set(SD_LANG_${NAME}_KIND ${KIND})
+    set(SD_LANG_${NAME}_ADAPTER ${_SDL_ADAPTER})
+    set(SD_LANG_${NAME}_PARSERS ${_SDL_PARSERS})
+endmacro()
+
+# Declaration order is registration order (must match the historical order of
+# LanguageAdapterRegistry::InitializeDefaultAdapters); user-supplied language
+# lists are re-sorted into this order so a subset build registers languages in
+# the same relative order as the full build.
+set(SITTING_DUCK_ALL_LANGUAGES "")
+
+sitting_duck_language(python PythonAdapter TS
+    ADAPTER src/language_adapters/python_adapter.cpp
+    PARSERS tree-sitter-python/src/parser.c tree-sitter-python/src/scanner.c)
+sitting_duck_language(javascript JavaScriptAdapter TS
+    ADAPTER src/language_adapters/javascript_adapter.cpp
+    PARSERS tree-sitter-javascript/src/parser.c tree-sitter-javascript/src/scanner.c)
+sitting_duck_language(cpp CPPAdapter TS
+    ADAPTER src/language_adapters/cpp_adapter.cpp
+    PARSERS tree-sitter-cpp/src/parser.c tree-sitter-cpp/src/scanner.c)
+sitting_duck_language(typescript TypeScriptAdapter TS
+    ADAPTER src/language_adapters/typescript_adapter.cpp
+    PARSERS tree-sitter-typescript/typescript/src/parser.c tree-sitter-typescript/typescript/src/scanner.c)
+sitting_duck_language(sql SQLAdapter TS
+    ADAPTER src/language_adapters/sql_adapter.cpp
+    PARSERS tree-sitter-sql/src/parser.c tree-sitter-sql/src/scanner.c)
+# DuckDB native parser - SQL parsing with database-native accuracy (no
+# tree-sitter grammar; the adapter wraps DuckDB's own parser).
+sitting_duck_language(duckdb DuckDBAdapter NATIVE
+    ADAPTER src/language_adapters/duckdb_adapter.cpp)
+sitting_duck_language(go GoAdapter TS
+    ADAPTER src/language_adapters/go_adapter.cpp
+    PARSERS tree-sitter-go/src/parser.c)
+sitting_duck_language(ruby RubyAdapter TS
+    ADAPTER src/language_adapters/ruby_adapter.cpp
+    PARSERS tree-sitter-ruby/src/parser.c tree-sitter-ruby/src/scanner.c)
+sitting_duck_language(markdown MarkdownAdapter TS
+    ADAPTER src/language_adapters/markdown_adapter.cpp
+    PARSERS tree-sitter-markdown/tree-sitter-markdown/src/parser.c
+            tree-sitter-markdown/tree-sitter-markdown/src/scanner.c)
+sitting_duck_language(java JavaAdapter TS
+    ADAPTER src/language_adapters/java_adapter.cpp
+    PARSERS tree-sitter-java/src/parser.c)
+sitting_duck_language(php PHPAdapter TS
+    ADAPTER src/language_adapters/php_adapter.cpp
+    PARSERS tree-sitter-php/php/src/parser.c tree-sitter-php/php/src/scanner.c)
+sitting_duck_language(html HTMLAdapter TS
+    ADAPTER src/language_adapters/html_adapter.cpp
+    PARSERS tree-sitter-html/src/parser.c tree-sitter-html/src/scanner.c)
+sitting_duck_language(css CSSAdapter TS
+    ADAPTER src/language_adapters/css_adapter.cpp
+    PARSERS tree-sitter-css/src/parser.c tree-sitter-css/src/scanner.c)
+sitting_duck_language(c CAdapter TS
+    ADAPTER src/language_adapters/c_adapter.cpp
+    PARSERS tree-sitter-c/src/parser.c)
+sitting_duck_language(rust RustAdapter TS
+    ADAPTER src/language_adapters/rust_adapter.cpp
+    PARSERS tree-sitter-rust/src/parser.c tree-sitter-rust/src/scanner.c)
+sitting_duck_language(json JSONAdapter TS
+    ADAPTER src/language_adapters/json_adapter.cpp
+    PARSERS tree-sitter-json/src/parser.c)
+sitting_duck_language(bash BashAdapter TS
+    ADAPTER src/language_adapters/bash_adapter.cpp
+    PARSERS tree-sitter-bash/src/parser.c tree-sitter-bash/src/scanner.c)
+sitting_duck_language(swift SwiftAdapter TS
+    ADAPTER src/language_adapters/swift_adapter.cpp
+    PARSERS tree-sitter-swift/src/parser.c tree-sitter-swift/src/scanner.c)
+sitting_duck_language(r RAdapter TS
+    ADAPTER src/language_adapters/r_adapter.cpp
+    PARSERS tree-sitter-r/src/parser.c tree-sitter-r/src/scanner.c)
+sitting_duck_language(kotlin KotlinAdapter TS
+    ADAPTER src/language_adapters/kotlin_adapter.cpp
+    PARSERS tree-sitter-kotlin/src/parser.c tree-sitter-kotlin/src/scanner.c)
+sitting_duck_language(csharp CSharpAdapter TS
+    ADAPTER src/language_adapters/csharp_adapter.cpp
+    PARSERS tree-sitter-c-sharp/src/parser.c tree-sitter-c-sharp/src/scanner.c)
+sitting_duck_language(lua LuaAdapter TS
+    ADAPTER src/language_adapters/lua_adapter.cpp
+    PARSERS tree-sitter-lua/src/parser.c tree-sitter-lua/src/scanner.c)
+sitting_duck_language(hcl HCLAdapter TS
+    ADAPTER src/language_adapters/hcl_adapter.cpp
+    PARSERS tree-sitter-hcl/src/parser.c tree-sitter-hcl/src/scanner.c)
+sitting_duck_language(graphql GraphQLAdapter TS
+    ADAPTER src/language_adapters/graphql_adapter.cpp
+    PARSERS tree-sitter-graphql/src/parser.c)
+sitting_duck_language(toml TOMLAdapter TS
+    ADAPTER src/language_adapters/toml_adapter.cpp
+    PARSERS tree-sitter-toml/src/parser.c tree-sitter-toml/src/scanner.c)
+sitting_duck_language(zig ZigAdapter TS
+    ADAPTER src/language_adapters/zig_adapter.cpp
+    PARSERS tree-sitter-zig/src/parser.c)
+sitting_duck_language(dart DartAdapter TS
+    ADAPTER src/language_adapters/dart_adapter.cpp
+    PARSERS tree-sitter-dart/src/parser.c tree-sitter-dart/src/scanner.c)
+
+#############################
+# Selection & validation
+#############################
+
+set(SITTING_DUCK_LANGUAGES "all" CACHE STRING
+    "Built-in languages to compile in ('all', or a ;- or ,-separated subset, e.g. python,cpp)")
+set(SITTING_DUCK_EXCLUDE_LANGUAGES "" CACHE STRING
+    "Built-in languages to compile out (;- or ,-separated; applied after SITTING_DUCK_LANGUAGES)")
+
+# sitting_duck_select_languages()
+#
+# Computes SD_ENABLED_LANGUAGES (canonical order) from the cache variables
+# above, failing the configure on unknown names or an empty result.
+function(sitting_duck_select_languages)
+    string(REPLACE "," ";" _requested "${SITTING_DUCK_LANGUAGES}")
+    string(REPLACE "," ";" _excluded "${SITTING_DUCK_EXCLUDE_LANGUAGES}")
+
+    if(_requested STREQUAL "all" OR _requested STREQUAL "")
+        set(_requested ${SITTING_DUCK_ALL_LANGUAGES})
+    endif()
+
+    set(_unknown "")
+    foreach(_lang IN LISTS _requested _excluded)
+        if(NOT _lang IN_LIST SITTING_DUCK_ALL_LANGUAGES)
+            list(APPEND _unknown ${_lang})
+        endif()
+    endforeach()
+    if(_unknown)
+        string(REPLACE ";" ", " _valid "${SITTING_DUCK_ALL_LANGUAGES}")
+        message(FATAL_ERROR
+            "sitting_duck: unknown language name(s) in SITTING_DUCK_LANGUAGES/"
+            "SITTING_DUCK_EXCLUDE_LANGUAGES: ${_unknown}\n"
+            "Valid names: all, ${_valid}")
+    endif()
+
+    # Intersect in canonical order so registration order is invariant.
+    set(_enabled "")
+    foreach(_lang IN LISTS SITTING_DUCK_ALL_LANGUAGES)
+        if(_lang IN_LIST _requested AND NOT _lang IN_LIST _excluded)
+            list(APPEND _enabled ${_lang})
+        endif()
+    endforeach()
+
+    if(NOT _enabled)
+        message(FATAL_ERROR
+            "sitting_duck: language selection is empty — SITTING_DUCK_LANGUAGES="
+            "'${SITTING_DUCK_LANGUAGES}' minus SITTING_DUCK_EXCLUDE_LANGUAGES="
+            "'${SITTING_DUCK_EXCLUDE_LANGUAGES}' leaves no languages to build")
+    endif()
+
+    set(SD_ENABLED_LANGUAGES ${_enabled} PARENT_SCOPE)
+endfunction()
+
+# sitting_duck_configure_languages(<parser_source_dir>)
+#
+# Runs selection, generates the registration X-macro table into the build tree,
+# and exposes:
+#   SD_ENABLED_LANGUAGES        enabled language names, canonical order
+#   SD_LANGUAGE_ADAPTER_SOURCES adapter .cpp files for enabled languages
+#   SD_LANGUAGE_PARSER_SOURCES  vendored parser .c files for enabled languages
+#   SD_LANGUAGE_DEF_INCLUDE_DIR include dir holding sitting_duck_builtin_languages.def
+function(sitting_duck_configure_languages PARSER_SOURCE_DIR)
+    sitting_duck_select_languages()
+
+    set(_adapters "")
+    set(_parsers "")
+    set(_def "// Generated by cmake/BuiltinLanguages.cmake — do not edit.\n")
+    string(APPEND _def "// Built-in languages enabled for this build (canonical registration order).\n")
+    string(APPEND _def "// Consumers define SD_BUILTIN_LANGUAGE_TS(name, AdapterClass) and\n")
+    string(APPEND _def "// SD_BUILTIN_LANGUAGE_NATIVE(name, AdapterClass) before including this file.\n")
+    foreach(_lang IN LISTS SD_ENABLED_LANGUAGES)
+        list(APPEND _adapters ${SD_LANG_${_lang}_ADAPTER})
+        foreach(_parser IN LISTS SD_LANG_${_lang}_PARSERS)
+            list(APPEND _parsers ${PARSER_SOURCE_DIR}/${_parser})
+        endforeach()
+        string(APPEND _def "SD_BUILTIN_LANGUAGE_${SD_LANG_${_lang}_KIND}(${_lang}, ${SD_LANG_${_lang}_CLASS})\n")
+    endforeach()
+
+    set(_def_dir "${CMAKE_CURRENT_BINARY_DIR}/sitting_duck_generated")
+    file(MAKE_DIRECTORY "${_def_dir}")
+    file(WRITE "${_def_dir}/sitting_duck_builtin_languages.def.tmp" "${_def}")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${_def_dir}/sitting_duck_builtin_languages.def.tmp"
+        "${_def_dir}/sitting_duck_builtin_languages.def")
+    file(REMOVE "${_def_dir}/sitting_duck_builtin_languages.def.tmp")
+
+    list(LENGTH SD_ENABLED_LANGUAGES _enabled_count)
+    list(LENGTH SITTING_DUCK_ALL_LANGUAGES _total_count)
+    string(REPLACE ";" ", " _enabled_pretty "${SD_ENABLED_LANGUAGES}")
+    message(STATUS "sitting_duck: building ${_enabled_count}/${_total_count} built-in languages: ${_enabled_pretty}")
+
+    set(SD_ENABLED_LANGUAGES ${SD_ENABLED_LANGUAGES} PARENT_SCOPE)
+    set(SD_LANGUAGE_ADAPTER_SOURCES ${_adapters} PARENT_SCOPE)
+    set(SD_LANGUAGE_PARSER_SOURCES ${_parsers} PARENT_SCOPE)
+    set(SD_LANGUAGE_DEF_INCLUDE_DIR "${_def_dir}" PARENT_SCOPE)
+endfunction()

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -42,6 +42,9 @@ EXT_FLAGS='-DSITTING_DUCK_EXCLUDE_LANGUAGES=dart,swift' make release
 ```
 
 Unknown language names fail the configure step with the list of valid names.
+Like any CMake cache variable, the selection sticks to the build directory:
+to return an existing build to the full set, pass
+`-DSITTING_DUCK_LANGUAGES=all` (or wipe the build directory).
 The per-language wiring lives in one place, `cmake/BuiltinLanguages.cmake`,
 which generates the registration table consumed by
 `src/language_adapter_registry_init.cpp`.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -27,6 +27,39 @@ CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make
 make test
 ```
 
+### Building a Language Subset
+
+Every built-in language (tree-sitter grammar + adapter + semantic-type config)
+is a build-time module. The default build compiles all of them; two CMake cache
+variables select a subset:
+
+```bash
+# Only these languages (comma or semicolon separated; semicolons need quoting)
+EXT_FLAGS='-DSITTING_DUCK_LANGUAGES=python,cpp' make release
+
+# Or subtract from the full set
+EXT_FLAGS='-DSITTING_DUCK_EXCLUDE_LANGUAGES=dart,swift' make release
+```
+
+Unknown language names fail the configure step with the list of valid names.
+The per-language wiring lives in one place, `cmake/BuiltinLanguages.cmake`,
+which generates the registration table consumed by
+`src/language_adapter_registry_init.cpp`.
+
+A compiled-out language behaves exactly like a language sitting_duck never
+supported: `detect_language()` misses its extensions, glob expansion skips its
+files, and naming it explicitly raises the usual `Unsupported language` error.
+`ast_supported_languages()` reflects only what was compiled in. (Once runtime
+grammar registration lands, a compiled-out language's name is deliberately free
+for runtime registration — built-ins only shadow names they actually contain.)
+
+Subset builds exist as groundwork for grammar packs and the slim
+"sitting_duckling" distribution — see
+[issue #87](https://github.com/teaguesterling/sitting_duck/issues/87).
+`scripts/test_language_subset.sh` smoke-tests a `python;cpp` build (run in CI by
+the `language-subset-build` job). Note that the SQL test suite assumes the full
+set; run it against a default build.
+
 ## Development Workflow
 
 ### Making Changes

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -1,9 +1,14 @@
 # This file is included by DuckDB's build system. It specifies which extension to load
 
+# core_functions must load before sitting_duck: the generated static loader
+# (LoadAllExtensions) loads extensions in the order listed here, and
+# sitting_duck's embedded SQL macros use core_functions operators (e.g. "&").
+# With sitting_duck listed first, the built duckdb shell failed at startup with
+# 'Scalar Function with name "&" is not in the catalog'.
+duckdb_extension_load(core_functions)
+
 # Extension from this repo
 duckdb_extension_load(sitting_duck
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
 )
-
-duckdb_extension_load(core_functions)

--- a/scripts/test_language_subset.sh
+++ b/scripts/test_language_subset.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Smoke test for a language-subset build (see cmake/BuiltinLanguages.cmake and
+# docs/development/contributing.md). Expects a build configured with
+#   -DSITTING_DUCK_LANGUAGES="python;cpp"
+# and verifies that:
+#   1. ast_supported_languages() lists exactly the subset
+#   2. a compiled-in language parses (python file, plus the "py" alias)
+#   3. a compiled-out language fails exactly like an unknown one
+#      (detect_language() misses; explicit language errors cleanly)
+#
+# Usage: scripts/test_language_subset.sh [path/to/duckdb]
+set -euo pipefail
+
+DUCKDB=${1:-build/release/duckdb}
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+run_sql() {
+    "$DUCKDB" -noheader -list -c "$1"
+}
+
+# Expect the SQL to error, with the message matching the given grep pattern.
+expect_error() {
+    local sql=$1 pattern=$2 label=$3
+    local out
+    if out=$("$DUCKDB" -c "$sql" 2>&1); then
+        fail "$label: expected an error, got success: $out"
+    fi
+    echo "$out" | grep -q "$pattern" || fail "$label: error did not match '$pattern': $out"
+    echo "ok: $label"
+}
+
+cat > "$WORKDIR/hello.py" <<'EOF'
+def hello(name):
+    return f"hello {name}"
+EOF
+
+cat > "$WORKDIR/hello.go" <<'EOF'
+package main
+
+func main() {}
+EOF
+
+# 1. Supported languages reflect exactly the compiled subset
+langs=$(run_sql "SELECT string_agg(language, ',' ORDER BY language) FROM ast_supported_languages();")
+[ "$langs" = "cpp,python" ] || fail "ast_supported_languages() = '$langs', expected 'cpp,python'"
+echo "ok: ast_supported_languages() lists exactly cpp,python"
+
+# 2. Compiled-in language parses, by extension and by alias
+count=$(run_sql "SELECT count(*) FROM read_ast('$WORKDIR/hello.py');")
+[ "$count" -gt 0 ] || fail "read_ast on python file returned $count nodes"
+echo "ok: read_ast parses python ($count nodes)"
+
+count=$(run_sql "SELECT count(*) FROM parse_ast('def f(): pass', 'py');")
+[ "$count" -gt 0 ] || fail "parse_ast with 'py' alias returned $count nodes"
+echo "ok: parse_ast accepts the 'py' alias"
+
+detected=$(run_sql "SELECT detect_language('$WORKDIR/hello.py');")
+[ "$detected" = "python" ] || fail "detect_language(.py) = '$detected', expected 'python'"
+echo "ok: detect_language maps .py to python"
+
+# 3. Compiled-out language behaves exactly like an unknown language
+detected=$(run_sql "SELECT coalesce(detect_language('$WORKDIR/hello.go'), '<null>');")
+[ "$detected" = "<null>" ] || fail "detect_language(.go) = '$detected', expected NULL (detection miss)"
+echo "ok: detect_language misses .go (compiled out)"
+
+expect_error "SELECT * FROM read_ast('$WORKDIR/hello.go');" \
+    "Could not detect language" "read_ast on a .go file errors like an unknown extension"
+
+expect_error "SELECT * FROM read_ast('$WORKDIR/hello.go', 'go');" \
+    "Unsupported language: go" "read_ast with explicit language 'go' errors cleanly"
+
+expect_error "SELECT * FROM parse_ast('package main', 'go');" \
+    "Unsupported language: go" "parse_ast with 'go' errors cleanly"
+
+# Excluded language's extensions are gone from the extension map
+exts=$(run_sql "SELECT count(*) FROM (SELECT unnest(extensions) FROM ast_supported_languages() WHERE language = 'go');")
+[ "$exts" = "0" ] || fail "go still advertises extensions in ast_supported_languages()"
+
+echo "PASS: language subset build behaves correctly"

--- a/src/ast_file_utils.cpp
+++ b/src/ast_file_utils.cpp
@@ -1,13 +1,21 @@
 #include "ast_file_utils.hpp"
+#include "language_adapter.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/file_system.hpp"
 #include <algorithm>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace duckdb {
 
-// Static mapping of file extensions to languages
+// Static mapping of file extensions to languages, covering every language
+// sitting_duck can be built with. Lookups go through the accessors below,
+// which filter these tables against the adapter registry once, so a language
+// compiled out via -DSITTING_DUCK_LANGUAGES behaves exactly like a language
+// sitting_duck never heard of: extension detection misses and glob expansion
+// has no extensions to match. In the default (all languages) build the
+// filtered tables are identical to these.
 static const std::unordered_map<string, string> EXTENSION_TO_LANGUAGE = {
     {"cpp", "cpp"},
     {"cc", "cpp"},
@@ -97,6 +105,46 @@ static const std::unordered_map<string, vector<string>> LANGUAGE_TO_EXTENSIONS =
     {"toml", {"toml"}},
     {"zig", {"zig"}},
     {"dart", {"dart"}}};
+
+// Built-in languages actually compiled into this build. The built-in set is
+// fixed once LanguageAdapterRegistry is constructed, so caching it here is
+// safe; runtime-registered languages (future work) must extend detection via
+// the registry, not these static tables.
+static const std::unordered_set<string> &GetCompiledLanguages() {
+	static const std::unordered_set<string> compiled = [] {
+		auto languages = LanguageAdapterRegistry::GetInstance().GetSupportedLanguages();
+		return std::unordered_set<string>(languages.begin(), languages.end());
+	}();
+	return compiled;
+}
+
+static const std::unordered_map<string, string> &GetExtensionToLanguageMap() {
+	static const std::unordered_map<string, string> filtered = [] {
+		const auto &compiled = GetCompiledLanguages();
+		std::unordered_map<string, string> result;
+		for (const auto &entry : EXTENSION_TO_LANGUAGE) {
+			if (compiled.count(entry.second)) {
+				result.insert(entry);
+			}
+		}
+		return result;
+	}();
+	return filtered;
+}
+
+static const std::unordered_map<string, vector<string>> &GetLanguageToExtensionsMap() {
+	static const std::unordered_map<string, vector<string>> filtered = [] {
+		const auto &compiled = GetCompiledLanguages();
+		std::unordered_map<string, vector<string>> result;
+		for (const auto &entry : LANGUAGE_TO_EXTENSIONS) {
+			if (compiled.count(entry.first)) {
+				result.insert(entry);
+			}
+		}
+		return result;
+	}();
+	return filtered;
+}
 
 vector<string> ASTFileUtils::GetFiles(ClientContext &context, const Value &path_value, bool ignore_errors,
                                       const vector<string> &supported_extensions) {
@@ -272,9 +320,10 @@ string ASTFileUtils::DetectLanguageFromPath(const string &file_path) {
 	// Convert to lowercase for case-insensitive matching
 	std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
 
-	// Look up the language
-	auto it = EXTENSION_TO_LANGUAGE.find(extension);
-	if (it != EXTENSION_TO_LANGUAGE.end()) {
+	// Look up the language (compiled-in languages only)
+	const auto &extension_map = GetExtensionToLanguageMap();
+	auto it = extension_map.find(extension);
+	if (it != extension_map.end()) {
 		return it->second;
 	}
 
@@ -287,11 +336,12 @@ bool ASTFileUtils::IsFileTypeSupported(const string &file_path, const string &la
 }
 
 vector<string> ASTFileUtils::GetSupportedExtensions(const string &language) {
-	auto it = LANGUAGE_TO_EXTENSIONS.find(language);
-	if (it != LANGUAGE_TO_EXTENSIONS.end()) {
+	const auto &language_map = GetLanguageToExtensionsMap();
+	auto it = language_map.find(language);
+	if (it != language_map.end()) {
 		return it->second;
 	}
-	return {}; // Language not recognized
+	return {}; // Language not recognized (or not compiled into this build)
 }
 
 // Helper function to check if a file extension is in the supported list

--- a/src/language_adapter_registry_init.cpp
+++ b/src/language_adapter_registry_init.cpp
@@ -4,54 +4,29 @@
 #include "unified_ast_backend_impl.hpp"
 #include "duckdb/common/helper.hpp"
 
+// Built-in language registration and parse dispatch.
+//
+// The set of built-in languages is a compile-time decision: CMake generates
+// sitting_duck_builtin_languages.def (from cmake/BuiltinLanguages.cmake, driven
+// by -DSITTING_DUCK_LANGUAGES / -DSITTING_DUCK_EXCLUDE_LANGUAGES) listing one
+// SD_BUILTIN_LANGUAGE_TS/SD_BUILTIN_LANGUAGE_NATIVE entry per enabled language,
+// in canonical registration order. Everything language-specific in this file is
+// expanded from that table, so a compiled-out language contributes no code here
+// and its adapter translation unit never links. A compiled-out language behaves
+// exactly like an unknown one (and its name becomes free for runtime
+// registration once that lands).
+
 namespace duckdb {
 
 void LanguageAdapterRegistry::InitializeDefaultAdapters() {
 	// Register factories instead of creating adapters immediately
-	RegisterLanguageFactory("python", []() { return make_uniq<PythonAdapter>(); });
-	RegisterLanguageFactory("javascript", []() { return make_uniq<JavaScriptAdapter>(); });
-	RegisterLanguageFactory("cpp", []() { return make_uniq<CPPAdapter>(); });
-	RegisterLanguageFactory("typescript", []() { return make_uniq<TypeScriptAdapter>(); });
-	RegisterLanguageFactory("sql", []() { return make_uniq<SQLAdapter>(); });
-	// DuckDB native parser - SQL parsing with database-native accuracy
-	RegisterLanguageFactory("duckdb", []() { return make_uniq<DuckDBAdapter>(); });
-	RegisterLanguageFactory("go", []() { return make_uniq<GoAdapter>(); });
-	RegisterLanguageFactory("ruby", []() { return make_uniq<RubyAdapter>(); });
-	RegisterLanguageFactory("markdown", []() { return make_uniq<MarkdownAdapter>(); });
-	RegisterLanguageFactory("java", []() { return make_uniq<JavaAdapter>(); });
-	// PHP enabled - scanner dependency resolved with basic implementation
-	RegisterLanguageFactory("php", []() { return make_uniq<PHPAdapter>(); });
-	RegisterLanguageFactory("html", []() { return make_uniq<HTMLAdapter>(); });
-	RegisterLanguageFactory("css", []() { return make_uniq<CSSAdapter>(); });
-	RegisterLanguageFactory("c", []() { return make_uniq<CAdapter>(); });
-	// Rust enabled - complete implementation with semantic types
-	RegisterLanguageFactory("rust", []() { return make_uniq<RustAdapter>(); });
-	// JSON enabled - configuration and data format support
-	RegisterLanguageFactory("json", []() { return make_uniq<JSONAdapter>(); });
-	// YAML grammar has complex self-modifying structure incompatible with tree-sitter CLI
-	// RegisterLanguageFactory("yaml", []() { return make_uniq<YAMLAdapter>(); });
-	// Bash enabled - shell scripting support
-	RegisterLanguageFactory("bash", []() { return make_uniq<BashAdapter>(); });
-	// Swift enabled - iOS/macOS development support
-	RegisterLanguageFactory("swift", []() { return make_uniq<SwiftAdapter>(); });
-	// R enabled - statistical computing and data analysis support
-	RegisterLanguageFactory("r", []() { return make_uniq<RAdapter>(); });
-	// Kotlin enabled - JVM ecosystem and Android development support
-	RegisterLanguageFactory("kotlin", []() { return make_uniq<KotlinAdapter>(); });
-	// C# enabled - .NET ecosystem support
-	RegisterLanguageFactory("csharp", []() { return make_uniq<CSharpAdapter>(); });
-	// Lua enabled - game scripting, embedded systems, Neovim plugins
-	RegisterLanguageFactory("lua", []() { return make_uniq<LuaAdapter>(); });
-	// HCL enabled - Terraform, Vault, Nomad, Waypoint configuration
-	RegisterLanguageFactory("hcl", []() { return make_uniq<HCLAdapter>(); });
-	// GraphQL enabled - schema and query language
-	RegisterLanguageFactory("graphql", []() { return make_uniq<GraphQLAdapter>(); });
-	// TOML enabled - configuration file format (Cargo.toml, pyproject.toml, etc.)
-	RegisterLanguageFactory("toml", []() { return make_uniq<TOMLAdapter>(); });
-	// Zig enabled - modern systems programming language
-	RegisterLanguageFactory("zig", []() { return make_uniq<ZigAdapter>(); });
-	// Dart enabled - client-optimized language with sound null safety
-	RegisterLanguageFactory("dart", []() { return make_uniq<DartAdapter>(); });
+#define SD_BUILTIN_LANGUAGE_TS(name, ADAPTER_CLASS)                                                                    \
+	RegisterLanguageFactory(#name, []() { return make_uniq<ADAPTER_CLASS>(); });
+#define SD_BUILTIN_LANGUAGE_NATIVE(name, ADAPTER_CLASS)                                                                \
+	RegisterLanguageFactory(#name, []() { return make_uniq<ADAPTER_CLASS>(); });
+#include "sitting_duck_builtin_languages.def"
+#undef SD_BUILTIN_LANGUAGE_TS
+#undef SD_BUILTIN_LANGUAGE_NATIVE
 }
 
 // Phase 2: Template-based parsing with zero virtual calls - NEW ExtractionConfig version
@@ -67,115 +42,21 @@ ASTResult LanguageAdapterRegistry::ParseContentTemplated(const string &content, 
 
 	// CRITICAL FIX: Use fresh adapter instances to prevent static state accumulation
 	// Static adapters were causing cumulative memory leaks leading to segfaults after 3+ large queries
-	if (normalized_language == "python") {
-		PythonAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
+#define SD_BUILTIN_LANGUAGE_TS(name, ADAPTER_CLASS)                                                                    \
+	if (normalized_language == #name) {                                                                                \
+		ADAPTER_CLASS adapter; /* Fresh instance - no static state persistence */                                      \
+		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);           \
 	}
-	if (normalized_language == "javascript") {
-		JavaScriptAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
+	// Native (non-tree-sitter) parsers, i.e. the DuckDB adapter.
+	// TODO: DuckDB adapter should also support ExtractionConfig
+#define SD_BUILTIN_LANGUAGE_NATIVE(name, ADAPTER_CLASS)                                                                \
+	if (normalized_language == #name) {                                                                                \
+		ADAPTER_CLASS adapter; /* Fresh instance - no static state persistence */                                      \
+		return adapter.ParseSQL(content);                                                                              \
 	}
-	if (normalized_language == "cpp") {
-		CPPAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "typescript") {
-		TypeScriptAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "sql") {
-		SQLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "duckdb") {
-		DuckDBAdapter adapter; // Fresh instance - no static state persistence
-		// TODO: DuckDB adapter should also support ExtractionConfig
-		return adapter.ParseSQL(content);
-	}
-	if (normalized_language == "go") {
-		GoAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "ruby") {
-		RubyAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "markdown") {
-		MarkdownAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "java") {
-		JavaAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "php") {
-		PHPAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "html") {
-		HTMLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "css") {
-		CSSAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "c") {
-		CAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "rust") {
-		RustAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "json") {
-		JSONAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "bash") {
-		BashAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "swift") {
-		SwiftAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "r") {
-		RAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "kotlin") {
-		KotlinAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "csharp") {
-		CSharpAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "lua") {
-		LuaAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "hcl") {
-		HCLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "graphql") {
-		GraphQLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "toml") {
-		TOMLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "zig") {
-		ZigAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
-	if (normalized_language == "dart") {
-		DartAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, config);
-	}
+#include "sitting_duck_builtin_languages.def"
+#undef SD_BUILTIN_LANGUAGE_TS
+#undef SD_BUILTIN_LANGUAGE_NATIVE
 
 	// Fallback for unsupported languages
 	throw InvalidInputException("Unsupported language: " + language);
@@ -193,141 +74,21 @@ ASTResult LanguageAdapterRegistry::ParseContentTemplated(const string &content, 
 	}
 
 	// CRITICAL FIX: Use fresh adapter instances to prevent static state accumulation (legacy version)
-	if (normalized_language == "python") {
-		PythonAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
+#define SD_BUILTIN_LANGUAGE_TS(name, ADAPTER_CLASS)                                                                    \
+	if (normalized_language == #name) {                                                                                \
+		ADAPTER_CLASS adapter; /* Fresh instance - no static state persistence */                                      \
+		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,         \
+		                                                    peek_mode);                                                \
 	}
-	if (normalized_language == "javascript") {
-		JavaScriptAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
+	// DuckDB adapter uses native parser, not tree-sitter template system
+#define SD_BUILTIN_LANGUAGE_NATIVE(name, ADAPTER_CLASS)                                                                \
+	if (normalized_language == #name) {                                                                                \
+		ADAPTER_CLASS adapter; /* Fresh instance - no static state persistence */                                      \
+		return adapter.ParseSQL(content);                                                                              \
 	}
-	if (normalized_language == "cpp") {
-		CPPAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "typescript") {
-		TypeScriptAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "sql") {
-		SQLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "duckdb") {
-		DuckDBAdapter adapter; // Fresh instance - no static state persistence
-		// DuckDB adapter uses native parser, not tree-sitter template system
-		return adapter.ParseSQL(content);
-	}
-	if (normalized_language == "go") {
-		GoAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "ruby") {
-		RubyAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "markdown") {
-		MarkdownAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "java") {
-		JavaAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "php") {
-		PHPAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "html") {
-		HTMLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "css") {
-		CSSAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "c") {
-		CAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "rust") {
-		RustAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "json") {
-		JSONAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "bash") {
-		BashAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "swift") {
-		SwiftAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "r") {
-		RAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "kotlin") {
-		KotlinAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "csharp") {
-		CSharpAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "lua") {
-		LuaAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "hcl") {
-		HCLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "graphql") {
-		GraphQLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "toml") {
-		TOMLAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "zig") {
-		ZigAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
-	if (normalized_language == "dart") {
-		DartAdapter adapter; // Fresh instance - no static state persistence
-		return UnifiedASTBackend::ParseToASTResultTemplated(&adapter, content, language, file_path, peek_size,
-		                                                    peek_mode);
-	}
+#include "sitting_duck_builtin_languages.def"
+#undef SD_BUILTIN_LANGUAGE_TS
+#undef SD_BUILTIN_LANGUAGE_NATIVE
 
 	// Fallback for unsupported languages
 	throw InvalidInputException("Unsupported language: " + language);


### PR DESCRIPTION
Groundwork for grammar packs / the slim sitting_duckling build (#87): each of the 27 built-in languages (vendored tree-sitter grammar + compiled adapter + `.def` semantic config) is now a build-time module that can be included or excluded at configure time. The default build is unchanged — all 27 languages, same registration order.

## Interface

```bash
# Only these languages (comma or semicolon separated)
EXT_FLAGS='-DSITTING_DUCK_LANGUAGES=python,cpp' make release

# Or subtract from the full set
EXT_FLAGS='-DSITTING_DUCK_EXCLUDE_LANGUAGES=dart,swift' make release
```

Unknown names fail the configure loudly with the list of valid names; an empty selection fails too. User-supplied lists are re-sorted into canonical order so a subset registers languages in the same relative order as the full build.

## Mechanism

- **One place per language**: `cmake/BuiltinLanguages.cmake` declares each language once — adapter source, parser sources, adapter class, TS vs native kind — in canonical registration order.
- **Generated registration table**: CMake emits `sitting_duck_builtin_languages.def`, an X-macro list of `SD_BUILTIN_LANGUAGE_TS/NATIVE(name, AdapterClass)` entries for the enabled set. `src/language_adapter_registry_init.cpp` expands it three times (factory registration + both parse-dispatch chains), replacing ~330 lines of hand-written per-language dispatch. A compiled-out language contributes no code and its adapter TU never compiles or links.
- **Extension/alias maps**: the static tables in `ast_file_utils.cpp` keep full data, but lookups go through accessors filtered once against the adapter registry. No `#ifdef` spray anywhere.

## Behavior when a language is compiled out

Exactly like a language sitting_duck never supported: `detect_language()` returns NULL for its extensions, `read_ast` auto-detection errors with `Could not detect language`, glob expansion has no extensions to match, and naming it explicitly raises the usual `Unsupported language` error. `ast_supported_languages()` reflects only what was compiled in. Deliberate consequence for #80/#87: a compiled-out language's *name* (and aliases/extensions) becomes available for runtime `register_language` — built-ins only shadow names they actually contain.

## Size (the #87 headline)

| Build | `sitting_duck.duckdb_extension` | `duckdb` (CLI, static) |
|---|---|---|
| default (27 languages) | 67,706,606 B (64.6 MiB) | 87,040,416 B |
| `python;cpp` subset | 38,691,310 B (36.9 MiB) | 57,966,096 B |

Dropping 25 of 27 built-ins cuts the loadable extension by **29.0 MB (−42.9%)** — that's the weight a `sitting_duckling` core could shed even before splitting adapters from grammars.

## Validation

- Default build: full sqllogictest suite green — **218 test cases, 12,274 assertions, 0 failures** — with identical `ast_supported_languages()` output and registration order.
- Subset build (`python;cpp`): compiles, and `scripts/test_language_subset.sh` passes (subset listing, python parse + `py` alias, `.go` detection miss, clean errors for explicit `go`).
- Unknown-name and empty-selection configure failures verified end-to-end.
- New CI job `language-subset-build` (styled after `embedded-header-sync`) builds the `python;cpp` subset on Linux and runs the smoke script. Default distribution legs (including WASM) untouched.

## Drive-by fix

`extension_config.cmake` now loads `core_functions` before `sitting_duck`: the generated static loader loads in listed order, and sitting_duck's embedded SQL macros use core_functions operators (`&`), so the built `duckdb` shell failed at startup on main. The sqllogictest runner was unaffected (loads via `require`), which is why CI never saw it. The smoke script relies on a working CLI.

Refs #87. Runtime-registration interplay per #80's collision rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mKzPp2FxHQaP3djX597C6