### PR TITLE
feat: ast_to_blocks — render ASTs as duck_blocks documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,69 @@ FROM ast_match('code',
 
 See **[Pattern Matching Guide](docs/guide/pattern-matching.md)** for full documentation.
 
+## Rendering Code as Documents (duck_blocks)
+
+`ast_to_blocks` converts parsed ASTs into **duck_blocks** — the document-element
+STRUCT spec shared by the markdown / webbed / duck_block_utils extensions — so
+code structure renders as a readable document: definitions become headings
+(definition nesting depth → heading level), definition bodies become code
+blocks, and each file opens with a YAML metadata block.
+
+duck_blocks is a **spec, not a dependency**: `ast_to_blocks` emits conforming
+STRUCTs with nothing loaded. If the `duck_block_utils` extension *is* available,
+rendering straight to the terminal is one query:
+
+```sql
+LOAD sitting_duck;
+LOAD duck_block_utils;
+PRAGMA duck_block_render;
+
+-- One query: parse a file, render its structure as an ANSI document
+SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
+```
+
+The row-shaped macro composes with the standard `list(... ORDER BY ...)` idiom:
+
+```sql
+-- One duck_block per row (columns: file_path, element_order, block)
+SELECT * FROM ast_to_blocks('src/main.py');
+
+-- Aggregate to LIST(duck_block) yourself (what ast_to_blocks_list does)
+SELECT db_render_blocks(list(block ORDER BY element_order))
+FROM ast_to_blocks('src/main.py')
+GROUP BY file_path;
+
+-- Convert a pre-parsed table (parse with peek := 'full' for complete bodies)
+CREATE TABLE code AS SELECT * FROM read_ast('src/**/*.py', peek := 'full');
+SELECT * FROM ast_to_blocks_from('code', style := 'summary');
+```
+
+**Parameters** (same tuning names on all three macros; `language` only on the
+parsing variants):
+
+| Parameter | Default | Meaning |
+|-----------|---------|---------|
+| `style` | `'outline'` | `'outline'` = nested headings + code bodies for leaf definitions; `'summary'` = headings + one-line signature paragraphs, no bodies; `'flat'` = every definition at one heading level, each with its body. Unknown values raise an error. |
+| `include_bodies` | `true` | `false` suppresses code blocks in any style |
+| `include_metadata` | `true` | Leading per-file `metadata` block (yaml: file_path, language, definition counts) |
+| `base_heading_level` | `1` | Heading level of a top-level definition |
+| `max_heading_level` | `6` | Demotion cap: definitions nested deeper render at this level |
+
+Spec conformance (duck_blocks v0.4.0): headings carry the semantic level in
+`attributes['heading_level']` (as a string) with a NULL `level` field; code
+blocks carry `attributes['language']`; metadata blocks use `encoding = 'yaml'`;
+`element_order` starts at 0 per file and follows document order.
+
+Body fidelity note: code-block content comes from the `peek` column — a
+*presentation* substrate, which is exactly what this macro is (peek is never
+used for correctness features). `ast_to_blocks` parses with `peek := 'full'`
+internally; for `ast_to_blocks_from`, body fidelity follows the input table's
+extraction config — `peek := 'smart'` input yields truncated bodies (not
+detectable per row), and an all-NULL peek column (`peek := 'none'`) raises an
+error with a re-parse hint. No extraction configuration retains per-node
+source text (`source :=` controls location columns only); exact-source
+extraction is planned v2 work.
+
 ## Limitations
 
 - **Parse-only**: This analyzes syntax, not semantics (no type checking, symbol resolution, etc.)

--- a/scripts/embed_sql_macros.py
+++ b/scripts/embed_sql_macros.py
@@ -53,6 +53,7 @@ def generate_header(sql_dir, output_file):
         'css_selectors.sql',
         'ast_select_rules.sql',
         'scope_resolution.sql',
+        'duck_blocks.sql',
     ]
 
     header_content = """// Auto-generated file - DO NOT EDIT

--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -4661,6 +4661,364 @@ CREATE OR REPLACE MACRO ast_find_references(
     FROM combined
     ORDER BY file_path, start_line, ref_kind;
 )SQLMACRO"},
+    {"duck_blocks.sql", R"SQLMACRO(
+-- =============================================================================
+-- Duck Blocks Interop: render code structure as document elements
+-- =============================================================================
+--
+-- ast_to_blocks converts parsed ASTs into duck_blocks — the document-element
+-- STRUCT spec shared by the markdown / webbed / duck_block_utils extensions
+-- (duck_block_utils docs/duck_blocks_spec.md, v0.4.0).
+--
+-- duck_blocks is a SPEC, not a dependency: these macros emit conforming
+-- STRUCTs and require nothing to be loaded. If duck_block_utils IS loaded,
+-- terminal rendering is one call away:
+--
+--   LOAD duck_block_utils;
+--   PRAGMA duck_block_render;
+--   SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
+--
+-- Element shape (spec v0.4.0):
+--   STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER,
+--          encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR),
+--          element_order INTEGER)
+--
+-- Spec fine print this producer honors:
+--   * kind is always 'block' (we emit no inlines).
+--   * A heading's semantic level lives in attributes['heading_level'] as a
+--     STRING ('1'..'6'); the `level` field is NULL for headings. `level` is
+--     structural nesting depth and is only set for metadata blocks (0).
+--   * code blocks carry attributes['language']; metadata uses encoding 'yaml'.
+--   * element_order starts at 0 and increases in document order, restarting
+--     per file (each file's element list is a document of its own; when
+--     composing multiple files, order by (file_path, element_order)).
+--
+-- Mapping (style := 'outline', the default):
+--   file        -> one leading 'metadata' block (yaml: file_path, language,
+--                  definition counts). Files with no definitions yield just
+--                  this block (or zero rows with include_metadata := false).
+--   definition  -> 'heading' block. heading_level = base_heading_level +
+--                  definition-ancestor nesting depth (a top-level def is at
+--                  the base), capped at max_heading_level — deeper defs
+--                  demote to the cap rather than overflow h6. Content is the
+--                  name plus signature when extracted (parameters / return
+--                  type from native extraction).
+--   body        -> 'code' block. attributes['language'] = source language.
+--                  In outline style only LEAF definitions (no nested defs)
+--                  get code blocks: a class's body already appears under its
+--                  methods' headings, so repeating it would duplicate text.
+--
+-- Body content comes from FULL PEEK. Peek is a presentation substrate, and
+-- ast_to_blocks is a presentation feature — this is the sanctioned pairing
+-- (peek remains off-limits for correctness features: patching, unparse,
+-- fidelity claims). Retained source would be preferred, but no extraction
+-- configuration retains per-node source text: source := 'none'/'path'/
+-- 'lines'/'full' controls *location* columns only ('full' merely adds
+-- start_column/end_column). Consequences:
+--   * ast_to_blocks parses internally with peek := 'full'.
+--   * ast_to_blocks_from requires the table to carry peek text when bodies
+--     are requested; an all-NULL peek column (peek := 'none') raises a
+--     targeted error with a re-parse hint rather than rendering empty
+--     bodies.
+--   * Body fidelity follows the input's extraction config: peek := 'smart'
+--     truncates long definitions, and truncated-vs-full peek is not
+--     detectable per row — parse with peek := 'full' for complete bodies.
+--     (Exact-source extraction is planned v2 work; see the v2 RFC.)
+
+-- =============================================================================
+-- ast_to_blocks_from: the converter engine, operates on a pre-parsed AST
+-- table (name resolved via query_table). Parse once with
+-- read_ast(..., peek := 'full'), convert many times with different styles.
+-- =============================================================================
+CREATE OR REPLACE MACRO ast_to_blocks_from(
+    source,
+    style := 'outline',
+    include_bodies := true,
+    include_metadata := true,
+    base_heading_level := 1,
+    max_heading_level := 6
+) AS TABLE
+    WITH
+        -- Parameter validation (issue #89 principle: unknown parameter values
+        -- must ERROR loudly, never silently render something else).
+        params_validation AS (
+            SELECT CASE
+                WHEN style NOT IN ('outline', 'summary', 'flat') THEN error(
+                    'ast_to_blocks: unknown style ''' || style::VARCHAR ||
+                    '''. Valid styles: outline, summary, flat.')
+                WHEN base_heading_level < 1 OR base_heading_level > 6 THEN error(
+                    'ast_to_blocks: base_heading_level must be between 1 and 6 (got ' ||
+                    base_heading_level::VARCHAR || ').')
+                WHEN max_heading_level < 1 OR max_heading_level > 6 THEN error(
+                    'ast_to_blocks: max_heading_level must be between 1 and 6 (got ' ||
+                    max_heading_level::VARCHAR || ').')
+                ELSE true
+            END AS ok
+        ),
+        ast AS (
+            SELECT * FROM query_table(source)
+        ),
+        files AS (
+            SELECT file_path, any_value(language) AS language
+            FROM ast
+            GROUP BY file_path
+        ),
+        -- Named definition constructs. The full filter chain (is_definition +
+        -- is_construct + non-empty name) is required to exclude keyword tokens
+        -- that share their parent's semantic type — see ast_definitions.
+        -- Function-scoped variable definitions (parameters, locals) are
+        -- implementation detail, not document structure — a function's
+        -- parameters already appear in its heading signature, so they are
+        -- excluded here (scope.function != 0 means "inside a function").
+        defs AS (
+            SELECT
+                a.file_path,
+                a.language,
+                a.node_id,
+                a.name,
+                a.semantic_type,
+                a.start_line,
+                a.end_line,
+                a.descendant_count,
+                a.peek,
+                a.signature_type,
+                a.parameters,
+                CASE
+                    WHEN is_function_definition(a.semantic_type) THEN 'function'
+                    WHEN is_class_definition(a.semantic_type) THEN 'class'
+                    WHEN is_variable_definition(a.semantic_type) THEN 'variable'
+                    WHEN is_module_definition(a.semantic_type) THEN 'module'
+                    WHEN is_type_definition(a.semantic_type) THEN 'type'
+                    ELSE 'other'
+                END AS definition_kind
+            FROM ast a
+            WHERE is_definition(a.semantic_type)
+              AND is_construct(a.flags)
+              AND a.name IS NOT NULL AND a.name != ''
+              AND NOT (is_variable_definition(a.semantic_type)
+                       AND coalesce(a.scope.function, 0) != 0)
+        ),
+        -- Bodies come from peek; a table whose peek column was never
+        -- materialized (peek := 'none' — every row NULL) can only render
+        -- empty code blocks. Materialized peek is never NULL, so all-NULL
+        -- means a mis-parsed table, not intent: raise a targeted error with
+        -- a re-parse hint (precedent: ast_select's peek_filter_validation;
+        -- principle: issue #89). Note this guard cannot distinguish smart
+        -- (truncated) from full peek — that difference is documented, not
+        -- detectable.
+        peek_validation AS (
+            SELECT CASE
+                WHEN include_bodies AND style IN ('outline', 'flat')
+                     AND EXISTS (SELECT 1 FROM defs)
+                     AND NOT EXISTS (SELECT 1 FROM defs WHERE peek IS NOT NULL)
+                THEN error(
+                    'ast_to_blocks: bodies requested but the source has no peek text '
+                    '(the peek column is entirely NULL — parsed with peek := ''none''?). '
+                    'Re-parse with read_ast(..., peek := ''full''), or pass '
+                    'include_bodies := false.')
+                ELSE true
+            END AS ok
+        ),
+        def_info AS (
+            SELECT
+                d.*,
+                -- Definition-ancestor nesting depth via DFS pre-order
+                -- containment: ancestors are defs whose [node_id,
+                -- node_id + descendant_count] range covers this node.
+                (SELECT count(*)
+                 FROM defs anc
+                 WHERE anc.file_path = d.file_path
+                   AND anc.node_id < d.node_id
+                   AND d.node_id <= anc.node_id + anc.descendant_count) AS nest_depth,
+                -- Leaf = contains no nested definitions (same range trick).
+                NOT EXISTS (
+                    SELECT 1
+                    FROM defs child
+                    WHERE child.file_path = d.file_path
+                      AND child.node_id > d.node_id
+                      AND child.node_id <= d.node_id + d.descendant_count) AS is_leaf,
+                -- Heading text: name + signature when native extraction
+                -- provides one. Functions always show parens; the annotated
+                -- type reads ' -> T' for functions, ': T' otherwise. A
+                -- signature_type that merely restates the definition kind
+                -- (e.g. 'class' on a class) adds nothing and is dropped.
+                d.name ||
+                CASE WHEN is_function_definition(d.semantic_type)
+                     THEN '(' || coalesce(array_to_string(list_transform(d.parameters, lambda p:
+                              CASE WHEN p.name IS NULL OR p.name = '' THEN coalesce(p.type, '')
+                                   WHEN p.type IS NULL OR p.type = '' THEN p.name
+                                   ELSE p.name || ': ' || p.type
+                              END), ', '), '') || ')'
+                     ELSE '' END ||
+                CASE WHEN d.signature_type IS NOT NULL AND d.signature_type != ''
+                          AND lower(d.signature_type) != d.definition_kind
+                     THEN CASE WHEN is_function_definition(d.semantic_type)
+                               THEN ' -> ' ELSE ': ' END || d.signature_type
+                     ELSE '' END AS signature
+            FROM defs d
+        ),
+        elements AS (
+            -- One metadata block per file (before any definition: sort_node -1).
+            SELECT
+                f.file_path,
+                CAST(-1 AS BIGINT) AS sort_node,
+                0 AS sort_part,
+                'metadata' AS element_type,
+                'file_path: ' || f.file_path || chr(10) ||
+                'language: ' || coalesce(f.language, 'unknown') || chr(10) ||
+                'definitions: ' || (SELECT count(*) FROM defs d
+                                    WHERE d.file_path = f.file_path)::VARCHAR || chr(10) ||
+                'functions: ' || (SELECT count(*) FROM defs d
+                                  WHERE d.file_path = f.file_path
+                                    AND is_function_definition(d.semantic_type))::VARCHAR || chr(10) ||
+                'classes: ' || (SELECT count(*) FROM defs d
+                                WHERE d.file_path = f.file_path
+                                  AND is_class_definition(d.semantic_type))::VARCHAR AS content,
+                0 AS level,
+                'yaml' AS encoding,
+                MAP([], [])::MAP(VARCHAR, VARCHAR) AS attributes
+            FROM files f
+            WHERE include_metadata
+
+            UNION ALL
+
+            -- One heading per definition. Semantic level goes in
+            -- attributes['heading_level'] (string) per spec; level is NULL.
+            SELECT
+                d.file_path,
+                d.node_id,
+                0,
+                'heading',
+                d.signature,
+                CAST(NULL AS INTEGER),
+                'text',
+                MAP {'heading_level':
+                     CASE WHEN style = 'flat'
+                          THEN LEAST(base_heading_level, max_heading_level)
+                          ELSE LEAST(base_heading_level + d.nest_depth,
+                                     max_heading_level)
+                     END::VARCHAR}
+            FROM def_info d
+
+            UNION ALL
+
+            -- Summary style: one-line signature paragraph instead of a body.
+            SELECT
+                d.file_path,
+                d.node_id,
+                1,
+                'paragraph',
+                d.definition_kind || ' ' || d.signature ||
+                    ' (lines ' || d.start_line::VARCHAR || '-' || d.end_line::VARCHAR || ')',
+                CAST(NULL AS INTEGER),
+                'text',
+                MAP([], [])::MAP(VARCHAR, VARCHAR)
+            FROM def_info d
+            WHERE style = 'summary'
+
+            UNION ALL
+
+            -- Code bodies: leaf defs in outline, every def in flat, never in
+            -- summary, never with include_bodies := false. Content is the
+            -- definition's peek text (full source text under peek := 'full').
+            SELECT
+                d.file_path,
+                d.node_id,
+                2,
+                'code',
+                d.peek,
+                CAST(NULL AS INTEGER),
+                'text',
+                MAP {'language': coalesce(d.language, 'unknown')}
+            FROM def_info d
+            WHERE include_bodies
+              AND (style = 'flat' OR (style = 'outline' AND d.is_leaf))
+        ),
+        ordered AS (
+            SELECT
+                e.*,
+                CAST(row_number() OVER (
+                    PARTITION BY e.file_path
+                    ORDER BY e.sort_node, e.sort_part) - 1 AS INTEGER) AS element_order
+            FROM elements e
+            WHERE (SELECT ok FROM params_validation)
+
+)SQLMACRO"
+        R"SQLMACRO(
+              AND (SELECT ok FROM peek_validation)
+        )
+    SELECT
+        o.file_path,
+        o.element_order,
+        {
+            'kind': 'block',
+            'element_type': o.element_type,
+            'content': o.content,
+            'level': o.level,
+            'encoding': o.encoding,
+            'attributes': o.attributes,
+            'element_order': o.element_order
+        } AS block
+    FROM ordered o
+    ORDER BY o.file_path, o.element_order;
+
+-- =============================================================================
+-- ast_to_blocks: convenience wrapper that parses source files (with the
+-- peek := 'full' that complete bodies require) and delegates to the
+-- converter engine. Same CTE-delegation pattern as
+-- ast_select -> ast_select_from.
+-- =============================================================================
+CREATE OR REPLACE MACRO ast_to_blocks(
+    source,
+    language := NULL,
+    style := 'outline',
+    include_bodies := true,
+    include_metadata := true,
+    base_heading_level := 1,
+    max_heading_level := 6
+) AS TABLE
+    WITH __ast_blocks_src AS (
+        SELECT * FROM read_ast(source, language, peek := 'full')
+    )
+    SELECT * FROM ast_to_blocks_from('__ast_blocks_src',
+        style := style,
+        include_bodies := include_bodies,
+        include_metadata := include_metadata,
+        base_heading_level := base_heading_level,
+        max_heading_level := max_heading_level);
+
+-- =============================================================================
+-- ast_to_blocks_list: one row per file with the blocks pre-aggregated into a
+-- LIST(duck_block) ready for consumers that take a whole document, e.g.
+-- duck_block_utils rendering:
+--
+--   SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
+--
+-- Equivalent to the general idiom over the row-shaped macro:
+--   list(block ORDER BY element_order) ... GROUP BY file_path
+-- =============================================================================
+CREATE OR REPLACE MACRO ast_to_blocks_list(
+    source,
+    language := NULL,
+    style := 'outline',
+    include_bodies := true,
+    include_metadata := true,
+    base_heading_level := 1,
+    max_heading_level := 6
+) AS TABLE
+    SELECT
+        file_path,
+        list(block ORDER BY element_order) AS blocks
+    FROM ast_to_blocks(source,
+        language := language,
+        style := style,
+        include_bodies := include_bodies,
+        include_metadata := include_metadata,
+        base_heading_level := base_heading_level,
+        max_heading_level := max_heading_level)
+    GROUP BY file_path
+    ORDER BY file_path;
+)SQLMACRO"},
 };
 
 } // namespace duckdb

--- a/src/sql_macros/duck_blocks.sql
+++ b/src/sql_macros/duck_blocks.sql
@@ -1,0 +1,353 @@
+-- =============================================================================
+-- Duck Blocks Interop: render code structure as document elements
+-- =============================================================================
+--
+-- ast_to_blocks converts parsed ASTs into duck_blocks — the document-element
+-- STRUCT spec shared by the markdown / webbed / duck_block_utils extensions
+-- (duck_block_utils docs/duck_blocks_spec.md, v0.4.0).
+--
+-- duck_blocks is a SPEC, not a dependency: these macros emit conforming
+-- STRUCTs and require nothing to be loaded. If duck_block_utils IS loaded,
+-- terminal rendering is one call away:
+--
+--   LOAD duck_block_utils;
+--   PRAGMA duck_block_render;
+--   SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
+--
+-- Element shape (spec v0.4.0):
+--   STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER,
+--          encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR),
+--          element_order INTEGER)
+--
+-- Spec fine print this producer honors:
+--   * kind is always 'block' (we emit no inlines).
+--   * A heading's semantic level lives in attributes['heading_level'] as a
+--     STRING ('1'..'6'); the `level` field is NULL for headings. `level` is
+--     structural nesting depth and is only set for metadata blocks (0).
+--   * code blocks carry attributes['language']; metadata uses encoding 'yaml'.
+--   * element_order starts at 0 and increases in document order, restarting
+--     per file (each file's element list is a document of its own; when
+--     composing multiple files, order by (file_path, element_order)).
+--
+-- Mapping (style := 'outline', the default):
+--   file        -> one leading 'metadata' block (yaml: file_path, language,
+--                  definition counts). Files with no definitions yield just
+--                  this block (or zero rows with include_metadata := false).
+--   definition  -> 'heading' block. heading_level = base_heading_level +
+--                  definition-ancestor nesting depth (a top-level def is at
+--                  the base), capped at max_heading_level — deeper defs
+--                  demote to the cap rather than overflow h6. Content is the
+--                  name plus signature when extracted (parameters / return
+--                  type from native extraction).
+--   body        -> 'code' block. attributes['language'] = source language.
+--                  In outline style only LEAF definitions (no nested defs)
+--                  get code blocks: a class's body already appears under its
+--                  methods' headings, so repeating it would duplicate text.
+--
+-- Body content comes from FULL PEEK. Peek is a presentation substrate, and
+-- ast_to_blocks is a presentation feature — this is the sanctioned pairing
+-- (peek remains off-limits for correctness features: patching, unparse,
+-- fidelity claims). Retained source would be preferred, but no extraction
+-- configuration retains per-node source text: source := 'none'/'path'/
+-- 'lines'/'full' controls *location* columns only ('full' merely adds
+-- start_column/end_column). Consequences:
+--   * ast_to_blocks parses internally with peek := 'full'.
+--   * ast_to_blocks_from requires the table to carry peek text when bodies
+--     are requested; an all-NULL peek column (peek := 'none') raises a
+--     targeted error with a re-parse hint rather than rendering empty
+--     bodies.
+--   * Body fidelity follows the input's extraction config: peek := 'smart'
+--     truncates long definitions, and truncated-vs-full peek is not
+--     detectable per row — parse with peek := 'full' for complete bodies.
+--     (Exact-source extraction is planned v2 work; see the v2 RFC.)
+
+-- =============================================================================
+-- ast_to_blocks_from: the converter engine, operates on a pre-parsed AST
+-- table (name resolved via query_table). Parse once with
+-- read_ast(..., peek := 'full'), convert many times with different styles.
+-- =============================================================================
+CREATE OR REPLACE MACRO ast_to_blocks_from(
+    source,
+    style := 'outline',
+    include_bodies := true,
+    include_metadata := true,
+    base_heading_level := 1,
+    max_heading_level := 6
+) AS TABLE
+    WITH
+        -- Parameter validation (issue #89 principle: unknown parameter values
+        -- must ERROR loudly, never silently render something else).
+        params_validation AS (
+            SELECT CASE
+                WHEN style NOT IN ('outline', 'summary', 'flat') THEN error(
+                    'ast_to_blocks: unknown style ''' || style::VARCHAR ||
+                    '''. Valid styles: outline, summary, flat.')
+                WHEN base_heading_level < 1 OR base_heading_level > 6 THEN error(
+                    'ast_to_blocks: base_heading_level must be between 1 and 6 (got ' ||
+                    base_heading_level::VARCHAR || ').')
+                WHEN max_heading_level < 1 OR max_heading_level > 6 THEN error(
+                    'ast_to_blocks: max_heading_level must be between 1 and 6 (got ' ||
+                    max_heading_level::VARCHAR || ').')
+                ELSE true
+            END AS ok
+        ),
+        ast AS (
+            SELECT * FROM query_table(source)
+        ),
+        files AS (
+            SELECT file_path, any_value(language) AS language
+            FROM ast
+            GROUP BY file_path
+        ),
+        -- Named definition constructs. The full filter chain (is_definition +
+        -- is_construct + non-empty name) is required to exclude keyword tokens
+        -- that share their parent's semantic type — see ast_definitions.
+        -- Function-scoped variable definitions (parameters, locals) are
+        -- implementation detail, not document structure — a function's
+        -- parameters already appear in its heading signature, so they are
+        -- excluded here (scope.function != 0 means "inside a function").
+        defs AS (
+            SELECT
+                a.file_path,
+                a.language,
+                a.node_id,
+                a.name,
+                a.semantic_type,
+                a.start_line,
+                a.end_line,
+                a.descendant_count,
+                a.peek,
+                a.signature_type,
+                a.parameters,
+                CASE
+                    WHEN is_function_definition(a.semantic_type) THEN 'function'
+                    WHEN is_class_definition(a.semantic_type) THEN 'class'
+                    WHEN is_variable_definition(a.semantic_type) THEN 'variable'
+                    WHEN is_module_definition(a.semantic_type) THEN 'module'
+                    WHEN is_type_definition(a.semantic_type) THEN 'type'
+                    ELSE 'other'
+                END AS definition_kind
+            FROM ast a
+            WHERE is_definition(a.semantic_type)
+              AND is_construct(a.flags)
+              AND a.name IS NOT NULL AND a.name != ''
+              AND NOT (is_variable_definition(a.semantic_type)
+                       AND coalesce(a.scope.function, 0) != 0)
+        ),
+        -- Bodies come from peek; a table whose peek column was never
+        -- materialized (peek := 'none' — every row NULL) can only render
+        -- empty code blocks. Materialized peek is never NULL, so all-NULL
+        -- means a mis-parsed table, not intent: raise a targeted error with
+        -- a re-parse hint (precedent: ast_select's peek_filter_validation;
+        -- principle: issue #89). Note this guard cannot distinguish smart
+        -- (truncated) from full peek — that difference is documented, not
+        -- detectable.
+        peek_validation AS (
+            SELECT CASE
+                WHEN include_bodies AND style IN ('outline', 'flat')
+                     AND EXISTS (SELECT 1 FROM defs)
+                     AND NOT EXISTS (SELECT 1 FROM defs WHERE peek IS NOT NULL)
+                THEN error(
+                    'ast_to_blocks: bodies requested but the source has no peek text '
+                    '(the peek column is entirely NULL — parsed with peek := ''none''?). '
+                    'Re-parse with read_ast(..., peek := ''full''), or pass '
+                    'include_bodies := false.')
+                ELSE true
+            END AS ok
+        ),
+        def_info AS (
+            SELECT
+                d.*,
+                -- Definition-ancestor nesting depth via DFS pre-order
+                -- containment: ancestors are defs whose [node_id,
+                -- node_id + descendant_count] range covers this node.
+                (SELECT count(*)
+                 FROM defs anc
+                 WHERE anc.file_path = d.file_path
+                   AND anc.node_id < d.node_id
+                   AND d.node_id <= anc.node_id + anc.descendant_count) AS nest_depth,
+                -- Leaf = contains no nested definitions (same range trick).
+                NOT EXISTS (
+                    SELECT 1
+                    FROM defs child
+                    WHERE child.file_path = d.file_path
+                      AND child.node_id > d.node_id
+                      AND child.node_id <= d.node_id + d.descendant_count) AS is_leaf,
+                -- Heading text: name + signature when native extraction
+                -- provides one. Functions always show parens; the annotated
+                -- type reads ' -> T' for functions, ': T' otherwise. A
+                -- signature_type that merely restates the definition kind
+                -- (e.g. 'class' on a class) adds nothing and is dropped.
+                d.name ||
+                CASE WHEN is_function_definition(d.semantic_type)
+                     THEN '(' || coalesce(array_to_string(list_transform(d.parameters, lambda p:
+                              CASE WHEN p.name IS NULL OR p.name = '' THEN coalesce(p.type, '')
+                                   WHEN p.type IS NULL OR p.type = '' THEN p.name
+                                   ELSE p.name || ': ' || p.type
+                              END), ', '), '') || ')'
+                     ELSE '' END ||
+                CASE WHEN d.signature_type IS NOT NULL AND d.signature_type != ''
+                          AND lower(d.signature_type) != d.definition_kind
+                     THEN CASE WHEN is_function_definition(d.semantic_type)
+                               THEN ' -> ' ELSE ': ' END || d.signature_type
+                     ELSE '' END AS signature
+            FROM defs d
+        ),
+        elements AS (
+            -- One metadata block per file (before any definition: sort_node -1).
+            SELECT
+                f.file_path,
+                CAST(-1 AS BIGINT) AS sort_node,
+                0 AS sort_part,
+                'metadata' AS element_type,
+                'file_path: ' || f.file_path || chr(10) ||
+                'language: ' || coalesce(f.language, 'unknown') || chr(10) ||
+                'definitions: ' || (SELECT count(*) FROM defs d
+                                    WHERE d.file_path = f.file_path)::VARCHAR || chr(10) ||
+                'functions: ' || (SELECT count(*) FROM defs d
+                                  WHERE d.file_path = f.file_path
+                                    AND is_function_definition(d.semantic_type))::VARCHAR || chr(10) ||
+                'classes: ' || (SELECT count(*) FROM defs d
+                                WHERE d.file_path = f.file_path
+                                  AND is_class_definition(d.semantic_type))::VARCHAR AS content,
+                0 AS level,
+                'yaml' AS encoding,
+                MAP([], [])::MAP(VARCHAR, VARCHAR) AS attributes
+            FROM files f
+            WHERE include_metadata
+
+            UNION ALL
+
+            -- One heading per definition. Semantic level goes in
+            -- attributes['heading_level'] (string) per spec; level is NULL.
+            SELECT
+                d.file_path,
+                d.node_id,
+                0,
+                'heading',
+                d.signature,
+                CAST(NULL AS INTEGER),
+                'text',
+                MAP {'heading_level':
+                     CASE WHEN style = 'flat'
+                          THEN LEAST(base_heading_level, max_heading_level)
+                          ELSE LEAST(base_heading_level + d.nest_depth,
+                                     max_heading_level)
+                     END::VARCHAR}
+            FROM def_info d
+
+            UNION ALL
+
+            -- Summary style: one-line signature paragraph instead of a body.
+            SELECT
+                d.file_path,
+                d.node_id,
+                1,
+                'paragraph',
+                d.definition_kind || ' ' || d.signature ||
+                    ' (lines ' || d.start_line::VARCHAR || '-' || d.end_line::VARCHAR || ')',
+                CAST(NULL AS INTEGER),
+                'text',
+                MAP([], [])::MAP(VARCHAR, VARCHAR)
+            FROM def_info d
+            WHERE style = 'summary'
+
+            UNION ALL
+
+            -- Code bodies: leaf defs in outline, every def in flat, never in
+            -- summary, never with include_bodies := false. Content is the
+            -- definition's peek text (full source text under peek := 'full').
+            SELECT
+                d.file_path,
+                d.node_id,
+                2,
+                'code',
+                d.peek,
+                CAST(NULL AS INTEGER),
+                'text',
+                MAP {'language': coalesce(d.language, 'unknown')}
+            FROM def_info d
+            WHERE include_bodies
+              AND (style = 'flat' OR (style = 'outline' AND d.is_leaf))
+        ),
+        ordered AS (
+            SELECT
+                e.*,
+                CAST(row_number() OVER (
+                    PARTITION BY e.file_path
+                    ORDER BY e.sort_node, e.sort_part) - 1 AS INTEGER) AS element_order
+            FROM elements e
+            WHERE (SELECT ok FROM params_validation)
+              AND (SELECT ok FROM peek_validation)
+        )
+    SELECT
+        o.file_path,
+        o.element_order,
+        {
+            'kind': 'block',
+            'element_type': o.element_type,
+            'content': o.content,
+            'level': o.level,
+            'encoding': o.encoding,
+            'attributes': o.attributes,
+            'element_order': o.element_order
+        } AS block
+    FROM ordered o
+    ORDER BY o.file_path, o.element_order;
+
+-- =============================================================================
+-- ast_to_blocks: convenience wrapper that parses source files (with the
+-- peek := 'full' that complete bodies require) and delegates to the
+-- converter engine. Same CTE-delegation pattern as
+-- ast_select -> ast_select_from.
+-- =============================================================================
+CREATE OR REPLACE MACRO ast_to_blocks(
+    source,
+    language := NULL,
+    style := 'outline',
+    include_bodies := true,
+    include_metadata := true,
+    base_heading_level := 1,
+    max_heading_level := 6
+) AS TABLE
+    WITH __ast_blocks_src AS (
+        SELECT * FROM read_ast(source, language, peek := 'full')
+    )
+    SELECT * FROM ast_to_blocks_from('__ast_blocks_src',
+        style := style,
+        include_bodies := include_bodies,
+        include_metadata := include_metadata,
+        base_heading_level := base_heading_level,
+        max_heading_level := max_heading_level);
+
+-- =============================================================================
+-- ast_to_blocks_list: one row per file with the blocks pre-aggregated into a
+-- LIST(duck_block) ready for consumers that take a whole document, e.g.
+-- duck_block_utils rendering:
+--
+--   SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
+--
+-- Equivalent to the general idiom over the row-shaped macro:
+--   list(block ORDER BY element_order) ... GROUP BY file_path
+-- =============================================================================
+CREATE OR REPLACE MACRO ast_to_blocks_list(
+    source,
+    language := NULL,
+    style := 'outline',
+    include_bodies := true,
+    include_metadata := true,
+    base_heading_level := 1,
+    max_heading_level := 6
+) AS TABLE
+    SELECT
+        file_path,
+        list(block ORDER BY element_order) AS blocks
+    FROM ast_to_blocks(source,
+        language := language,
+        style := style,
+        include_bodies := include_bodies,
+        include_metadata := include_metadata,
+        base_heading_level := base_heading_level,
+        max_heading_level := max_heading_level)
+    GROUP BY file_path
+    ORDER BY file_path;

--- a/test/data/python/macros/blocks_demo.py
+++ b/test/data/python/macros/blocks_demo.py
@@ -1,0 +1,12 @@
+CONST = 1
+
+class Shape:
+    def area(self):
+        return 0
+
+    class Inner:
+        def deep(self):
+            return 1
+
+def top(x: int, y: int) -> int:
+    return x + y

--- a/test/data/python/macros/blocks_empty.py
+++ b/test/data/python/macros/blocks_empty.py
@@ -1,0 +1,1 @@
+print("no definitions here")

--- a/test/sql/duck_blocks.test
+++ b/test/sql/duck_blocks.test
@@ -1,0 +1,359 @@
+# name: test/sql/duck_blocks.test
+# description: ast_to_blocks — render ASTs as duck_blocks document elements
+# group: [sql]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# Fixture: test/data/python/macros/blocks_demo.py
+#   1  CONST = 1
+#   3  class Shape:
+#   4      def area(self):          (nested 1 deep)
+#   7      class Inner:             (nested 1 deep)
+#   8          def deep(self):      (nested 2 deep)
+#  11  def top(x: int, y: int) -> int:
+
+# =============================================================================
+# Spec conformance (duck_blocks v0.4.0)
+# =============================================================================
+
+# Every emitted element is kind='block'
+query I
+SELECT DISTINCT block.kind FROM ast_to_blocks('test/data/python/macros/blocks_demo.py');
+----
+block
+
+# Only recognized block element types are emitted (outline style)
+query I
+SELECT DISTINCT block.element_type FROM ast_to_blocks('test/data/python/macros/blocks_demo.py') ORDER BY 1;
+----
+code
+heading
+metadata
+
+# Headings: level field is NULL; heading_level attribute is a string '1'..'6'
+query I
+SELECT count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.element_type = 'heading'
+  AND (block.level IS NOT NULL
+       OR block.attributes['heading_level'] IS NULL
+       OR NOT block.attributes['heading_level'] IN ('1', '2', '3', '4', '5', '6'));
+----
+0
+
+# heading_level is stored as VARCHAR (string per spec, not an integer)
+query I
+SELECT DISTINCT typeof(block.attributes['heading_level'])
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.element_type = 'heading';
+----
+VARCHAR
+
+# Code blocks carry attributes['language']
+query II
+SELECT count(*), count(*) FILTER (WHERE block.attributes['language'] = 'python')
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.element_type = 'code';
+----
+4	4
+
+# Metadata block: encoding yaml, structural level 0
+query III
+SELECT block.encoding, block.level, block.element_order
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.element_type = 'metadata';
+----
+yaml	0	0
+
+# element_order starts at 0 and is strictly increasing in document order
+query I
+SELECT count(*)
+FROM (SELECT block.element_order AS eo,
+             row_number() OVER (ORDER BY element_order) - 1 AS expected
+      FROM ast_to_blocks('test/data/python/macros/blocks_demo.py'))
+WHERE eo != expected;
+----
+0
+
+# The struct's element_order matches the hoisted column
+query I
+SELECT count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.element_order != element_order;
+----
+0
+
+# =============================================================================
+# Outline style (default): exact document sequence
+# =============================================================================
+
+# Full element sequence: metadata, then headings in document order with
+# nesting-derived levels, leaf definitions followed by their code bodies.
+# (Function parameters/locals are excluded: function-scoped variable defs
+# are signature detail, not document structure.)
+query ITT
+SELECT element_order, block.element_type,
+       CASE WHEN block.element_type = 'heading' THEN block.content
+            ELSE coalesce(block.attributes['heading_level'], '-') END AS detail
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+ORDER BY element_order;
+----
+0	metadata	-
+1	heading	CONST: int
+2	code	-
+3	heading	Shape
+4	heading	area(self)
+5	code	-
+6	heading	Inner
+7	heading	deep(self)
+8	code	-
+9	heading	top(x: int, y: int) -> int
+10	code	-
+
+# Heading levels follow definition nesting depth
+query TI
+SELECT block.content, block.attributes['heading_level']::INTEGER AS hl
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.element_type = 'heading'
+ORDER BY element_order;
+----
+CONST: int	1
+Shape	1
+area(self)	2
+Inner	2
+deep(self)	3
+top(x: int, y: int) -> int	1
+
+# Body code block content: full source of the definition (peek := 'full'),
+# pinned by prefix
+query I
+SELECT block.content LIKE 'def top(x: int, y: int) -> int:' || chr(10) || '%'
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE element_order = 10;
+----
+true
+
+# Outline gives bodies to LEAF definitions only: the class Shape (which
+# contains nested definitions) has no code block of its own
+query I
+SELECT count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.element_type = 'code' AND block.content LIKE 'class Shape%';
+----
+0
+
+# Metadata content: yaml with file_path, language, and definition counts
+# (newlines flattened to ' | ' for single-line pinning)
+query I
+SELECT replace(block.content, chr(10), ' | ')
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.element_type = 'metadata';
+----
+file_path: test/data/python/macros/blocks_demo.py | language: python | definitions: 6 | functions: 3 | classes: 2
+
+# =============================================================================
+# Summary style: headings + one-line signature paragraphs, never code bodies
+# =============================================================================
+
+query I
+SELECT count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'summary')
+WHERE block.element_type = 'code';
+----
+0
+
+query TT
+SELECT block.element_type, block.content
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'summary')
+WHERE block.element_type = 'paragraph'
+ORDER BY element_order;
+----
+paragraph	variable CONST: int (lines 1-1)
+paragraph	class Shape (lines 3-9)
+paragraph	function area(self) (lines 4-5)
+paragraph	class Inner (lines 7-9)
+paragraph	function deep(self) (lines 8-9)
+paragraph	function top(x: int, y: int) -> int (lines 11-12)
+
+# =============================================================================
+# Flat style: uniform heading level, every definition gets its body
+# =============================================================================
+
+query I
+SELECT DISTINCT block.attributes['heading_level']
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'flat')
+WHERE block.element_type = 'heading';
+----
+1
+
+query TI
+SELECT block.element_type, count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'flat')
+GROUP BY 1 ORDER BY 1;
+----
+code	6
+heading	6
+metadata	1
+
+# =============================================================================
+# Tuning parameters
+# =============================================================================
+
+# include_bodies := false suppresses code blocks (outline)
+query I
+SELECT count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', include_bodies := false)
+WHERE block.element_type = 'code';
+----
+0
+
+# ...and in flat style
+query I
+SELECT count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'flat', include_bodies := false)
+WHERE block.element_type = 'code';
+----
+0
+
+# include_metadata := false drops the leading metadata block
+query I
+SELECT count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', include_metadata := false)
+WHERE block.element_type = 'metadata';
+----
+0
+
+# max_heading_level := 2 demotes deeper definitions to the cap
+# (deep would be h3; it renders at h2 alongside its parents)
+query II
+SELECT block.attributes['heading_level']::INTEGER AS hl, count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', max_heading_level := 2)
+WHERE block.element_type = 'heading'
+GROUP BY 1 ORDER BY 1;
+----
+1	3
+2	3
+
+# base_heading_level := 2 shifts the whole outline down one level
+query II
+SELECT block.attributes['heading_level']::INTEGER AS hl, count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', base_heading_level := 2)
+WHERE block.element_type = 'heading'
+GROUP BY 1 ORDER BY 1;
+----
+2	3
+3	2
+4	1
+
+# =============================================================================
+# Parameter validation: unknown values error loudly (issue #89 principle)
+# =============================================================================
+
+statement error
+SELECT * FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'markdown');
+----
+ast_to_blocks: unknown style 'markdown'. Valid styles: outline, summary, flat.
+
+# Positive twin: the same call with a valid style succeeds
+query I
+SELECT count(*) > 0 FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'summary');
+----
+true
+
+statement error
+SELECT * FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', max_heading_level := 9);
+----
+ast_to_blocks: max_heading_level must be between 1 and 6
+
+statement error
+SELECT * FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', base_heading_level := 0);
+----
+ast_to_blocks: base_heading_level must be between 1 and 6
+
+# =============================================================================
+# Files with no definitions: metadata-only, never an error
+# =============================================================================
+
+query TT
+SELECT block.element_type, replace(block.content, chr(10), ' | ')
+FROM ast_to_blocks('test/data/python/macros/blocks_empty.py');
+----
+metadata	file_path: test/data/python/macros/blocks_empty.py | language: python | definitions: 0 | functions: 0 | classes: 0
+
+# ...and with metadata off, cleanly empty (zero rows, no error)
+query I
+SELECT count(*) FROM ast_to_blocks('test/data/python/macros/blocks_empty.py', include_metadata := false);
+----
+0
+
+# =============================================================================
+# ast_to_blocks_from: pre-parsed tables
+# =============================================================================
+
+statement ok
+CREATE TABLE blocks_src AS
+SELECT * FROM read_ast('test/data/python/macros/blocks_demo.py', peek := 'full');
+
+# Same document as the parsing wrapper
+query I
+SELECT count(*) FROM ast_to_blocks_from('blocks_src');
+----
+11
+
+query I
+SELECT block.content FROM ast_to_blocks_from('blocks_src') WHERE element_order = 9;
+----
+top(x: int, y: int) -> int
+
+# Bodies need peek text: an all-NULL peek column (peek := 'none+schema')
+# errors with a re-parse hint instead of rendering empty code blocks
+statement ok
+CREATE TABLE blocks_src_nopeek AS
+SELECT * FROM read_ast('test/data/python/macros/blocks_demo.py', peek := 'none+schema');
+
+statement error
+SELECT * FROM ast_to_blocks_from('blocks_src_nopeek');
+----
+ast_to_blocks: bodies requested but the source has no peek text
+
+# Positive twins: the same table works when bodies are off or unneeded
+query I
+SELECT count(*) FROM ast_to_blocks_from('blocks_src_nopeek', include_bodies := false);
+----
+7
+
+query I
+SELECT count(*) FROM ast_to_blocks_from('blocks_src_nopeek', style := 'summary');
+----
+13
+
+# =============================================================================
+# ast_to_blocks_list: LIST(duck_block) per file, ready for renderers
+# =============================================================================
+
+query TI
+SELECT file_path, len(blocks) FROM ast_to_blocks_list('test/data/python/macros/blocks_demo.py');
+----
+test/data/python/macros/blocks_demo.py	11
+
+# The list is in document order, starting at element_order 0
+query II
+SELECT blocks[1].element_order, blocks[len(blocks)].element_order
+FROM ast_to_blocks_list('test/data/python/macros/blocks_demo.py');
+----
+0	10
+
+# =============================================================================
+# Multiple files: element_order restarts per file (each file is a document)
+# =============================================================================
+
+query TII
+SELECT file_path, min(element_order), count(*)
+FROM ast_to_blocks('test/data/python/macros/blocks_*.py')
+GROUP BY file_path ORDER BY file_path;
+----
+test/data/python/macros/blocks_demo.py	0	11
+test/data/python/macros/blocks_empty.py	0	1


### PR DESCRIPTION
Adds `ast_to_blocks` — a presentation add-on that converts parsed ASTs into **duck_blocks** (the document-element STRUCT spec, v0.4.0), so code structure renders as a readable document, including straight to the terminal via duck_block_utils' `db_render_blocks`.

This implements the "Interop: duck_blocks" item of the v2 architecture RFC (docs/planning/v2-architecture.md on the `docs/v2-architecture-rfc` branch): a pure duck_blocks *producer* — the spec is emitted as conforming STRUCTs, **not** a dependency (no LOAD required). Per the RFC's macro rule this is an add-on (presentation opinion) and will live in the composition, not core, when the v2 split lands; for now it is a new macro file `src/sql_macros/duck_blocks.sql`.

## Macros

| Macro | Shape | Purpose |
|-------|-------|---------|
| `ast_to_blocks(source, language := NULL, ...)` | table | Parse files (internally `peek := 'full'`) and emit one duck_block per row (`file_path`, `element_order`, `block`) |
| `ast_to_blocks_from(source, ...)` | table | Same conversion over a pre-parsed AST table (parse once, convert many times) — `ast_select`/`ast_select_from` delegation pattern |
| `ast_to_blocks_list(source, ...)` | table | One row per file with `blocks LIST(duck_block)`, ready for whole-document consumers |

One-query terminal demo (with duck_block_utils):

```sql
LOAD sitting_duck; LOAD duck_block_utils; PRAGMA duck_block_render;
SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
```

## Mapping

- **file** → leading `metadata` block (`encoding = 'yaml'`: file_path, language, definition counts). Files with no definitions yield metadata-only (or cleanly zero rows with `include_metadata := false`) — never an error.
- **definition** → `heading` block. `attributes['heading_level']` (string, per spec — the `level` field is NULL for headings) = `base_heading_level` + definition-ancestor nesting depth (computed via DFS pre-order `node_id`/`descendant_count` containment), capped at `max_heading_level` (deeper defs demote to the cap). Content = name + signature from native extraction (`parameters`, `signature_type`); a `signature_type` that merely restates the kind (`class` on a class) is dropped. Function-scoped variable definitions (parameters, locals — `scope.function != 0`) are excluded: they're signature detail, not document structure.
- **body** → `code` block (`attributes['language']`), from full peek. In outline style only **leaf** definitions get bodies — a class's text already appears under its methods' headings.

## Parameters

`style := 'outline'` (`'outline'` | `'summary'` headings + one-line signature paragraphs, no bodies | `'flat'` uniform level, every def gets its body), `include_bodies := true`, `include_metadata := true`, `base_heading_level := 1`, `max_heading_level := 6`. Unknown style / out-of-range levels **error loudly** (#89 principle), via the validation-CTE pattern from `ast_select`.

## Body substrate: peek (presentation), with a finding for the RFC

Bodies come from **full peek**. Peek is sanctioned here because ast_to_blocks is a presentation feature (peek remains off-limits for correctness features). Investigated whether `source :=` retention could supply exact text: it cannot — `source := 'none'/'path'/'lines'/'full'` controls *location* columns only (`'full'` merely adds `start_column`/`end_column`); no extraction configuration retains per-node source text. Exact-source extraction stays planned v2 work (RFC items 3/6). Consequences implemented:

- `ast_to_blocks_from` with an all-NULL peek column (`peek := 'none+schema'`) errors with a re-parse hint (precedent: `ast_select`'s `peek_filter_validation`) instead of rendering empty bodies; `peek := 'none'` (column absent) fails loudly at bind.
- `peek := 'smart'` truncation is not detectable per row; body fidelity following the input's extraction config is documented in the README.

## Spec conformance & tests

`test/sql/duck_blocks.test` (119 assertions, row-pinned): kind always `'block'`; headings carry `attributes['heading_level']` as VARCHAR with NULL `level`; code blocks carry `attributes['language']`; metadata is `yaml`/level 0; `element_order` starts at 0 per file, strictly increasing in document order. The fixture pins the exact outline sequence + levels (nested class/method), summary (no code blocks), flat (uniform level), `include_bodies := false`, `max_heading_level := 2` demotion, `base_heading_level := 2` shift, unknown-style error + positive twin, peek-guard error + positive twins, no-definition file, and multi-file element_order restart.

Cross-extension smoke (local only, not added to CI): sitting_duck's shell (v1.5.5-dev) and the local duck_block_utils build (v1.5.3) can't co-load, so blocks were bridged via Parquet — `db_blocks_validate` returns `{'valid': true, 'errors': []}` and `db_render_blocks` renders the fixture as an ANSI document (headings colored by level, language-tagged code gutters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mKzPp2FxHQaP3djX597C6
