### PR TITLE
test: normalize glob-expanded file_path separators (fixes Windows CI)

### DIFF
--- a/test/sql/duck_blocks.test
+++ b/test/sql/duck_blocks.test
@@ -350,8 +350,9 @@ FROM ast_to_blocks_list('test/data/python/macros/blocks_demo.py');
 # Multiple files: element_order restarts per file (each file is a document)
 # =============================================================================
 
+# replace(): glob expansion yields native separators (backslashes on Windows)
 query TII
-SELECT file_path, min(element_order), count(*)
+SELECT replace(file_path, '\', '/') AS file_path, min(element_order), count(*)
 FROM ast_to_blocks('test/data/python/macros/blocks_*.py')
 GROUP BY file_path ORDER BY file_path;
 ----


### PR DESCRIPTION
## What

One-line test fix: `duck_blocks.test`'s multi-file glob assertion now compares `replace(file_path, '\', '/')` instead of raw `file_path`.

## Why

The community-extensions v1.10.0 bump (duckdb/community-extensions#2322) failed only on `windows_amd64`: glob expansion returns native backslash separators, so `test\data\python\macros\blocks_demo.py` ≠ the forward-slash literal in the expected block. 1 failed assertion of 6,494; every other platform green.

## Scope check

Swept all tests changed since v1.9.0 for the same pattern: `ast_patch.test` uses literal paths only (verbatim pass-through, no separator conversion), and `register_language_concurrency.test` globs but only aggregates counts — both separator-safe. Literal-path assertions elsewhere in `duck_blocks.test` passed on the same Windows run.

## Validation

- `test/sql/duck_blocks.test`: 119 assertions pass locally (Linux; `replace` is a no-op there by design)
- Full SQL suite: green, 0 failures (4 env-gated skips)
- Windows: needs this repo's CI to confirm — that's the point of the PR

After merge: tag v1.10.1 and update duckdb/community-extensions#2322 to the new ref, then reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B32kWhs96dz7VnR9dYYAJy