### PR TITLE
fix(read_ast): populate start_column/end_column at source := 'full'

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -28,8 +28,25 @@
   - Cross-language: `'**/*.{py,js,cpp}'` or `['**/*.py', '**/*.js', '**/*.cpp']`
 - `language` (VARCHAR, optional): Language override (auto-detected from extension if omitted)
 - `ignore_errors` (BOOLEAN, optional): Continue processing when encountering syntax errors (default: false)
-- `peek_size` (INTEGER, optional): Number of characters to include in peek field (default: 120)
-- `peek_mode` (VARCHAR, optional): How to extract peek text - 'auto', 'chars', 'lines' (default: 'auto')
+- `peek` (VARCHAR | INTEGER, optional): How much source text to put in the `peek`
+  column (default: `'smart'`). Accepts:
+  - `'none'` — omit the `peek` column entirely
+  - `'smart'` — a short preview, currently capped at 80 characters
+  - `'full'` — the node's complete source text, however large
+  - an INTEGER — requested preview size in characters
+  - any of the above with `'+schema'` appended (e.g. `'none+schema'`) to keep the
+    column in the schema while suppressing its content
+
+  ⚠️ **Known limitation:** a numeric `peek` is accepted but **not currently
+  honoured** — the output is the same 80 characters `'smart'` produces,
+  regardless of the size requested. Until that is fixed, the effective choice is
+  `'smart'` (80 chars) or `'full'` (unbounded). See "Extracting source from
+  minified files" below.
+
+> **Superseded parameters.** `peek_size` (INTEGER) and `peek_mode` (VARCHAR) are
+> legacy and retained only for backward compatibility. Use `peek` instead.
+> Note that `peek_mode` takes `'none' | 'smart' | 'full' | 'custom'` — *not*
+> `'auto' | 'chars' | 'lines'`, which are not valid values and are rejected.
 
 **Returns:** Table with complete AST node data
 
@@ -41,9 +58,9 @@
 | `file_path` | VARCHAR | Source file path |
 | `language` | VARCHAR | Detected programming language |
 | `start_line` | UINTEGER | Starting line number (1-based) |
-| `start_column` | UINTEGER | Starting column (1-based) |
 | `end_line` | UINTEGER | Ending line number (1-based) |
-| `end_column` | UINTEGER | Ending column (1-based) |
+| `start_column` | UINTEGER | Starting column (1-based). **Only present when `source := 'full'`** — see note below |
+| `end_column` | UINTEGER | Ending column (1-based). **Only present when `source := 'full'`** — see note below |
 | `parent_id` | BIGINT | Parent node ID (NULL for root) |
 | `depth` | UINTEGER | Tree depth (0 for root) |
 | `sibling_index` | UINTEGER | Position among siblings (0-based) |
@@ -53,6 +70,47 @@
 | `semantic_type` | UTINYINT | Universal semantic category (0-255) |
 | `flags` | UTINYINT | Universal semantic flags (IS_CONSTRUCT, IS_EMBODIED) |
 | `arity_bin` | UTINYINT | Binned arity for analysis |
+
+> **Column availability.** The default projection is 21 columns. Passing
+> `source := 'full'` adds `start_column` and `end_column` (23 columns).
+>
+> ⚠️ **Known limitation:** `start_column` and `end_column` are currently
+> **always 0**, on every file — they are present in the schema but never
+> populated. Do not build extraction on them yet.
+
+### Extracting source from minified files
+
+Minified bundles are the hard case for source extraction, because every node
+reports `start_line = end_line = 1`: a single "line" can be tens of thousands of
+characters, so line-addressed extraction returns the whole file.
+
+This matters because **every `ast_get_source*` function is line-addressed**
+(`ast_get_source(file_path, start_line, end_line)`,
+`ast_get_source_numbered(...)`, `ast_get_source_line(file_path, line_num)`).
+On minified input they cannot isolate a node.
+
+That leaves `peek` as the only character-oriented extraction path, and the two
+limitations noted above currently constrain it:
+
+| Approach | Minified input |
+|---|---|
+| `ast_get_source*` | Unusable — line-addressed, and everything is line 1 |
+| `start_column` / `end_column` | Unusable — always 0 (see above) |
+| `peek := 'smart'` | Works, but capped at 80 characters |
+| `peek := <integer>` | Size not yet honoured — behaves as `'smart'` |
+| `peek := 'full'` | Works, but unbounded — a single node can be tens of KB |
+
+**Practical recommendation today:** use `peek := 'smart'` for triage (safe and
+bounded) and `peek := 'full'` when you need the complete node and can tolerate
+the size. Combine with `semantic_type` to narrow the node set first — for
+example `semantic_type = 144` (FLOW_CONDITIONAL) to find decision sites rather
+than every textual match:
+
+```sql
+SELECT type, name, peek
+FROM read_ast('bundle.js', peek := 'full')
+WHERE semantic_type = 144 AND peek LIKE '%win32%';
+```
 
 **Examples:**
 ```sql

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -74,9 +74,13 @@
 > **Column availability.** The default projection is 21 columns. Passing
 > `source := 'full'` adds `start_column` and `end_column` (23 columns).
 >
-> ⚠️ **Known limitation:** `start_column` and `end_column` are currently
-> **always 0**, on every file — they are present in the schema but never
-> populated. Do not build extraction on them yet.
+> ⚠️ **Released builds return 0.** In published builds up to and including
+> `f7b9c60`, `start_column` and `end_column` are **always 0** on every file:
+> `read_ast`'s parsing path populates the flattened `source_start_column` /
+> `source_end_column` fields, while the table projection read the legacy
+> `start_column` / `end_column` members, which keep their zero initializer.
+> Fixed in this branch; if you are on a released build, verify before relying
+> on these columns.
 
 ### Extracting source from minified files
 

--- a/src/unified_ast_backend.cpp
+++ b/src/unified_ast_backend.cpp
@@ -832,9 +832,9 @@ void UnifiedASTBackend::ProjectToTable(const ASTResult &result, DataChunk &outpu
 		file_path_vec[count] = StringVector::AddString(output.data[3], result.source.file_path);
 		language_vec[count] = StringVector::AddString(output.data[4], result.source.language);
 		start_line_vec[count] = node.start_line;
-		start_column_vec[count] = node.start_column;
+		start_column_vec[count] = node.source_start_column;
 		end_line_vec[count] = node.end_line;
-		end_column_vec[count] = node.end_column;
+		end_column_vec[count] = node.source_end_column;
 
 		if (node.parent_index < 0) {
 			parent_validity.SetInvalid(count);
@@ -1195,8 +1195,8 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 
 			if (schema_config.source >= SourceLevel::FULL) {
 				if (config.source >= SourceLevel::FULL) {
-					start_column_vec[count] = node.start_column;
-					end_column_vec[count] = node.end_column;
+					start_column_vec[count] = node.source_start_column;
+					end_column_vec[count] = node.source_end_column;
 				} else {
 					// +schema: column exists but data wasn't computed — NULL
 					FlatVector::SetNull(output.data[start_column_col], count, true);

--- a/test/sql/source_full_columns.test
+++ b/test/sql/source_full_columns.test
@@ -33,9 +33,11 @@ WHERE semantic_type = 240 AND start_line = 1;
 ----
 1
 
-# end_column must be past the start of the node, not zero.
+# end_column must be past the start of the node, not zero. Aggregated because
+# line 1 matches more than one node at this semantic type (the whole
+# function_definition and the `def` keyword token both start there).
 query I
-SELECT end_column > start_column
+SELECT bool_and(end_column > start_column)
 FROM read_ast('test/data/test_native_context.py', source := 'full')
 WHERE semantic_type = 240 AND start_line = 1;
 ----

--- a/test/sql/source_full_columns.test
+++ b/test/sql/source_full_columns.test
@@ -1,0 +1,98 @@
+# name: test/sql/source_full_columns.test
+# description: source := 'full' must populate start_column / end_column
+# group: [sql]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# Fixture: test/data/test_native_context.py
+#   1  def simple_function(param1, param2="default"):
+#   2      """A simple function with parameters."""
+#   3      return param1 + param2
+#   5  async def async_function(data: str, count: int = 5) -> str:
+#
+# Columns are 1-based (the parser adds 1 to tree-sitter's 0-based column), so a
+# definition starting in the leftmost position reports start_column = 1.
+#
+# Regression: both table projections used to read the legacy start_column /
+# end_column members while read_ast's parsing path populated only the flattened
+# source_start_column / source_end_column fields, so every row came back 0.
+# Line numbers were unaffected, which is why this stayed hidden.
+
+# =============================================================================
+# Columns are present and populated at source := 'full'
+# =============================================================================
+
+# A top-level definition starts in the leftmost column.
+query I
+SELECT DISTINCT start_column
+FROM read_ast('test/data/test_native_context.py', source := 'full')
+WHERE semantic_type = 240 AND start_line = 1;
+----
+1
+
+# end_column must be past the start of the node, not zero.
+query I
+SELECT end_column > start_column
+FROM read_ast('test/data/test_native_context.py', source := 'full')
+WHERE semantic_type = 240 AND start_line = 1;
+----
+true
+
+# The all-zero symptom: no node may report a zero start_column at FULL level.
+query I
+SELECT count(*)
+FROM read_ast('test/data/test_native_context.py', source := 'full')
+WHERE start_column = 0;
+----
+0
+
+# Columns must vary across the file — a constant would pass the checks above
+# while still carrying no positional information.
+query I
+SELECT count(DISTINCT start_column) > 1
+FROM read_ast('test/data/test_native_context.py', source := 'full');
+----
+true
+
+# =============================================================================
+# Columns track nesting, not just presence
+# =============================================================================
+
+# An indented body statement must start further right than its enclosing def.
+query I
+SELECT min(start_column) > 1
+FROM read_ast('test/data/test_native_context.py', source := 'full')
+WHERE start_line = 3;
+----
+true
+
+# =============================================================================
+# Schema: the columns appear only at source := 'full'
+# =============================================================================
+
+query I
+SELECT count(*) FROM (DESCRIBE SELECT * FROM read_ast('test/data/test_native_context.py', source := 'full'))
+WHERE column_name IN ('start_column', 'end_column');
+----
+2
+
+query I
+SELECT count(*) FROM (DESCRIBE SELECT * FROM read_ast('test/data/test_native_context.py', source := 'lines'))
+WHERE column_name IN ('start_column', 'end_column');
+----
+0
+
+# =============================================================================
+# Line numbers keep working (they were never broken — guard the regression)
+# =============================================================================
+
+query I
+SELECT start_line
+FROM read_ast('test/data/test_native_context.py', source := 'full')
+WHERE semantic_type = 240 AND start_line = 1
+LIMIT 1;
+----
+1


### PR DESCRIPTION
## The bug

`read_ast(..., source := 'full')` adds `start_column` and `end_column`, and both are **0 for every node in every file**. The columns are in the schema but carry no information, so `source := 'full'` costs two columns and buys nothing.

Reproduces on the current release (`f7b9c60`) — 169 of 169 rows report `start_column = 0` on `test/data/test_native_context.py`, and the same holds for ordinary multi-line files, not just minified ones.

## Cause

`ASTNode` carries two sets of position fields — a legacy pair and the flattened pair introduced by the `source_*` migration:

```cpp
uint16_t start_column = 0;          // legacy
uint16_t end_column = 0;
// FULLY FLATTENED FIELDS
uint32_t source_start_column = 0;   // what parsing actually writes
uint32_t source_end_column = 0;
```

`read_ast`'s parsing path (`unified_ast_backend_impl.hpp:203-209`) writes only the flattened fields. Both table projections (`unified_ast_backend.cpp:835/837` and `:1198/1199`) read the legacy members, which are written only in `ast_type.cpp` — a different path — so via `read_ast` they keep their `= 0` initializer.

**Line numbers are unaffected**, which is why this went unnoticed: they resolve through a path that does populate their legacy members. Anything spot-checking `start_line` looks correct.

## Fix

Point the two projections at `source_start_column` / `source_end_column`.

## Tests

`test/sql/source_full_columns.test` asserts the columns carry real positions, not merely non-zero ones:

- a top-level definition reports `start_column = 1` (columns are 1-based)
- `end_column > start_column`
- no row reports `start_column = 0`
- **more than one distinct `start_column` across the file** — so a constant can't pass while carrying no positional information
- an indented statement starts further right than its enclosing definition
- the columns appear only at `source := 'full'`, not at `'lines'`
- `start_line` still resolves (guards the regression)

Verified these fail against the released build (5 of the assertions) and pass with the fix, so they can't pass vacuously.

## Docs

`API_REFERENCE.md` documented `peek_size` / `peek_mode` with values (`'auto' | 'chars' | 'lines'`) that the binder rejects, and omitted the canonical `peek` parameter. Corrected, with the superseded parameters marked and the real vocabulary documented (`none | smart | full | <int>`, optional `+schema`).

Also records a separate verified limitation, **not** fixed here: a numeric `peek` is accepted but ignored — it always yields the 80-char `'smart'` output regardless of the size requested.