### PR TITLE
docs: retract three claims about peek and columns, including #100's

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -37,11 +37,11 @@
   - any of the above with `'+schema'` appended (e.g. `'none+schema'`) to keep the
     column in the schema while suppressing its content
 
-  ⚠️ **Known limitation:** a numeric `peek` is accepted but **not currently
-  honoured** — the output is the same 80 characters `'smart'` produces,
-  regardless of the size requested. Until that is fixed, the effective choice is
-  `'smart'` (80 chars) or `'full'` (unbounded). See "Extracting source from
-  minified files" below.
+  A numeric `peek` is honoured exactly: `peek := '20'` yields peeks of at most
+  20 characters, `peek := '400'` at most 400. This is the middle ground between
+  `'smart'` (fixed 80-character cap) and `'full'` (unbounded), and it is the
+  setting to reach for on minified input — see "Extracting source from minified
+  files" below.
 
 > **Superseded parameters.** `peek_size` (INTEGER) and `peek_mode` (VARCHAR) are
 > legacy and retained only for backward compatibility. Use `peek` instead.
@@ -74,13 +74,16 @@
 > **Column availability.** The default projection is 21 columns. Passing
 > `source := 'full'` adds `start_column` and `end_column` (23 columns).
 >
-> ⚠️ **Released builds return 0.** In published builds up to and including
-> `f7b9c60`, `start_column` and `end_column` are **always 0** on every file:
-> `read_ast`'s parsing path populates the flattened `source_start_column` /
-> `source_end_column` fields, while the table projection read the legacy
-> `start_column` / `end_column` members, which keep their zero initializer.
-> Fixed in this branch; if you are on a released build, verify before relying
-> on these columns.
+> ⚠️ **v1.10.0 and v1.10.1 return 0.** In those two releases `start_column` and
+> `end_column` are **always 0** on every file: since the runtime-loadable
+> grammar work (#80), `read_ast`'s parsing path populates the flattened
+> `source_start_column` / `source_end_column` fields, while the table projection
+> still read the legacy `start_column` / `end_column` members, which keep their
+> zero initializer. Line numbers were unaffected, which is why it went unnoticed.
+>
+> Fixed in **v1.10.2**. Releases before v1.10.0 are also unaffected — they
+> predate #80 and populate the legacy fields. If you are on v1.10.0 or v1.10.1,
+> upgrade rather than working around it.
 
 ### Extracting source from minified files
 
@@ -93,20 +96,25 @@ This matters because **every `ast_get_source*` function is line-addressed**
 `ast_get_source_numbered(...)`, `ast_get_source_line(file_path, line_num)`).
 On minified input they cannot isolate a node.
 
-That leaves `peek` as the only character-oriented extraction path, and the two
-limitations noted above currently constrain it:
+Two character-oriented paths remain, and on v1.10.2 both work:
 
 | Approach | Minified input |
 |---|---|
 | `ast_get_source*` | Unusable — line-addressed, and everything is line 1 |
-| `start_column` / `end_column` | Unusable — always 0 (see above) |
+| `start_column` / `end_column` | Works (v1.10.2+) — the only way to locate a node *within* the single line |
 | `peek := 'smart'` | Works, but capped at 80 characters |
-| `peek := <integer>` | Size not yet honoured — behaves as `'smart'` |
+| `peek := <integer>` | Works — an explicit character budget, e.g. `peek := '400'` |
 | `peek := 'full'` | Works, but unbounded — a single node can be tens of KB |
 
-**Practical recommendation today:** use `peek := 'smart'` for triage (safe and
-bounded) and `peek := 'full'` when you need the complete node and can tolerate
-the size. Combine with `semantic_type` to narrow the node set first — for
+On a 40-function minified bundle, `source := 'full'` reports one distinct
+`start_line` and 600 distinct `start_column` values — so the columns carry all
+the positional information the line numbers have lost, and a node can be sliced
+out of the raw text by character offset.
+
+**Practical recommendation:** use `peek := 'smart'` for triage (safe and
+bounded), a numeric `peek` when 80 characters is too few but `'full'` is too
+much, and `peek := 'full'` when you need the complete node and can tolerate the
+size. Combine with `semantic_type` to narrow the node set first — for
 example `semantic_type = 144` (FLOW_CONDITIONAL) to find decision sites rather
 than every textual match:
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -74,16 +74,16 @@
 > **Column availability.** The default projection is 21 columns. Passing
 > `source := 'full'` adds `start_column` and `end_column` (23 columns).
 >
-> ⚠️ **v1.10.0 and v1.10.1 return 0.** In those two releases `start_column` and
-> `end_column` are **always 0** on every file: since the runtime-loadable
-> grammar work (#80), `read_ast`'s parsing path populates the flattened
-> `source_start_column` / `source_end_column` fields, while the table projection
-> still read the legacy `start_column` / `end_column` members, which keep their
-> zero initializer. Line numbers were unaffected, which is why it went unnoticed.
+> **Older builds returned 0.** A community build reporting `extension_version`
+> `f7b9c60` returned `start_column = 0` for all 169 nodes of
+> `test/data/test_native_context.py` under `source := 'full'`. Line numbers were
+> unaffected, so anything spot-checking `start_line` looked correct.
 >
-> Fixed in **v1.10.2**. Releases before v1.10.0 are also unaffected — they
-> predate #80 and populate the legacy fields. If you are on v1.10.0 or v1.10.1,
-> upgrade rather than working around it.
+> This is **already fixed in v1.9.0 and later** — verified against the community
+> build reporting `1da4374`, which returns 52 distinct column values on that same
+> file. If you see zeros, check what you actually have loaded before anything
+> else: `SELECT extension_version, install_path FROM duckdb_extensions() WHERE
+> extension_name = 'sitting_duck'`.
 
 ### Extracting source from minified files
 
@@ -96,12 +96,12 @@ This matters because **every `ast_get_source*` function is line-addressed**
 `ast_get_source_numbered(...)`, `ast_get_source_line(file_path, line_num)`).
 On minified input they cannot isolate a node.
 
-Two character-oriented paths remain, and on v1.10.2 both work:
+Two character-oriented paths remain, and on v1.9.0+ both work:
 
 | Approach | Minified input |
 |---|---|
 | `ast_get_source*` | Unusable — line-addressed, and everything is line 1 |
-| `start_column` / `end_column` | Works (v1.10.2+) — the only way to locate a node *within* the single line |
+| `start_column` / `end_column` | Works (v1.9.0+) — the only way to locate a node *within* the single line |
 | `peek := 'smart'` | Works, but capped at 80 characters |
 | `peek := <integer>` | Works — an explicit character budget, e.g. `peek := '400'` |
 | `peek := 'full'` | Works, but unbounded — a single node can be tens of KB |

--- a/test/sql/source_full_columns.test
+++ b/test/sql/source_full_columns.test
@@ -16,10 +16,16 @@ LOAD sitting_duck;
 # Columns are 1-based (the parser adds 1 to tree-sitter's 0-based column), so a
 # definition starting in the leftmost position reports start_column = 1.
 #
-# Regression: both table projections used to read the legacy start_column /
-# end_column members while read_ast's parsing path populated only the flattened
-# source_start_column / source_end_column fields, so every row came back 0.
-# Line numbers were unaffected, which is why this stayed hidden.
+# This is an invariant test, NOT a regression guard for any specific commit.
+# An older community build (extension_version f7b9c60) returned 0 for every
+# node here; builds from v1.9.0 on do not. The projection change in #100 was
+# measured to be a behavioral no-op — pre- and post-change builds emit
+# byte-identical columns over 30,144 nodes across 129 files — so this test
+# passes on both, and would not have caught that change either way.
+#
+# What it does guard: that columns stay populated, vary across the file, and
+# track nesting. Line numbers were unaffected by the historical bug, which is
+# why spot-checking start_line hid it.
 
 # =============================================================================
 # Columns are present and populated at source := 'full'


### PR DESCRIPTION
Documentation-only. Retracts three claims — two from `d9b49cf`, one from #100's own description — that do not survive measurement. The common cause matters more than any of them individually: **each was "verified" against the installed community extension rather than the source being described.**

### 1. Numeric `peek` is honoured (retracts a "known limitation")

| requested | max peek length |
|---|---|
| `'5'` | 5 |
| `'37'` | 37 |
| `'120'` | 120 |
| `'250+schema'` | 250 |
| `'1000'` | 929 (bounded by the largest node — `'full'` is also 929) |
| `'smart'` | 80 |

The 80-character `'smart'` cap is real, confirmed on a file with 500-character lines.

### 2. #100 was a behavioral no-op (retracts its headline)

Built the extension from `7ec5a97^` and from `7ec5a97` — same flags, python-only — and diffed `read_ast(..., source := 'full')`:

```
30,144 rows across 129 files — byte-identical
```

Both builds report 0 zeros and 52 distinct `start_column` values on `test/data/test_native_context.py`. On current main the legacy `start_column`/`end_column` members *and* the flattened `source_*` fields are populated, so reading either gives the same answer. #100 did not fix a bug, and v1.10.2's release notes have been corrected accordingly.

**The change is kept** — reading the fields the parsing path writes is the more defensive of two equivalent options. It just isn't a fix.

### 3. The bug was real, but older and already fixed

| build | `start_column` on the 169-node fixture |
|---|---|
| community `f7b9c60` | 0 for all 169 |
| community `1da4374` (v1.9.0+) | 52 distinct values |
| current main, pre- and post-#100 | 52 distinct values |

So the affected range is builds around `f7b9c60`, fixed by v1.9.0 — not "all published builds up to `f7b9c60`", and not "v1.10.0 and v1.10.1" (an intermediate guess in this PR's earlier description, also wrong).

`test/sql/source_full_columns.test` is relabeled an invariant test: it passes on both builds, so it never guarded #100.

### Consequence for users

If you see zeroed columns, check what is actually loaded first:

```sql
SELECT extension_version, install_path FROM duckdb_extensions() WHERE extension_name = 'sitting_duck';
```

No source change, so no version bump. duckdb/community-extensions#2502 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExXsetxEKGA5DLCHkfb29C
