### PR TITLE
fix(extractors): route decorators/annotations to annotations column (contract A)

### DIFF
--- a/src/include/java_native_extractors.hpp
+++ b/src/include/java_native_extractors.hpp
@@ -42,6 +42,7 @@ struct JavaNativeExtractor<NativeExtractionStrategy::FUNCTION_WITH_PARAMS> {
 		// Extract access modifiers and other modifiers
 		auto modifiers = ExtractJavaModifiers(node, content);
 		context.modifiers = modifiers;
+		SplitAnnotations(context.modifiers, context.annotations);
 
 		return context;
 	}
@@ -305,6 +306,7 @@ struct JavaNativeExtractor<NativeExtractionStrategy::CLASS_WITH_METHODS> {
 			context.parameters.clear();
 		}
 
+		SplitAnnotations(context.modifiers, context.annotations);
 		return context;
 	}
 
@@ -710,6 +712,7 @@ struct JavaNativeExtractor<NativeExtractionStrategy::VARIABLE_WITH_TYPE> {
 			context.modifiers.clear();
 		}
 
+		SplitAnnotations(context.modifiers, context.annotations);
 		return context;
 	}
 

--- a/src/include/native_context_extraction.hpp
+++ b/src/include/native_context_extraction.hpp
@@ -318,6 +318,54 @@ inline void SplitAnnotations(vector<string> &modifiers, string &annotations) {
 	modifiers = std::move(keyword_only);
 }
 
+// Collect '@decorator' text from a declaration node's children and its preceding
+// siblings (decorators sit before/inside the declaration in TS/Python-style grammars).
+inline vector<string> ExtractDecoratorTexts(TSNode node, const string &content) {
+	vector<string> out;
+	auto grab = [&](TSNode n) {
+		if (string(ts_node_type(n)) == "decorator") {
+			uint32_t s = ts_node_start_byte(n);
+			uint32_t e = ts_node_end_byte(n);
+			if (s < content.size() && e <= content.size() && e > s) {
+				out.push_back(content.substr(s, e - s));
+			}
+		}
+	};
+	uint32_t child_count = ts_node_child_count(node);
+	for (uint32_t i = 0; i < child_count; i++) {
+		grab(ts_node_child(node, i));
+	}
+	// Preceding siblings: only the CONTIGUOUS run of decorators immediately before
+	// the node belong to it. A non-decorator sibling (e.g. a prior method) ends the
+	// run, so an earlier declaration's decorators don't bleed onto this one.
+	TSNode parent = ts_node_parent(node);
+	if (!ts_node_is_null(parent)) {
+		uint32_t parent_count = ts_node_child_count(parent);
+		uint32_t self_idx = parent_count;
+		for (uint32_t i = 0; i < parent_count; i++) {
+			if (ts_node_eq(ts_node_child(parent, i), node)) {
+				self_idx = i;
+				break;
+			}
+		}
+		vector<string> preceding;
+		for (uint32_t i = self_idx; i-- > 0;) {
+			TSNode sib = ts_node_child(parent, i);
+			if (string(ts_node_type(sib)) != "decorator") {
+				break; // run ends at the first non-decorator
+			}
+			uint32_t s = ts_node_start_byte(sib);
+			uint32_t e = ts_node_end_byte(sib);
+			if (s < content.size() && e <= content.size() && e > s) {
+				preceding.push_back(content.substr(s, e - s));
+			}
+		}
+		// preceding was collected nearest-first; restore source order
+		out.insert(out.end(), preceding.rbegin(), preceding.rend());
+	}
+	return out;
+}
+
 // Helper function to build qualified name from context
 string BuildQualifiedName(TSNode node, const string &content, const string &base_name);
 

--- a/src/include/native_context_extraction.hpp
+++ b/src/include/native_context_extraction.hpp
@@ -296,6 +296,28 @@ inline void EnsureModifier(vector<string> &modifiers, const string &mod, bool pr
 	}
 }
 
+// Contract A: annotations/decorators are always '@'-prefixed in extracted text.
+// Split them out of a mixed modifier list into the dedicated `annotations` string
+// (joined by ", "), leaving `modifiers` keyword-only. No-op when there are none.
+inline void SplitAnnotations(vector<string> &modifiers, string &annotations) {
+	vector<string> keyword_only;
+	string annots;
+	for (const auto &m : modifiers) {
+		if (!m.empty() && m[0] == '@') {
+			if (!annots.empty()) {
+				annots += ", ";
+			}
+			annots += m;
+		} else {
+			keyword_only.push_back(m);
+		}
+	}
+	if (!annots.empty()) {
+		annotations = annots;
+	}
+	modifiers = std::move(keyword_only);
+}
+
 // Helper function to build qualified name from context
 string BuildQualifiedName(TSNode node, const string &content, const string &base_name);
 

--- a/src/include/python_native_extractors.hpp
+++ b/src/include/python_native_extractors.hpp
@@ -34,9 +34,16 @@ struct PythonNativeExtractor<NativeExtractionStrategy::FUNCTION_WITH_PARAMS> {
 		// Extract function parameters
 		context.parameters = ExtractPythonParameters(node, content);
 
-		// Extract decorators if present
+		// Contract A: decorators belong in `annotations`; `modifiers` stays keyword-only.
 		auto decorators = ExtractPythonDecorators(node, content);
-		context.modifiers = decorators;
+		if (!decorators.empty()) {
+			string joined;
+			for (size_t k = 0; k < decorators.size(); k++) {
+				joined += (k ? ", " : "");
+				joined += decorators[k];
+			}
+			context.annotations = joined;
+		}
 
 		// Scan children for keyword modifiers (async, etc.)
 		// tree-sitter-python emits 'async' as a child of function_definition,

--- a/src/include/typescript_native_extractors.hpp
+++ b/src/include/typescript_native_extractors.hpp
@@ -34,6 +34,12 @@ struct TypeScriptNativeExtractor<NativeExtractionStrategy::FUNCTION_WITH_PARAMS>
 		auto modifiers = ExtractTypeScriptModifiers(node, content);
 		context.modifiers = modifiers;
 
+		// Contract A: decorators -> annotations (TS previously dropped them entirely)
+		for (const auto &deco : ExtractDecoratorTexts(node, content)) {
+			context.modifiers.push_back(deco);
+		}
+		SplitAnnotations(context.modifiers, context.annotations);
+
 		return context;
 	}
 
@@ -413,6 +419,11 @@ struct TypeScriptNativeExtractor<NativeExtractionStrategy::CLASS_WITH_METHODS> {
 			context.parameters.clear();
 		}
 
+		// Contract A: class/interface/enum decorators -> annotations
+		for (const auto &deco : ExtractDecoratorTexts(node, content)) {
+			context.modifiers.push_back(deco);
+		}
+		SplitAnnotations(context.modifiers, context.annotations);
 		return context;
 	}
 

--- a/test/data/annotation_extraction/Annotated.java
+++ b/test/data/annotation_extraction/Annotated.java
@@ -1,0 +1,16 @@
+@Deprecated
+public abstract class Base {
+    private static final int MAX = 10;
+
+    @Override
+    public synchronized String process(int x) {
+        return "";
+    }
+
+    @Deprecated
+    private int legacy() {
+        return 0;
+    }
+
+    public void plain() {}
+}

--- a/test/data/annotation_extraction/decorators.py
+++ b/test/data/annotation_extraction/decorators.py
@@ -1,0 +1,13 @@
+@app.route("/api")
+@staticmethod
+def handler(request):
+    return 200
+
+
+@property
+def name(self):
+    return self._name
+
+
+def plain():
+    pass

--- a/test/data/annotation_extraction/decorators.ts
+++ b/test/data/annotation_extraction/decorators.ts
@@ -1,0 +1,13 @@
+@Component({selector: "app"})
+class Service {
+  private count: number = 0;
+
+  @Input()
+  async fetch(url: string): Promise<Data> {
+    return await get(url);
+  }
+
+  validate(x: number): boolean {
+    return true;
+  }
+}

--- a/test/sql/native_extraction/annotation_extraction.test
+++ b/test/sql/native_extraction/annotation_extraction.test
@@ -41,3 +41,34 @@ query I
 SELECT COUNT(*) FROM ast_select('test/data/annotation_extraction/decorators.py', '.func:decorated');
 ----
 2
+
+# =============================================================================
+# JAVA — @Annotations -> annotations column (methods AND classes), not modifiers
+# =============================================================================
+
+# No annotation ('@...') leaks into modifiers, for methods or classes.
+query I
+SELECT COUNT(*) FROM read_ast('test/data/annotation_extraction/Annotated.java', context := 'native')
+WHERE (is_function_definition(semantic_type) OR is_class_definition(semantic_type))
+  AND array_to_string(modifiers, ',') LIKE '%@%';
+----
+0
+
+# Annotated methods and the class expose their annotation via annotations.
+query TT
+SELECT name, annotations FROM read_ast('test/data/annotation_extraction/Annotated.java', context := 'native')
+WHERE name IN ('Base', 'process', 'legacy')
+  AND annotations IS NOT NULL AND annotations != ''
+ORDER BY name;
+----
+Base	@Deprecated
+legacy	@Deprecated
+process	@Override
+
+# Keyword modifiers still land in modifiers (order-independent).
+query I
+SELECT COUNT(*) FROM read_ast('test/data/annotation_extraction/Annotated.java', context := 'native')
+WHERE name = 'process'
+  AND list_contains(modifiers, 'public') AND list_contains(modifiers, 'synchronized');
+----
+1

--- a/test/sql/native_extraction/annotation_extraction.test
+++ b/test/sql/native_extraction/annotation_extraction.test
@@ -72,3 +72,39 @@ WHERE name = 'process'
   AND list_contains(modifiers, 'public') AND list_contains(modifiers, 'synchronized');
 ----
 1
+
+# =============================================================================
+# TYPESCRIPT — decorators -> annotations (previously dropped entirely)
+# =============================================================================
+
+# No decorator ('@...') leaks into modifiers.
+query I
+SELECT COUNT(*) FROM read_ast('test/data/annotation_extraction/decorators.ts', context := 'native')
+WHERE (is_function_definition(semantic_type) OR is_class_definition(semantic_type))
+  AND array_to_string(modifiers, ',') LIKE '%@%';
+----
+0
+
+# Class and method decorators are exposed via annotations.
+query TT
+SELECT name, annotations FROM read_ast('test/data/annotation_extraction/decorators.ts', context := 'native')
+WHERE name IN ('Service', 'fetch') AND annotations IS NOT NULL AND annotations != ''
+ORDER BY name;
+----
+Service	@Component({selector: "app"})
+fetch	@Input()
+
+# :decorated (reads annotations) matches the decorated class + method.
+query I
+SELECT COUNT(*) FROM ast_select('test/data/annotation_extraction/decorators.ts', ':decorated');
+----
+2
+
+# An undecorated method after a decorated one must NOT inherit the prior decorator
+# (contiguous-run guard: preceding-sibling scan stops at the first non-decorator).
+query I
+SELECT COUNT(*) FROM read_ast('test/data/annotation_extraction/decorators.ts', context := 'native')
+WHERE name = 'validate' AND is_function_definition(semantic_type)
+  AND (annotations IS NULL OR annotations IN ('', '{}'));
+----
+1

--- a/test/sql/native_extraction/annotation_extraction.test
+++ b/test/sql/native_extraction/annotation_extraction.test
@@ -1,0 +1,43 @@
+# name: test/sql/native_extraction/annotation_extraction.test
+# description: Contract A — decorators/annotations land in the `annotations` column, not `modifiers`.
+#              `modifiers` stays keyword-only; `:decorated` (which reads `annotations`) starts matching.
+# group: [native_extraction]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# =============================================================================
+# PYTHON — function decorators -> annotations (not modifiers)
+# =============================================================================
+
+# Contract A invariant: no decorator ('@...') leaks into modifiers.
+query I
+SELECT COUNT(*) FROM read_ast('test/data/annotation_extraction/decorators.py', context := 'native')
+WHERE is_function_definition(semantic_type) AND array_to_string(modifiers, ',') LIKE '%@%';
+----
+0
+
+# Decorators are exposed via the annotations column, in source order.
+query TT
+SELECT name, annotations FROM read_ast('test/data/annotation_extraction/decorators.py', context := 'native')
+WHERE is_function_definition(semantic_type) AND name IN ('handler', 'name')
+ORDER BY name;
+----
+handler	@app.route("/api"), @staticmethod
+name	@property
+
+# Undecorated functions carry no annotations.
+query I
+SELECT COUNT(*) FROM read_ast('test/data/annotation_extraction/decorators.py', context := 'native')
+WHERE is_function_definition(semantic_type) AND name = 'plain'
+  AND (annotations IS NULL OR annotations IN ('', '{}'));
+----
+1
+
+# The :decorated pseudo-class (reads annotations) now matches the two decorated defs.
+query I
+SELECT COUNT(*) FROM ast_select('test/data/annotation_extraction/decorators.py', '.func:decorated');
+----
+2

--- a/test/sql/native_extraction/java_extraction.test
+++ b/test/sql/native_extraction/java_extraction.test
@@ -76,12 +76,13 @@ WHERE type = 'interface_declaration' AND name = 'Athlete';
 ----
 Athlete	[{'name': Runner, 'type': extends}, {'name': Serializable, 'type': extends}]	[interface]
 
-# Test: Functional interface with annotation
-query ITTT
-SELECT name, signature_type, parameters, modifiers FROM read_ast('test/data/languages/java/Inheritance.java', context := 'native')
+# Test: Functional interface with annotation.
+# Contract A: @FunctionalInterface lands in `annotations`, not `modifiers`.
+query ITTTT
+SELECT name, signature_type, parameters, modifiers, annotations FROM read_ast('test/data/languages/java/Inheritance.java', context := 'native')
 WHERE type = 'interface_declaration' AND name = 'SoundMaker';
 ----
-SoundMaker	functional_interface	[]	[interface, @FunctionalInterface]
+SoundMaker	functional_interface	[]	[interface]	@FunctionalInterface
 
 # =============================================================================
 # DEFINITION_ENUM - Enum Declarations
@@ -98,19 +99,20 @@ DogBreed	[{'name': Serializable, 'type': implements}]	[enum]
 # DEFINITION_FUNCTION - Method Declarations
 # =============================================================================
 
-# Test: Method return types are extracted correctly (includes inner interface method)
-query ITT
-SELECT name, signature_type, modifiers FROM read_ast('test/data/languages/java/Test.java', context := 'native')
+# Test: Method return types are extracted correctly (includes inner interface method).
+# Contract A: @Override moves from modifiers to the annotations column.
+query ITTT
+SELECT name, signature_type, modifiers, annotations FROM read_ast('test/data/languages/java/Test.java', context := 'native')
 WHERE type = 'method_declaration' AND name IS NOT NULL
 ORDER BY start_line;
 ----
-toString	String	[@Override, public]
-increment	void	[public]
-getCounter	int	[protected]
-reset	void	[private]
-main	void	[public, static]
-processData	String	[private, static]
-process	void	[]
+toString	String	[public]	@Override
+increment	void	[public]	NULL
+getCounter	int	[protected]	NULL
+reset	void	[private]	NULL
+main	void	[public, static]	NULL
+processData	String	[private, static]	NULL
+process	void	[]	NULL
 
 # Test: Method parameters are extracted
 query IT

--- a/test/sql/native_extraction/modifier_extraction_audit.test
+++ b/test/sql/native_extraction/modifier_extraction_audit.test
@@ -16,7 +16,8 @@ LOAD sitting_duck;
 # PYTHON: async modifier extraction
 # =============================================================================
 
-# Async functions should have [async] (including decorated async)
+# Async functions should have [async]. Contract A: decorators live in `annotations`,
+# not `modifiers`, so a decorated async function's modifiers are keyword-only ([async]).
 query TT
 SELECT name, modifiers FROM read_ast('test/data/modifier_audit/async_functions.py', context := 'native')
 WHERE is_function_definition(semantic_type) AND NOT is_syntax_only(flags) AND name != ''
@@ -26,7 +27,7 @@ fetch_data	[async]
 sync_helper	[]
 process_items	[async]
 some_decorator	[]
-decorated_async	[async, @some_decorator]
+decorated_async	[async]
 
 # Verify: list_contains works for filtering
 query I


### PR DESCRIPTION
## Contract A: decorators/annotations belong in `annotations`, not `modifiers`

Native extraction routed function/class **decorators and annotations** into the
`modifiers[]` column, leaving the dedicated `annotations` column empty and the
`:decorated` selector (which reads `annotations`) permanently non-matching.

Fixes across all three best-covered languages:
- **Python** — decorators were assigned to `modifiers`; now joined into `annotations`, `modifiers` stays keyword-only.
- **Java** — `@Override`/`@Deprecated`/etc. were lumped into `modifiers` across methods, classes, interfaces, enums, fields; a shared `SplitAnnotations()` helper routes `@`-prefixed entries to `annotations`.
- **TypeScript** — decorators were **dropped entirely** (only `async` survived); new `ExtractDecoratorTexts()` collects them (with a contiguous-run guard so an earlier method's decorator can't bleed onto a later undecorated one).

`modifiers` is now keyword-only; `annotations` is populated; `:decorated` revives with no selector change.

### Tests
TDD throughout (RED captured before each fix). New `test/sql/native_extraction/annotation_extraction.test` (Python + Java + TS, incl. the bleed guard); `modifier_extraction_audit` and `java_extraction` updated to contract A. **Full suite green: 6539 assertions / 115 cases, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
