### PR TITLE
fix(macros): modern lambda syntax (DuckDB 2.0 compat)

### DIFF
--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -196,7 +196,7 @@ CREATE OR REPLACE MACRO ast_qualified_name_as_string(qn) AS (
     CASE
         WHEN qn IS NULL OR len(qn) = 0 THEN NULL
         ELSE list_aggregate(
-            list_transform(qn, s ->
+            list_transform(qn, lambda s:
                 CASE
                     WHEN is_function_definition(s.semantic_type) THEN 'F'
                     WHEN is_class_definition(s.semantic_type) THEN 'C'

--- a/src/sql_macros/semantic_predicates.sql
+++ b/src/sql_macros/semantic_predicates.sql
@@ -180,7 +180,7 @@ CREATE OR REPLACE MACRO ast_qualified_name_as_string(qn) AS (
     CASE
         WHEN qn IS NULL OR len(qn) = 0 THEN NULL
         ELSE list_aggregate(
-            list_transform(qn, s ->
+            list_transform(qn, lambda s:
                 CASE
                     WHEN is_function_definition(s.semantic_type) THEN 'F'
                     WHEN is_class_definition(s.semantic_type) THEN 'C'

--- a/test/sql/lambda_syntax.test
+++ b/test/sql/lambda_syntax.test
@@ -1,0 +1,31 @@
+# name: test/sql/lambda_syntax.test
+# description: Macros must use the modern `lambda x:` syntax, not the deprecated `x ->`
+#              arrow (removed in a future DuckDB release). Guards against regressions
+#              in embedded SQL macros like ast_qualified_name_as_string.
+# group: [sql]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# Force DuckDB to REJECT the deprecated single-arrow lambda. If any embedded macro
+# still uses `x -> ...`, evaluating it under this setting errors out.
+statement ok
+SET lambda_syntax='DISABLE_SINGLE_ARROW';
+
+# ast_qualified_name_as_string uses list_transform with a lambda; it must work with
+# single-arrow disabled (i.e. it uses the modern `lambda s:` form).
+statement ok
+SELECT ast_qualified_name_as_string(qualified_name)
+FROM read_ast('test/data/comprehensive_python_test.py', context := 'native')
+WHERE is_function_definition(semantic_type) AND qualified_name IS NOT NULL;
+
+# And it still produces the expected scope-path string.
+query I
+SELECT COUNT(*)
+FROM read_ast('test/data/comprehensive_python_test.py', context := 'native')
+WHERE is_function_definition(semantic_type)
+  AND ast_qualified_name_as_string(qualified_name) = 'F[basic_function]';
+----
+1


### PR DESCRIPTION
## Modern lambda syntax in `ast_qualified_name_as_string`

DuckDB deprecated the single-arrow lambda (`x -> expr`); it warns today and will be **removed in a future release (breaks on DuckDB 2.0)**. `ast_qualified_name_as_string` used the deprecated form in a `list_transform`. Switched to `lambda s:` and regenerated `embedded_sql_macros.hpp` (the compiled-in copy, kept in sync per CI).

This was the **only** deprecated lambda arrow in the codebase — verified by scanning all `sql_macros` minus comments, signature-format strings, and C++ pointer derefs.

### Test
`test/sql/lambda_syntax.test` runs the macro under `SET lambda_syntax='DISABLE_SINGLE_ARROW'`, which errors if any embedded macro still uses `->`. Future-proof guard for when the old syntax is removed. Verified: 0 deprecation warnings (was firing), regression sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
