### PR TITLE
test: pin numeric peek behavior; resolve #012 (stale-install false alarm)

### DIFF
--- a/test/sql/numeric_peek.test
+++ b/test/sql/numeric_peek.test
@@ -1,0 +1,42 @@
+# name: test/sql/numeric_peek.test
+# description: numeric peek := N truncates previews to N characters (guards the
+#   behavior falsely reported broken in tracker bug #012 — the report came from
+#   a stale local install; this pins the real contract so a regression cannot
+#   hide behind schema-shaped output)
+# group: [sql]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# read_ast: every non-NULL peek respects the requested cap
+query I
+SELECT bool_and(length(peek) <= 20) FROM read_ast('test/data/python/simple.py', peek := 20) WHERE peek IS NOT NULL;
+----
+true
+
+# ...and the cap actually bites: at least one node's smart preview would exceed it
+query I
+SELECT max(length(peek)) = 20 FROM read_ast('test/data/python/simple.py', peek := 20) WHERE peek IS NOT NULL;
+----
+true
+
+# parse_ast honours the same contract
+query I
+SELECT bool_and(length(peek) <= 15) FROM parse_ast('def f():' || chr(10) || '    return "a deliberately long string constant exceeding any smart preview cap"', 'python', peek := 15) WHERE peek IS NOT NULL;
+----
+true
+
+# different sizes yield different truncation (the parameter is not a no-op)
+query I
+SELECT (SELECT max(length(peek)) FROM read_ast('test/data/python/simple.py', peek := 20) WHERE peek IS NOT NULL)
+     < (SELECT max(length(peek)) FROM read_ast('test/data/python/simple.py', peek := 60) WHERE peek IS NOT NULL);
+----
+true
+
+# smart mode still caps at 80 (documents the default's contract alongside)
+query I
+SELECT bool_and(length(peek) <= 80) FROM read_ast('test/data/python/simple.py', peek := 'smart') WHERE peek IS NOT NULL;
+----
+true

--- a/tracker/bugs/resolved/012-numeric-peek-not-honoured.md
+++ b/tracker/bugs/resolved/012-numeric-peek-not-honoured.md
@@ -1,0 +1,55 @@
+# Bug #012: numeric `peek` accepted but not honoured
+
+**Status:** Resolved — NOT A BUG (stale local install)
+**Priority:** P2
+**Found:** documented in PR #100's investigation, 2026-08-14
+**Resolved:** 2026-08-31 — numeric `peek` works correctly on v1.10.3: `peek := 20`
+caps previews at 20 chars, `peek := 60` at 60 (verified empirically, not a no-op).
+The original report came from a **stale locally-installed build** — the same class
+as #100/#101, whose peek/column doc claims were retracted in #101. The docs were
+already corrected by #101; the behavior is now **pinned by
+`test/sql/numeric_peek.test`** so this cannot be falsely re-reported behind
+schema-shaped output. The "conformance kit" recommendation below still stands.
+
+## Symptom (as originally reported — did NOT reproduce on v1.10.3)
+
+`peek := <int>` binds successfully (parsed into `PeekLevel::CUSTOM` +
+`peek_size`) but the runtime always emits the 80-char smart-mode output —
+the numeric size is never applied.
+
+```sql
+SELECT peek FROM read_ast('file.py', peek := 50);
+-- rows exceed 50 chars; identical output to peek := 'smart'
+```
+
+## Impact
+
+The README and API reference document numeric peek as "fixed-size snippets:
+at most N characters per node." The parameter silently does nothing —
+the same value-shaped-nothing class as #100's zero columns and #011's
+unclassified macros.
+
+## Suspected shape
+
+Same split-brain as #100: `ParseExtractionConfig`
+(unified_ast_backend.cpp:~251-280) populates `config.peek = CUSTOM` and
+`config.peek_size`, but the peek-emission path likely branches on a legacy
+peek_mode/peek_size pair (see read_ast_streaming_state.hpp:93/118,
+unified_ast_backend_impl.hpp:579) that CUSTOM never reaches. Unverified —
+diagnose before fixing.
+
+## Test to add (behavior, not interface)
+
+```sql
+query I
+SELECT bool_and(length(peek) <= 50) FROM read_ast('f.py', peek := 50) WHERE peek IS NOT NULL;
+-- expect true; today false
+```
+
+## Recommendation for v2 conformance kit
+
+Generalize PR #100's `source_full_columns.test` approach into a kit rule:
+**every advertised column/parameter must demonstrably take effect on a
+canonical fixture** (columns vary, sizes bind, filters filter). Schema
+presence and binder acceptance are not evidence of behavior — #100, #011,
+and this bug are all the same failure class caught late.


### PR DESCRIPTION
Bug #012 reported numeric `peek := N` as accepted-but-ignored. **Verified empirically on v1.10.3 it works** — `peek := 20` caps previews at 20 chars, `peek := 60` at 60 (not a no-op). The report came from a **stale local install** (same class as #100/#101, whose peek/column claims were retracted in #101, which already corrected the docs).

Adds `test/sql/numeric_peek.test` to pin the contract so this can't be falsely re-reported behind schema-shaped output, and moves bug #012 to `resolved/` with the diagnosis. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)