### PR TITLE
fix(blocks): ast_to_blocks level>=1 per current duck_blocks spec + vendor 6.2 conformance

### DIFF
--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -4668,7 +4668,8 @@ CREATE OR REPLACE MACRO ast_find_references(
 --
 -- ast_to_blocks converts parsed ASTs into duck_blocks — the document-element
 -- STRUCT spec shared by the markdown / webbed / duck_block_utils extensions
--- (duck_block_utils docs/duck_blocks_spec.md, v0.4.0).
+-- (duck_block_utils SPEC_VERSION 6.2; vendored vocabulary + conformance macros
+-- in third_party/duck_block_utils/, validated by test/sql/duck_blocks_conformance.test).
 --
 -- duck_blocks is a SPEC, not a dependency: these macros emit conforming
 -- STRUCTs and require nothing to be loaded. If duck_block_utils IS loaded,
@@ -4678,7 +4679,7 @@ CREATE OR REPLACE MACRO ast_find_references(
 --   PRAGMA duck_block_render;
 --   SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
 --
--- Element shape (spec v0.4.0):
+-- Element shape (SPEC_VERSION 6.2):
 --   STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER,
 --          encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR),
 --          element_order INTEGER)
@@ -4686,8 +4687,10 @@ CREATE OR REPLACE MACRO ast_find_references(
 -- Spec fine print this producer honors:
 --   * kind is always 'block' (we emit no inlines).
 --   * A heading's semantic level lives in attributes['heading_level'] as a
---     STRING ('1'..'6'); the `level` field is NULL for headings. `level` is
---     structural nesting depth and is only set for metadata blocks (0).
+--     STRING ('1'..'6'), NOT in the `level` field. `level` is structural
+--     nesting depth: SPEC_VERSION 3.0+ requires it >= 1 for every element
+--     (no NULLs, never semantic). This outline is flat — no section/div
+--     containers — so every block we emit is a top-level sibling at level 1.
 --   * code blocks carry attributes['language']; metadata uses encoding 'yaml'.
 --   * element_order starts at 0 and increases in document order, restarting
 --     per file (each file's element list is a document of its own; when
@@ -4874,7 +4877,7 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
                 'classes: ' || (SELECT count(*) FROM defs d
                                 WHERE d.file_path = f.file_path
                                   AND is_class_definition(d.semantic_type))::VARCHAR AS content,
-                0 AS level,
+                1 AS level,
                 'yaml' AS encoding,
                 MAP([], [])::MAP(VARCHAR, VARCHAR) AS attributes
             FROM files f
@@ -4883,14 +4886,15 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
             UNION ALL
 
             -- One heading per definition. Semantic level goes in
-            -- attributes['heading_level'] (string) per spec; level is NULL.
+            -- attributes['heading_level'] (string) per spec; structural level
+            -- is 1 (flat outline — headings are leaf blocks, not containers).
             SELECT
                 d.file_path,
                 d.node_id,
                 0,
                 'heading',
                 d.signature,
-                CAST(NULL AS INTEGER),
+                1,
                 'text',
                 MAP {'heading_level':
                      CASE WHEN style = 'flat'
@@ -4910,7 +4914,7 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
                 'paragraph',
                 d.definition_kind || ' ' || d.signature ||
                     ' (lines ' || d.start_line::VARCHAR || '-' || d.end_line::VARCHAR || ')',
-                CAST(NULL AS INTEGER),
+                1,
                 'text',
                 MAP([], [])::MAP(VARCHAR, VARCHAR)
             FROM def_info d
@@ -4927,7 +4931,7 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
                 2,
                 'code',
                 d.peek,
-                CAST(NULL AS INTEGER),
+                1,
                 'text',
                 MAP {'language': coalesce(d.language, 'unknown')}
             FROM def_info d
@@ -4937,14 +4941,14 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
         ordered AS (
             SELECT
                 e.*,
+
+)SQLMACRO"
+        R"SQLMACRO(
                 CAST(row_number() OVER (
                     PARTITION BY e.file_path
                     ORDER BY e.sort_node, e.sort_part) - 1 AS INTEGER) AS element_order
             FROM elements e
             WHERE (SELECT ok FROM params_validation)
-
-)SQLMACRO"
-        R"SQLMACRO(
               AND (SELECT ok FROM peek_validation)
         )
     SELECT

--- a/src/sql_macros/duck_blocks.sql
+++ b/src/sql_macros/duck_blocks.sql
@@ -4,7 +4,8 @@
 --
 -- ast_to_blocks converts parsed ASTs into duck_blocks — the document-element
 -- STRUCT spec shared by the markdown / webbed / duck_block_utils extensions
--- (duck_block_utils docs/duck_blocks_spec.md, v0.4.0).
+-- (duck_block_utils SPEC_VERSION 6.2; vendored vocabulary + conformance macros
+-- in third_party/duck_block_utils/, validated by test/sql/duck_blocks_conformance.test).
 --
 -- duck_blocks is a SPEC, not a dependency: these macros emit conforming
 -- STRUCTs and require nothing to be loaded. If duck_block_utils IS loaded,
@@ -14,7 +15,7 @@
 --   PRAGMA duck_block_render;
 --   SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
 --
--- Element shape (spec v0.4.0):
+-- Element shape (SPEC_VERSION 6.2):
 --   STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER,
 --          encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR),
 --          element_order INTEGER)
@@ -22,8 +23,10 @@
 -- Spec fine print this producer honors:
 --   * kind is always 'block' (we emit no inlines).
 --   * A heading's semantic level lives in attributes['heading_level'] as a
---     STRING ('1'..'6'); the `level` field is NULL for headings. `level` is
---     structural nesting depth and is only set for metadata blocks (0).
+--     STRING ('1'..'6'), NOT in the `level` field. `level` is structural
+--     nesting depth: SPEC_VERSION 3.0+ requires it >= 1 for every element
+--     (no NULLs, never semantic). This outline is flat — no section/div
+--     containers — so every block we emit is a top-level sibling at level 1.
 --   * code blocks carry attributes['language']; metadata uses encoding 'yaml'.
 --   * element_order starts at 0 and increases in document order, restarting
 --     per file (each file's element list is a document of its own; when
@@ -210,7 +213,7 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
                 'classes: ' || (SELECT count(*) FROM defs d
                                 WHERE d.file_path = f.file_path
                                   AND is_class_definition(d.semantic_type))::VARCHAR AS content,
-                0 AS level,
+                1 AS level,
                 'yaml' AS encoding,
                 MAP([], [])::MAP(VARCHAR, VARCHAR) AS attributes
             FROM files f
@@ -219,14 +222,15 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
             UNION ALL
 
             -- One heading per definition. Semantic level goes in
-            -- attributes['heading_level'] (string) per spec; level is NULL.
+            -- attributes['heading_level'] (string) per spec; structural level
+            -- is 1 (flat outline — headings are leaf blocks, not containers).
             SELECT
                 d.file_path,
                 d.node_id,
                 0,
                 'heading',
                 d.signature,
-                CAST(NULL AS INTEGER),
+                1,
                 'text',
                 MAP {'heading_level':
                      CASE WHEN style = 'flat'
@@ -246,7 +250,7 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
                 'paragraph',
                 d.definition_kind || ' ' || d.signature ||
                     ' (lines ' || d.start_line::VARCHAR || '-' || d.end_line::VARCHAR || ')',
-                CAST(NULL AS INTEGER),
+                1,
                 'text',
                 MAP([], [])::MAP(VARCHAR, VARCHAR)
             FROM def_info d
@@ -263,7 +267,7 @@ CREATE OR REPLACE MACRO ast_to_blocks_from(
                 2,
                 'code',
                 d.peek,
-                CAST(NULL AS INTEGER),
+                1,
                 'text',
                 MAP {'language': coalesce(d.language, 'unknown')}
             FROM def_info d

--- a/test/sql/duck_blocks.test
+++ b/test/sql/duck_blocks.test
@@ -16,7 +16,7 @@ LOAD sitting_duck;
 #  11  def top(x: int, y: int) -> int:
 
 # =============================================================================
-# Spec conformance (duck_blocks v0.4.0)
+# Spec conformance (duck_blocks SPEC_VERSION 6.2)
 # =============================================================================
 
 # Every emitted element is kind='block'
@@ -33,12 +33,13 @@ code
 heading
 metadata
 
-# Headings: level field is NULL; heading_level attribute is a string '1'..'6'
+# Headings: structural level is 1 (SPEC 3.0+ requires an explicit depth >= 1, no NULLs);
+# the heading rank lives in the heading_level attribute as a string '1'..'6'
 query I
 SELECT count(*)
 FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
 WHERE block.element_type = 'heading'
-  AND (block.level IS NOT NULL
+  AND (block.level IS DISTINCT FROM 1
        OR block.attributes['heading_level'] IS NULL
        OR NOT block.attributes['heading_level'] IN ('1', '2', '3', '4', '5', '6'));
 ----
@@ -60,13 +61,13 @@ WHERE block.element_type = 'code';
 ----
 4	4
 
-# Metadata block: encoding yaml, structural level 0
+# Metadata block: encoding yaml, structural level 1 (SPEC 3.0+), first in document order
 query III
 SELECT block.encoding, block.level, block.element_order
 FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
 WHERE block.element_type = 'metadata';
 ----
-yaml	0	0
+yaml	1	0
 
 # element_order starts at 0 and is strictly increasing in document order
 query I

--- a/test/sql/duck_blocks_conformance.test
+++ b/test/sql/duck_blocks_conformance.test
@@ -1,0 +1,81 @@
+# name: test/sql/duck_blocks_conformance.test
+# description: ast_to_blocks output validated against the vendored duck_blocks conformance macros
+# group: [sql]
+#
+# Runs the duck_block_utils conformance validator over real ast_to_blocks output,
+# so producer/spec drift is caught (tracker/bugs/014). The three macros below are
+# copied VERBATIM from third_party/duck_block_utils/duck_block_conformance.sql
+# (SPEC_VERSION 6.2, upstream 3bd7ff8) — resync BOTH together when the vendored
+# copy is bumped. See third_party/duck_block_utils/PROVENANCE.md.
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# --- vendored validator (verbatim copy; keep in sync with third_party/) ---
+
+statement ok
+CREATE OR REPLACE MACRO duck_block_declared_kinds() AS (['block', 'inline', 'value']);
+
+statement ok
+CREATE OR REPLACE MACRO duck_block_declared_encodings() AS (
+    ['text', 'json', 'yaml', 'html', 'xml', 'latex', 'markdown', 'toml']
+);
+
+statement ok
+CREATE OR REPLACE MACRO duck_block_is_valid(elem) AS (
+    list_contains(duck_block_declared_kinds(), elem.kind)
+    AND elem.element_type IS NOT NULL
+    AND list_contains(duck_block_declared_encodings(), elem.encoding)
+    AND elem.level IS NOT NULL
+    AND elem.level >= 1
+    AND elem.element_order IS NOT NULL
+    AND elem.element_order >= 0
+);
+
+# =============================================================================
+# Every emitted block is conformant (level >= 1, valid kind/encoding, order >= 0)
+# =============================================================================
+
+# Python (classes + nested defs + module metadata)
+query I
+SELECT count(*) FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE NOT duck_block_is_valid(block);
+----
+0
+
+# Go (functions; regenerated grammar in #108)
+query I
+SELECT count(*) FROM ast_to_blocks('test/data/go/simple.go', 'go')
+WHERE NOT duck_block_is_valid(block);
+----
+0
+
+# summary style (emits paragraph blocks) is also conformant
+query I
+SELECT count(*) FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'summary')
+WHERE NOT duck_block_is_valid(block);
+----
+0
+
+# flat style is conformant
+query I
+SELECT count(*) FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'flat')
+WHERE NOT duck_block_is_valid(block);
+----
+0
+
+# metadata-only file (no definitions) still emits a conformant metadata block
+query I
+SELECT count(*) FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', include_bodies := false)
+WHERE NOT duck_block_is_valid(block);
+----
+0
+
+# Every block carries an explicit structural level >= 1 (no NULLs, no 0)
+query I
+SELECT count(*) FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
+WHERE block.level IS NULL OR block.level < 1;
+----
+0

--- a/third_party/duck_block_utils/PROVENANCE.md
+++ b/third_party/duck_block_utils/PROVENANCE.md
@@ -1,0 +1,14 @@
+# Vendored from duckdb_duck_block_utils
+
+These files are a **vendored copy** — do not edit here; re-sync from upstream.
+
+- **Source repo:** teaguesterling/duckdb_duck_block_utils
+- **Commit:** `3bd7ff8a2bbe` (origin/main, 2026-09-01)
+- **SPEC_VERSION:** 6.2
+- **Files:** `duck_block_vocabulary.hpp` (type/encoding vocabulary + SPEC_VERSION),
+  `duck_block_conformance.sql` (`duck_blocks_validate()` and friends — pure SQL,
+  requires no extension loaded).
+
+sitting_duck's `ast_to_blocks` emits duck_blocks conforming to this version; the
+conformance test in `test/sql/duck_blocks_conformance.test` runs the validator here
+over real `ast_to_blocks` output so producer/spec drift is caught (see tracker/bugs/014).

--- a/third_party/duck_block_utils/duck_block_conformance.sql
+++ b/third_party/duck_block_utils/duck_block_conformance.sql
@@ -1,0 +1,256 @@
+-- duck_block conformance checks, PURE SQL -- no duck_block_utils required.
+--
+-- WHY THIS FILE EXISTS. duck_blocks_validate() ships inside an extension built for a
+-- specific DuckDB version, and DuckDB matches extension ABI by EXACT version string.
+-- An extension that vendors its own DuckDB submodule pinned off-release reports e.g.
+-- 'v1.5.5-dev154' and CANNOT LOAD duck_block_utils by any route -- not INSTALL, not
+-- LOAD '<path>', and publishing would not change it.
+--
+-- Raised by the webbed session, whose metadata blocks carried a NULL level for three
+-- major spec versions with nothing in a position to object: the check that would have
+-- caught it was one they structurally could not run. If markdown and panduck vendor
+-- duckdb too, none of the three consuming extensions could run the validator, which
+-- explains a great deal about how long these defects survived.
+--
+-- So conformance for that class of consumer has to be SHAPE-BASED, not
+-- extension-based. Copy this file; it needs nothing but DuckDB.
+--
+-- It is kept honest by test/check_conformance_macro.py, which runs both these macros
+-- and the real duck_blocks_validate() over the same corpus and FAILS if they disagree.
+-- Two copies of one rule checked by the same party cannot detect their own
+-- disagreement -- this repo shipped exactly that defect in an image's alt text -- so
+-- the two implementations are compared rather than merely both maintained.
+
+-- WHAT THIS BUYS YOU, from the panduck session and sharper than the framing above:
+-- the value is not "the same checks without a dependency". It is TWO CHECKS YOU COULD
+-- NOT HAVE HAD AT ALL. Duplicate element_order and level-jumping-by-more-than-one are
+-- inexpressible in a per-element macro, and the second is the rule whose absence caused
+-- a year of drift across four extensions -- so every consumer who copied the
+-- per-element macro this spec published until 2026-09-01 was unguarded against
+-- precisely the defect most likely to bite them.
+
+-- USAGE, and read this before the first call fails.
+--
+--   SELECT duck_blocks_are_valid(<a LIST(duck_block) expression>);
+--
+-- If your producer is a TABLE function, DuckDB rejects passing it inline:
+--
+--   SELECT duck_blocks_are_valid(my_reader('doc.epub'));
+--     -> Binder Error: Table function cannot contain subqueries
+--
+-- Materialise it first:
+--
+--   CREATE TEMP TABLE b AS SELECT my_reader('doc.epub') AS blk;
+--   SELECT duck_blocks_are_valid(blk) FROM b;
+--
+-- MATERIALISE FIRST, ALWAYS. Do not try to work out whether your producer is exempt.
+--
+-- This file said "a scalar producer passes inline fine; the restriction is specific to
+-- table functions". That was measured -- and measured on THIS repo's producers, which
+-- are the ones that happen to work. panduck's producer is also scalar and does NOT
+-- work, because what trips the binder is what the producer EXPANDS TO once inlined
+-- into a subquery position, not the kind it is declared as. panduck's dispatch runs
+-- through `query()`, which rejects a subquery in its argument including one that
+-- arrives by macro inlining.
+--
+-- So the exemption is not knowable from here: it depends on an implementation this
+-- file cannot see. An accurate-sounding exemption is worse than none, because it
+-- invites exactly the inline call that fails, with an error naming subqueries the
+-- caller never wrote.
+--
+-- Reported twice by the panduck session: once as the restriction, once to correct the
+-- exemption I wrote in response to it.
+--
+-- The macros are `duck_block_is_valid` (one element) and `duck_blocks_are_valid` (a
+-- document). The FILE name is not a macro name -- also panduck, who grepped for it.
+
+-- Per-element shape. Covers 4 of the 6 things duck_blocks_validate reports.
+-- Declared `kind` values. A LITERAL here until 2026-09-01, which is how the version of
+-- this check published in the spec came to enumerate two kinds when three exist -- the
+-- instruction that leaves a producer with nowhere to put a document's title. It is a
+-- macro now for the same reason the type list is: check_conformance_macro.py compares
+-- it against duck_block_kind_names() and FAILS on drift, so the copy cannot rot.
+--
+-- Kinds and element types are DIFFERENT AXES and both are needed. duckdb_markdown
+-- reported a false positive from comparing the type list against the kind names; the
+-- file offered only one of the two, so the mistake was available to make.
+CREATE OR REPLACE MACRO duck_block_declared_kinds() AS (['block', 'inline', 'value']);
+
+-- Declared `encoding` values. Also a literal until 2026-09-01, and also compared
+-- against the build by check_conformance_macro.py -- this list was hardcoded in FOUR
+-- places across the repo, so adding `toml` was a five-file change with four copies
+-- nothing checked.
+CREATE OR REPLACE MACRO duck_block_declared_encodings() AS (
+    ['text', 'json', 'yaml', 'html', 'xml', 'latex', 'markdown', 'toml']
+);
+
+CREATE OR REPLACE MACRO duck_block_is_valid(elem) AS (
+    list_contains(duck_block_declared_kinds(), elem.kind)
+    AND elem.element_type IS NOT NULL
+    AND list_contains(duck_block_declared_encodings(), elem.encoding)
+    AND elem.level IS NOT NULL
+    AND elem.level >= 1
+    AND elem.element_order IS NOT NULL
+    AND elem.element_order >= 0
+);
+
+-- Declared element_type names, for the check the EXTENSION does and this file could
+-- not. An element_type outside the vocabulary was invisible to everything until
+-- 2026-09-01: `duck_blocks_validate` accepted any string. duckdb_markdown emits
+-- `frontmatter` where the vocabulary declares `metadata` and nothing objected.
+--
+-- This list is a COPY of duck_block_type_names(), which is the kind of thing that
+-- drifts. test/check_conformance_macro.py compares the two on every `make check` and
+-- FAILS if they differ, so it is a copy that cannot rot silently -- the same reason the
+-- macros above are compared against the real validator rather than merely maintained.
+--
+-- Kept SEPARATE from duck_blocks_are_valid deliberately: an unknown type is a LINT, not
+-- an invalidity. A consumer built against an older vocabulary must still read data from
+-- a newer producer, so a name you do not recognise is reported, not refused. Rejecting
+-- it would make every additive spec release break every consumer who had not upgraded.
+CREATE OR REPLACE MACRO duck_block_declared_types() AS (
+    [
+        'blockquote', 'blocks', 'bold', 'bool', 'caption', 'cite', 'code', 'deflist',
+        'div', 'figure', 'generic', 'heading', 'hr', 'image', 'inlines', 'italic',
+        'lineblock', 'linebreak', 'link', 'list', 'list_item', 'map', 'math', 'metadata',
+        'note', 'page_break', 'paragraph', 'plain', 'quoted', 'raw', 'section',
+        'smallcaps', 'softbreak', 'space', 'span', 'strikethrough', 'string', 'subscript',
+        'superscript', 'table', 'text', 'underline', 'version'
+    ]
+);
+
+-- Which elements carry a type this vocabulary does not declare. Empty is conforming;
+-- anything listed should probably be `generic` with the original name kept in
+-- attributes['source_type'], so it reads as a gap rather than a private invention.
+CREATE OR REPLACE MACRO duck_blocks_undeclared_types(blocks) AS (
+    -- coalesce, because an aggregate over ZERO rows returns NULL, and a conforming
+    -- document has zero rows here. NULL is the one answer this must never give: it
+    -- reads as "could not tell" and as "none" equally, which is the ambiguity every
+    -- check in this file exists to remove. Caught by running it, not by writing it.
+    coalesce(
+        (SELECT list_sort(list_distinct(list(e.element_type)))
+         FROM unnest(blocks) AS t(e)
+         WHERE NOT list_contains(duck_block_declared_types(), e.element_type)),
+        []::VARCHAR[]
+    )
+);
+
+-- ERRORS WITH DETAIL, not just a verdict. Requested by Teague after panduck hit the
+-- gap immediately: `duck_blocks_are_valid` tells you a fixture broke and nothing about
+-- WHERE, so they were bisecting a twelve-fixture gate by hand. This returns the same
+-- {element_order, field, message} rows the extension's `duck_blocks_validate` does,
+-- and check_conformance_macro.py compares the two so they cannot drift apart.
+--
+-- A boolean is the right thing for a gate and the wrong thing for a FAILING gate.
+CREATE OR REPLACE MACRO duck_blocks_errors(blocks) AS TABLE (
+    WITH e AS (SELECT unnest(blocks) AS el, generate_subscripts(blocks, 1) AS pos),
+    lv AS (SELECT el, pos, el.level AS lvl, lag(el.level) OVER (ORDER BY pos) AS prev FROM e),
+    dup AS (SELECT el.element_order AS ord FROM e GROUP BY 1 HAVING count(*) > 1)
+    SELECT el.element_order AS element_order, 'kind' AS field,
+           'Invalid kind ' || chr(39) || coalesce(el.kind, 'NULL') || chr(39)
+             || '; see duck_block_kind_names()' AS message
+      FROM e WHERE NOT list_contains(duck_block_declared_kinds(), el.kind)
+    UNION ALL
+    SELECT el.element_order, 'element_type', 'element_type is NULL'
+      FROM e WHERE el.element_type IS NULL
+    UNION ALL
+    SELECT el.element_order, 'encoding',
+           'Invalid encoding ' || chr(39) || el.encoding || chr(39)
+      FROM e WHERE el.encoding IS NOT NULL
+        AND NOT list_contains(duck_block_declared_encodings(), el.encoding)
+    UNION ALL
+    SELECT el.element_order, 'level',
+           CASE WHEN el.level IS NULL
+                THEN 'level is NULL; every element carries an explicit depth, top level is 1'
+                ELSE 'level ' || el.level || ' is below 1; top level is 1' END
+      FROM e WHERE el.level IS NULL OR el.level < 1
+    UNION ALL
+    SELECT el.element_order, 'level',
+           'level jumps from ' || prev || ' to ' || lvl
+             || '; depth-first ordering descends one at a time, so this element''s parent is missing'
+      FROM lv WHERE prev IS NOT NULL AND lvl > prev + 1
+    UNION ALL
+    SELECT el.element_order, 'element_order', 'element_order must be non-negative'
+      FROM e WHERE el.element_order IS NULL OR el.element_order < 0
+    UNION ALL
+    SELECT ord, 'element_order', 'Duplicate element_order value' FROM dup
+);
+
+-- ADVISORY WARNINGS. Legal shapes that are superseded, non-canonical, or lose
+-- information. Separate from duck_blocks_errors: none of these makes a document
+-- invalid, and a consumer must still read data that trips them.
+--
+-- Added because webbed asked whether "content iff a single text child" applies to
+-- `figure` as well as `list_item`. It does -- the rule is universal and the extension's
+-- normalizer and linter are both type-blind -- but the vendorable file had validity and
+-- no advisory rules, so a producer who cannot load the extension had NO INSTRUMENT
+-- EXPRESSING THE PREFERENCE. Two conformant producers could differ on the same document
+-- with nothing objecting, which is the divergence this vocabulary exists to remove.
+--
+-- Compared against the extension's duck_blocks_lint() by test/check_conformance_macro.py.
+CREATE OR REPLACE MACRO duck_blocks_warnings(blocks) AS TABLE (
+    WITH e AS (SELECT unnest(blocks) AS el, generate_subscripts(blocks, 1) AS pos),
+    nxt AS (
+        SELECT el, pos,
+               lead(el) OVER (ORDER BY pos) AS nx,
+               lag(el)  OVER (ORDER BY pos) AS pv
+        FROM e
+    )
+    -- A `plain` that is the only child of a content-empty container. Its text belongs
+    -- in that container's own `content`. UNIVERSAL: figure, section, div, blockquote,
+    -- caption and list_item alike -- decided by what sits BESIDE the run, never by
+    -- which element_type is above it.
+    SELECT el.element_order AS element_order, 'plain_should_be_content' AS rule,
+           'plain is the only child of ' || pv.element_type ||
+           '; its text belongs in that element''s content' AS message
+    FROM nxt
+    WHERE el.element_type = 'plain' AND el.kind = 'block'
+      AND pv IS NOT NULL AND pv.kind = 'block'
+      AND coalesce(pv.content, '') = '' AND pv.level = el.level - 1
+      AND (nx IS NULL OR nx.level < el.level OR nx.kind <> 'block')
+    UNION ALL
+    -- A table not in the native schema.
+    SELECT el.element_order, 'table_not_native',
+           'table content is not the native {headers,rows} schema'
+    FROM e WHERE el.element_type = 'table'
+      AND coalesce(el.content, '') <> '' AND position('"headers"' IN el.content) = 0
+    UNION ALL
+    SELECT el.element_order, 'deflist_superseded',
+           'deflist is superseded by list with list_type=''definition'''
+    FROM e WHERE el.element_type = 'deflist'
+    UNION ALL
+    SELECT el.element_order, 'heading_without_rank',
+           'heading without attributes[''heading_level'']: do NOT fall back to level'
+    FROM e WHERE el.element_type = 'heading'
+      AND coalesce(el.attributes['heading_level'], '') = ''
+    UNION ALL
+    SELECT el.element_order, 'undeclared_element_type',
+           'element_type ' || el.element_type || ' is not in the vocabulary'
+    FROM e WHERE NOT list_contains(duck_block_declared_types(), el.element_type)
+);
+
+-- Document shape. The other 2, and they are the ones a per-element check CANNOT see:
+--
+--   duplicate element_order  needs the whole list
+--   level jumping by >1      needs ADJACENCY. `level` is structural depth in a
+--                            depth-first ordering, so a document descends one at a
+--                            time; a jump means the element's parent is missing.
+--                            This is the rule whose absence caused a year of drift
+--                            across four extensions, and it is precisely the one a
+--                            per-element macro cannot express -- so a consumer given
+--                            only the element macro is unguarded against the defect
+--                            most likely to bite them.
+CREATE OR REPLACE MACRO duck_blocks_are_valid(blocks) AS (
+    -- every element individually
+    NOT EXISTS (SELECT 1 FROM unnest(blocks) AS t(e) WHERE NOT duck_block_is_valid(e))
+    -- element_order unique
+    AND (SELECT count(DISTINCT e.element_order) = count(*) FROM unnest(blocks) AS t(e))
+    -- depth-first ordering descends one level at a time
+    AND NOT EXISTS (
+        SELECT 1 FROM (
+            SELECT e.level AS lvl,
+                   lag(e.level) OVER (ORDER BY i) AS prev
+            FROM unnest(blocks) WITH ORDINALITY AS t(e, i)
+        ) WHERE prev IS NOT NULL AND lvl > prev + 1
+    )
+);

--- a/third_party/duck_block_utils/duck_block_vocabulary.hpp
+++ b/third_party/duck_block_utils/duck_block_vocabulary.hpp
@@ -1,0 +1,479 @@
+#pragma once
+
+// ============================================================================
+// The duck_block vocabulary -- PUBLISHED INTERFACE.
+//
+// Header-only and link-free ON PURPOSE. Sibling extensions (panduck, webbed,
+// duckdb_markdown, sitting_duck) consume this by VENDORING a copy -- see
+// "VENDORING THIS FILE" below for why a copy beats a submodule here, and for
+// the drift check that has to come with it.
+//
+// Nothing here has a definition in a .cpp, so including it costs no linking.
+// The type constructors and Register() live in block_types.hpp, which needs
+// block_types.cpp -- do NOT move them here, or consumers get link errors for
+// functions they never called.
+//
+// Changes to these names are BREAKING for every consumer. Bump SPEC_VERSION
+// and say so. Consumers should assert agreement at test time rather than
+// trusting that their copy is current:
+//
+//     SELECT duck_block_kind_names();        -- ['block', 'inline', 'value']
+//     SELECT duck_block_type_names();        -- every element_type name
+//     SELECT duck_block_spec_version();
+//
+// See docs/duck_blocks_spec.md for what each name means.
+//
+// ---------------------------------------------------------------------------
+// VENDORING THIS FILE
+//
+// WHAT ELSE IS VENDORABLE, and where. `vendor/README.md` upstream is the index; this
+// header is the one vendorable file that does NOT live there, because four extensions
+// already pull it from `src/include/` and moving it to buy tidiness would break their
+// tooling for no gain. The others:
+//
+//     vendor/duck_block_conformance.sql   validity, error detail, declared kind /
+//                                         type / encoding lists -- pure DuckDB SQL
+//     vendor/duck_block_normalize.hpp     the content rule as a transform
+//
+// PATHS MOVE. `duck_block_conformance.sql` lived at `conformance/` until 2026-09-01.
+// A consumer re-syncing by URL got a 404 -- and duckdb_markdown pointed out how that
+// fails: `curl -sS -o file URL` writes GitHub's 404 page INTO the vendored file, and
+// `curl -sSf` leaves the stale copy in place while the consumer believes they
+// re-synced. Either way they keep validating against an old vocabulary and nothing
+// says so.
+//
+// So CHECK THE HTTP STATUS and fail loudly on anything but 200, the same way you
+// would refuse to print OK from an undatable fetch (below). A vendored file that
+// silently did not update is the failure this whole block exists to prevent.
+//
+// Copy it. Do NOT add duck_block_utils as a submodule: the DuckDB extension CI
+// templates check out with submodules: 'recursive' and this repo carries its
+// own duckdb submodule, so a pin drags a ~290 MB nested DuckDB clone into your
+// CI to deliver 12 KB. This file needs none of it -- <cstdint> only.
+//
+// A submodule pin is ALSO a copy. It sits at whatever sha you checked out and
+// never tracks main, so it goes stale exactly as a vendored file does -- and it
+// never complains, whereas a check does. It is additionally bounded by the
+// upstream PUSH cadence, not the commit cadence: an unpushed commit cannot be
+// pinned at all.
+//
+// So vendor, and add a drift check that actually runs. Note first WHY a check
+// is not optional: these constants protect against a RENAME, not against a
+// changed VALUE.
+//
+//     TYPE_PAGE = "page_break"   ->   TYPE_PAGE = "pagebreak"
+//
+// A rename is a compile error at every use site. That value change compiles
+// clean everywhere, and a consumer's writer silently stops matching the type.
+// Nothing in C++ catches it -- not a vendored copy, not a submodule pin. Only
+// a check does. (Found by the duckdb_markdown session, 2026-08-31.)
+//
+//   1. Record the provenance where a reader will find it -- in your copy's
+//      header comment, note the upstream sha and the SPEC_VERSION below.
+//
+//   2. Fail your build when a constant is renamed, removed, or CHANGES VALUE.
+//      Fetch upstream and compare BY NAME AND VALUE -- parse both sides, do
+//      not diff the text:
+//
+//      DO NOT fetch the /main/ raw url directly. raw.githubusercontent.com serves
+//      branch urls from a CDN that is only EVENTUALLY consistent with the branch,
+//      so a check running shortly after an upstream push compares against the
+//      PREVIOUS version, finds no difference, and reports a clean bill of health.
+//      That window is precisely when a drift check matters most, and the failure
+//      is in the reassuring direction, which is the direction nobody re-checks.
+//      (Found by duckdb_markdown, whose check reported "in sync" against a copy
+//      two spec versions old; it only surfaced because a human said otherwise.)
+//
+//      Resolve the branch to a commit sha first, then fetch the SHA-PINNED url,
+//      which is immutable and therefore cannot be stale:
+//
+//        https://api.github.com/repos/teaguesterling/duckdb_duck_block_utils/commits/main
+//        https://raw.githubusercontent.com/teaguesterling/
+//          duckdb_duck_block_utils/<sha>/src/include/duck_block_vocabulary.hpp
+//
+//      Print the sha alongside the verdict, so the output says what it actually
+//      compared against. And when the sha lookup fails -- rate limit, outage,
+//      offline -- falling back to the branch url is fine, but that path must NEVER
+//      print OK: "no drift seen" from a copy you could not date is not a clean
+//      bill of health, and reporting it as one is the same defect again.
+//
+//      A plain `diff` over this file fires on comment edits and cosmetic churn
+//      -- commit 3957f36 rewrote every idx_t to uint64_t and changed no name
+//      and no value. A check that cries wolf gets muted, and a muted check
+//      catches nothing. Silence on cosmetic change is what keeps it credible.
+//
+//      Worth reporting separately rather than as one pass/fail: DRIFT (renamed,
+//      removed, or value changed) should fail; NEW (published here, absent from
+//      your copy) and GAPS (published, but nothing in your code branches on it)
+//      should report without failing. GAPS is the arm that earns its keep -- it
+//      is what surfaced inline `generic` losing source_type in two extensions
+//      in the same week. Carry an explicit allowlist of intentional gaps, or an
+//      unexplained one and a deliberate one look identical. Filter NUMERIC-valued
+//      constants out when selecting the vocabulary by name prefix -- otherwise
+//      KIND_IDX and the other struct field offsets get reported as published-but-
+//      unhandled types, and a check whose first run on a new consumer is a false
+//      positive has already taught that consumer to ignore it. (panduck hit exactly
+//      this while adopting the arm from this recommendation.)
+//
+//      duckdb_markdown has a working implementation of exactly this, which
+//      looks in both a vendored and a submodule location:
+//      scripts/check_duck_block_vocabulary.py (`make check-vocabulary`).
+//
+//   3. Assert the RUNTIME vocabulary too, which no file comparison can see --
+//      the installed extension may be older than any header:
+//
+//        SELECT duck_block_type_names();   -- every element_type
+//        SELECT duck_block_kind_names();   -- ['block','inline','value']
+//        SELECT duck_block_spec_version(); -- major equality + minor floor;
+//                                          see SPEC_VERSION below for why not
+//                                          plain equality
+//
+// (2) catches a stale copy; (3) catches a stale INSTALL. They fail differently
+// and neither subsumes the other.
+// ---------------------------------------------------------------------------
+// ============================================================================
+
+// <cstdint> ONLY. This header deliberately pulls in nothing from DuckDB.
+//
+// It used to include duckdb/common/types.hpp for idx_t, which is `typedef
+// uint64_t idx_t` -- so the include bought nothing but a dependency. And it was
+// an expensive one: it made this file unusable as a standalone copy, forcing
+// consumers toward a submodule -- and the DuckDB extension CI templates check
+// out with submodules: 'recursive' while this repo carries its own duckdb
+// submodule. That meant a 290 MB nested DuckDB clone in every consumer's CI to
+// deliver a 12 KB header.
+//
+// Field indices are uint64_t, which is type-identical to idx_t.
+#include <cstdint>
+
+namespace duckdb {
+
+struct DuckBlockVocabulary {
+	// Field indices for duck_block struct
+	static constexpr uint64_t KIND_IDX = 0;
+	static constexpr uint64_t ELEMENT_TYPE_IDX = 1;
+	static constexpr uint64_t CONTENT_IDX = 2;
+	static constexpr uint64_t LEVEL_IDX = 3;
+	static constexpr uint64_t ENCODING_IDX = 4;
+	static constexpr uint64_t ATTRIBUTES_IDX = 5;
+	static constexpr uint64_t ELEMENT_ORDER_IDX = 6;
+
+	// Additional field indices for duck_block_ext
+	static constexpr uint64_t SOURCE_FORMAT_IDX = 7;
+	static constexpr uint64_t FILE_PATH_IDX = 8;
+
+	// Kind values
+	static constexpr const char *KIND_BLOCK = "block";
+	static constexpr const char *KIND_INLINE = "inline";
+	// Non-prose data attached to a document -- currently its metadata. Consumers that
+	// walk document content filter on KIND_BLOCK and ignore these automatically, which
+	// is what makes the kind additive rather than breaking.
+	static constexpr const char *KIND_VALUE = "value";
+
+	// ========================================================================
+	// Value type names (kind = 'value')
+	// ========================================================================
+	// Model Pandoc's recursive MetaValue tree. `list` and `map` nest their children
+	// via `level`, exactly as `div` and `figure` do; `inlines` and `blocks` carry
+	// ordinary kind='inline'/'block' children. The map key, where there is one, is in
+	// attributes['key'].
+	static constexpr const char *VALUE_STRING = "string";
+	static constexpr const char *VALUE_BOOL = "bool";
+	static constexpr const char *VALUE_LIST = "list";
+	static constexpr const char *VALUE_MAP = "map";
+	static constexpr const char *VALUE_INLINES = "inlines";
+	static constexpr const char *VALUE_BLOCKS = "blocks";
+	// Stream metadata, not document metadata: records which duck_block spec a
+	// persisted or exchanged block list was written against. Carries no
+	// attributes['key'], which is what keeps it out of a document's Pandoc `meta`.
+	static constexpr const char *VALUE_VERSION = "version";
+
+	// The duck_block spec version this build implements, as MAJOR.MINOR.
+	//
+	//   MAJOR bumps for a BREAKING change -- a shape or vocabulary change that a
+	//         conforming consumer must migrate for.
+	//   MINOR bumps for an ADDITIVE one -- new types or attributes that existing
+	//         consumers can ignore.
+	//
+	// ASSERT MAJOR EQUALITY AND A MINOR FLOOR, not equality on the whole string.
+	// Equality goes red on every release including ones that cannot affect you,
+	// and a check that cries wolf gets muted:
+	//
+	//     major(duck_block_spec_version()) == 2   AND   minor(...) >= <what you need>
+	//
+	// (Asked by panduck, who noticed the guidance said "compare against
+	// SPEC_VERSION" without saying compare HOW, and whose readers are untouched by
+	// 2.0 apart from lists.)
+	//
+	// HONEST HISTORY, because the numbers only mean something if they were applied
+	// consistently and one of these was not:
+	//
+	//   1.1 -> 1.2  list and blockquote became structural. BREAKING -- it broke
+	//               duckdb_markdown's writer in three places. It should have been
+	//               2.0 and the minor bump was wrong. A consumer pinning "major 1"
+	//               would have been broken by a release the numbering promised was
+	//               safe.
+	//   1.2 -> 2.0  one shape per BLOCK element_type. Breaking, numbered correctly.
+	//   2.0 -> 3.0  every element carries an EXPLICIT level; no NULLs, one scale for
+	//               blocks and inlines, and `level` is never semantic. Breaking.
+	//               The NULL-at-top-level convention 1.x and 2.0 documented was
+	//               never approved -- see docs/duck_blocks_spec.md.
+	//   3.0 -> 4.0  `plain` added: Pandoc's Plain constructor, which this reader had
+	//               been collapsing onto `paragraph`, losing the tight vs loose list
+	//               distinction. BREAKING by this contract's own rule -- a consumer
+	//               rendering `paragraph` now receives `plain` for a tight list item
+	//               -- so a MAJOR bump even though the vocabulary change is additive.
+	//               Also makes `list_type` canonical, `ordered` a legacy alias.
+	//   4.0 -> 5.0  `table` emits the NATIVE {headers,rows} schema, with the full
+	//               Pandoc tuple preserved in attributes['pandoc_ast'] so nothing is
+	//               lost; definition lists become `list` with list_type='definition'
+	//               rather than the opaque `deflist`. Both previously serialised
+	//               structure into a field consumers read verbatim: tables rendered
+	//               as NOTHING and deflists rendered their own AST, and both poisoned
+	//               search. Breaking -- a consumer parsing either JSON must migrate.
+	//
+	//   5.0 -> 6.0  `plain` is NARROWED to text that has nowhere else to live. A
+	//               container whose only child is a text run carries that text in its
+	//               own `content` -- v1's content rule, unchanged since v1.0 -- so
+	//               `<li>text</li>` is `list_item(content='text')`, not
+	//               `list_item > plain('text')`. 5.0 shipped the second, which meant a
+	//               container with a single text child had TWO legal shapes depending
+	//               on which producer built it, and removing that ambiguity is the
+	//               thing every version since 2.0 has been for.
+	//
+	//               `plain` still exists and is still required, in exactly two places:
+	//                 * beside block siblings -- `section > plain('Lead') + heading`,
+	//                   where the container's content cannot hold the run because the
+	//                   run is not the only child;
+	//                 * at the TOP LEVEL, where the document root has no content field.
+	//
+	//               Tight-vs-loose list items are NOT lost by this and need no
+	//               attribute: content on the item is Pandoc's `Plain` (tight), a
+	//               `paragraph` child is `Para` (loose). Measured on the exporter
+	//               before the change, not assumed.
+	//
+	//               Breaking for a consumer that walks for a `plain` child; a consumer
+	//               that already read the container's `content` -- which the rule has
+	//               required since v1 -- needs no change.
+	//
+	//   6.0 -> 6.1  ADDITIVE. `duck_blocks_normalize(blocks)` applies 6.0's content
+	//               rule to a finished block vector, so a producer can emit the naive
+	//               shape and fix it up afterwards instead of implementing the rule.
+	//
+	//               Needed because the rule is SIBLING-DEPENDENT: whether a text run
+	//               becomes its container's content or stays a `plain` depends on what
+	//               FOLLOWS it, which a streaming reader does not know when it reaches
+	//               the run. Raised by the panduck session, whose EPUB and LaTeX
+	//               readers both emit as they walk; it is true of any streaming reader
+	//               of any format, so the answer should not be four private lookaheads
+	//               that drift. Nothing is removed or renamed -- a consumer on 6.0 is
+	//               unaffected.
+	//
+	//   6.1 -> 6.2  ADDITIVE, three clarifications that were load-bearing and unstated.
+	//               `metadata` gains attributes['role'], with 'frontmatter' declared --
+	//               one type plus a role rather than minting `frontmatter` as its own
+	//               element_type, which is this vocabulary's own rule applied to a case
+	//               three producers had each guessed differently.
+	//
+	//               Value elements after the blocks is now a CONTRACT, not the
+	//               "convenience" the spec called it: two producers asked where they go,
+	//               which is a question a convenience cannot answer. With it, the rule
+	//               that a consumer must end an inline run at any NON-INLINE element --
+	//               getting that wrong made this repo's exporter emit a document whose
+	//               body had been replaced by its title.
+	//
+	//               A document with NO blocks -- a .toml file read as pure metadata --
+	//               is conformant, and stated rather than left to be inferred from
+	//               nothing objecting.
+	//
+	//               Nothing renamed, nothing removed; a consumer on 6.1 is unaffected.
+	//
+	// The rule above is what will be followed from here.
+	static constexpr const char *SPEC_VERSION = "6.2";
+
+	// ========================================================================
+	// Block type names
+	// ========================================================================
+	static constexpr const char *TYPE_HEADING = "heading";
+	static constexpr const char *TYPE_PARAGRAPH = "paragraph";
+	// A block-level text run with NO paragraph semantics -- Pandoc's `Plain`, and
+	// HTML text that is not wrapped in a <p>: `<li>text</li>`, `<td>text</td>`,
+	// `<dd>text</dd>`, `<figcaption>text</figcaption>`.
+	//
+	// This existed in Pandoc all along and this reader collapsed it onto
+	// `paragraph`, which is how the TIGHT vs LOOSE list distinction was being lost
+	// -- and lost independently in webbed, by a different mechanism, with neither
+	// reader aware. Modelling it as its own type rather than an attribute keeps the
+	// mapping honest: it is a constructor we were failing to represent, not a
+	// variation we were failing to annotate.
+	static constexpr const char *TYPE_PLAIN = "plain";
+	static constexpr const char *TYPE_CODE = "code";
+	static constexpr const char *TYPE_BLOCKQUOTE = "blockquote";
+	static constexpr const char *TYPE_LIST = "list";
+	static constexpr const char *TYPE_LIST_ITEM = "list_item";
+	static constexpr const char *TYPE_TABLE = "table";
+	static constexpr const char *TYPE_HR = "hr";
+	static constexpr const char *TYPE_METADATA = "metadata";
+	static constexpr const char *TYPE_IMAGE = "image";
+	static constexpr const char *TYPE_RAW = "raw";
+	static constexpr const char *TYPE_DIV = "div";
+	// A SEMANTIC sectioning container, distinct from `div`. HTML's own spec calls
+	// div "an element of last resort", so mapping <section>/<article>/<aside> onto
+	// it would make element_type say something false while the truth hid in an
+	// attribute. Which kind of section lives in attributes['role'] -- section,
+	// article, aside, nav, header, footer, main -- following the convention already
+	// set by heading+heading_level, list+list_type and quoted+quote_type rather
+	// than minting one type per variant.
+	// Pandoc has no Section constructor, so this exports as a Div whose class is
+	// the role; that is pandoc's nearest honest equivalent.
+	static constexpr const char *TYPE_SECTION = "section";
+	// A physical pagination boundary -- a MARKER, not a container. Like `hr` it
+	// carries no content and owns no children; element_order already groups
+	// "blocks between marker N and N+1", so a container would re-nest whole
+	// documents for nothing. The number lives in attributes['page_number'].
+	//
+	// Physical, NOT semantic: a table of contents and a section slicer must
+	// IGNORE pages, which is precisely what they cannot do when a reader fakes
+	// them as headings.
+	static constexpr const char *TYPE_PAGE = "page_break";
+	static constexpr const char *TYPE_LINEBLOCK = "lineblock";
+	static constexpr const char *TYPE_DEFLIST = "deflist";
+	static constexpr const char *TYPE_FIGURE = "figure";
+	// A caption belonging to the container that precedes it. Deliberately general
+	// rather than figure-specific: Pandoc's Table also carries a Caption, and can
+	// adopt this later without another vocabulary change.
+	static constexpr const char *TYPE_CAPTION = "caption";
+	// A structurally-valid element whose type is not in the standard vocabulary.
+	// Distinct from TYPE_RAW, which is literal content in a *named* format; this is a
+	// structured element we cannot name. Format-neutral on purpose: any reader
+	// (pandoc, html, sitting_duck) can use it. The originating type name is preserved
+	// in attributes['source_type']. Shares its string with INLINE_GENERIC; `kind`
+	// disambiguates, as it already does for code/image/raw.
+	static constexpr const char *TYPE_GENERIC = "generic";
+
+	// ========================================================================
+	// Inline type names
+	// ========================================================================
+	// Text and whitespace
+	static constexpr const char *INLINE_TEXT = "text";
+	static constexpr const char *INLINE_SPACE = "space";
+	static constexpr const char *INLINE_SOFTBREAK = "softbreak";
+	static constexpr const char *INLINE_LINEBREAK = "linebreak";
+
+	// Formatting (container types)
+	static constexpr const char *INLINE_BOLD = "bold";
+	static constexpr const char *INLINE_ITALIC = "italic";
+	static constexpr const char *INLINE_STRIKETHROUGH = "strikethrough";
+	static constexpr const char *INLINE_SUPERSCRIPT = "superscript";
+	static constexpr const char *INLINE_SUBSCRIPT = "subscript";
+	static constexpr const char *INLINE_SMALLCAPS = "smallcaps";
+	static constexpr const char *INLINE_UNDERLINE = "underline";
+
+	// Semantic
+	static constexpr const char *INLINE_CODE = "code";
+	static constexpr const char *INLINE_MATH = "math";
+	static constexpr const char *INLINE_LINK = "link";
+	static constexpr const char *INLINE_IMAGE = "image";
+	static constexpr const char *INLINE_QUOTED = "quoted";
+	static constexpr const char *INLINE_CITE = "cite";
+	static constexpr const char *INLINE_NOTE = "note";
+	static constexpr const char *INLINE_SPAN = "span";
+	static constexpr const char *INLINE_RAW = "raw";
+	// Inline counterpart of TYPE_GENERIC -- same string, distinguished by kind.
+	static constexpr const char *INLINE_GENERIC = "generic";
+
+	// ========================================================================
+	// Encoding values
+	// ========================================================================
+	static constexpr const char *ENCODING_TEXT = "text";
+	static constexpr const char *ENCODING_JSON = "json";
+	static constexpr const char *ENCODING_YAML = "yaml";
+	static constexpr const char *ENCODING_HTML = "html";
+	static constexpr const char *ENCODING_XML = "xml";
+	static constexpr const char *ENCODING_LATEX = "latex";
+	static constexpr const char *ENCODING_MARKDOWN = "markdown";
+	// TOML is a distinct syntax with no equivalent in the set above. Emitting a
+	// verbatim .toml blob as 'text' discards the one fact a consumer needs in order to
+	// parse it, which is the opposite of what a verbatim blob is for. Asked for by the
+	// panduck session rather than minted by them -- the behaviour the spec asks for.
+	static constexpr const char *ENCODING_TOML = "toml";
+
+	// ========================================================================
+	// Attribute NAMES
+	//
+	// These were bare string literals until 2026-09-01 -- `"role"` appeared in six
+	// places in this repo's own source and in every consumer's, and a drift check that
+	// compares CONSTANTS by name and value could see none of it. A misspelled `"roles"`
+	// produces an element that is valid, conformant, lint-clean and wrong.
+	//
+	// Raised by duckdb_markdown, and the argument is the one that decided
+	// `metadata`+role over minting a `frontmatter` type in the first place: if the ROLE
+	// carries the meaning, the role needs the enforcement the type has.
+	// ========================================================================
+	static constexpr const char *ATTR_ROLE = "role";
+	static constexpr const char *ATTR_KEY = "key";
+	static constexpr const char *ATTR_HEADING_LEVEL = "heading_level";
+	static constexpr const char *ATTR_LIST_TYPE = "list_type";
+	static constexpr const char *ATTR_SOURCE_TYPE = "source_type";
+	static constexpr const char *ATTR_PANDOC_AST = "pandoc_ast";
+
+	// ========================================================================
+	// Role values, per the type that carries them
+	// ========================================================================
+	// `metadata` -- which verbatim blob this is
+	static constexpr const char *ROLE_FRONTMATTER = "frontmatter"; // has a document body after it
+	static constexpr const char *ROLE_DOCUMENT = "document";       // the blob IS the whole document
+
+	// ========================================================================
+	// `list_type` values -- the attribute is ATTR_LIST_TYPE
+	//
+	// The KEY got a constant and the VALUES did not, which duckdb_markdown named as the
+	// shape that keeps recurring: "the key gets a constant, the value it is compared
+	// against does not." Their writer branches on `list_type == "definition"` to choose
+	// the definition-list rendering, so a value rename upstream turns every definition
+	// list into a bullet list, silently, with every check green.
+	//
+	// WHY `list_type` AND NOT THE OLDER `attributes['ordered']`. A boolean answers
+	// "ordered or not" and cannot answer "which KIND of list", so it had no way to say
+	// `definition` -- and definition lists arrived the same day the question was
+	// settled, needing zero new element_types because `list_type` could carry them.
+	// A `navlist`, or anything else with list semantics, lands the same way.
+	//
+	// That is the general rule and it is worth more than this instance: WHEN
+	// COLLAPSING TWO NAMES FOR ONE FACT, KEEP THE ONE THAT CAN STILL EXPRESS THE FACT
+	// WHEN IT GROWS. The v1-fidelity argument said keep `ordered`; it optimised for
+	// matching the past and never asked what the next value would need.
+	//
+	// `attributes['ordered']` = 'true'/'false' remains a LEGACY ALIAS. Producers may
+	// emit both -- this one does -- and CONSUMERS MUST TOLERATE IT, because data
+	// written before the rule exists and does not rewrite itself. Read `list_type`
+	// first and fall back.
+	//
+	// Recorded here rather than only in the spec because a consumer reading these
+	// constants is exactly the reader who needs it, and would otherwise not learn the
+	// alias exists at all. (duckeye's point: a reason like this belongs beside the
+	// constant, not only in the thread that produced it.)
+	// ========================================================================
+	static constexpr const char *LIST_TYPE_BULLET = "bullet";
+	static constexpr const char *LIST_TYPE_ORDERED = "ordered";
+	static constexpr const char *LIST_TYPE_DEFINITION = "definition";
+	// The legacy boolean. Declared so a consumer tolerating it names the attribute
+	// rather than spelling it, and so a drift check can see it at all.
+	static constexpr const char *ATTR_ORDERED_LEGACY = "ordered";
+
+	// `list_item` in a definition list
+	static constexpr const char *ROLE_TERM = "term";
+	static constexpr const char *ROLE_DEFINITION = "definition";
+
+	// `section` -- which sectioning construct
+	static constexpr const char *ROLE_SECTION = "section";
+	static constexpr const char *ROLE_ARTICLE = "article";
+	static constexpr const char *ROLE_ASIDE = "aside";
+	static constexpr const char *ROLE_NAV = "nav";
+	static constexpr const char *ROLE_HEADER = "header";
+	static constexpr const char *ROLE_FOOTER = "footer";
+	static constexpr const char *ROLE_MAIN = "main";
+	static constexpr const char *ROLE_PAGE = "page";
+};
+
+} // namespace duckdb

--- a/tracker/bugs/014-duck-blocks-level-nonconformance.md
+++ b/tracker/bugs/014-duck-blocks-level-nonconformance.md
@@ -1,0 +1,94 @@
+# 014 — ast_to_blocks emits `level` non-conformant with current duck_blocks spec
+
+**Status:** open — assessment only, no code change yet (kibitzer floor blocks src/test edits; needs Teague to widen `[floor] allow` or work in a permitted mode)
+**Found:** 2026-09-01, reviewing duck_block_utils `origin/main` @ SPEC_VERSION **6.2**
+**Our reader cites:** duck_blocks spec **v0.4.0** (`src/sql_macros/duck_blocks.sql:7`)
+
+## Summary
+
+`ast_to_blocks_from` / `ast_to_blocks` / `ast_to_blocks_list` emit a duck_block STRUCT
+that is conformant in **every field except `level`**. We set `level` per the old
+"NULL-at-top-level" convention, which the spec explicitly **reversed and calls "never
+approved"**.
+
+- metadata block → `level = 0`
+- heading / code / paragraph → `level = NULL`
+  (`src/sql_macros/duck_blocks.sql`, CTE projections feeding the block STRUCT at `:286-294`)
+
+Current spec (`duck_block_vocabulary.hpp` version history, 2.0→3.0):
+> *every element carries an EXPLICIT level; no NULLs, one scale for blocks and inlines,
+> and `level` is never semantic. The NULL-at-top-level convention 1.x and 2.0 documented
+> was never approved.*
+
+The conformance validator `duck_block_is_valid` asserts `elem.level >= 1`. Under it,
+**every block we emit fails** — `NULL >= 1` is NULL, `0 >= 1` is false. This is the same
+year-long, four-extension drift the 3.0+ spec exists to end; the v1-alignment review
+(2026-08-31) reaffirms `level ≥ 1` structural-depth as the *v1-faithful* reading, not a
+2.0 invention.
+
+## The fix (small, but it changes emitted output + tests)
+
+We emit a **flat** outline — `kind` is always `'block'`, nothing nests (agent-verified:
+no container children anywhere in the blocks path). So the correct structural depth for
+**every** block we emit is `level = 1`.
+
+- metadata: `0` → `1`
+- heading / code / paragraph: `NULL` → `1`
+- heading *rank* stays where it already correctly is: `attributes['heading_level']`
+  (string `'1'..'6'`) — do **not** move it into `level`.
+
+Then update `test/sql/duck_blocks.test`, which currently *enshrines the old rule* — it
+asserts `block.level IS NULL` for headings (`:37-45`). That assertion must flip to
+`level = 1`. (The test was written against the same v0.4.0 the producer claims, so it
+cannot independently catch this drift — see "Vendoring" below.)
+
+### Implementation traps
+- `src/include/embedded_sql_macros.hpp` is **build-generated** and carries the same
+  macros (~line 4664). The CI job "Embedded SQL macros header in sync" fails if you edit
+  `duck_blocks.sql` without regenerating it.
+- **kibitzer floor**: `src/sql_macros/duck_blocks.sql` and `test/sql/duck_blocks.test` are
+  outside the `tracker/**` allow-list. The code fix needs `[floor] allow` widened first.
+
+## Everything else already conforms (verified against 6.2)
+
+| field | we emit | 6.2 | verdict |
+|---|---|---|---|
+| STRUCT shape | `kind, element_type, content, level, encoding, attributes, element_order` | same 7 fields | ✅ |
+| `kind` | `'block'` | block/inline/value | ✅ |
+| `element_type` | metadata, heading, code, paragraph | all recognized (`TYPE_METADATA`, `TYPE_HEADING`, `TYPE_PARAGRAPH`, `TYPE_CODE`) | ✅ |
+| `encoding` | `yaml`, `text` | both legal (`ENCODING_YAML`, `ENCODING_TEXT`) | ✅ |
+| `heading_level` | string `'1'..'6'` in attributes | matches | ✅ |
+| `element_order` | 0-based, per-file order | matches | ✅ |
+| content rule | leaf blocks carry content, no container children | universal rule (content XOR children) trivially satisfied | ✅ |
+| **`level`** | **NULL / 0** | **must be ≥ 1** | ❌ **this bug** |
+
+The pandoc-only additions (figure, caption, deflist, lineblock, underline, plain) are
+**not our concern** — we read source code, not documents.
+
+## Why this matters concretely (not a hypothetical consumer)
+
+The duck_block_utils reader-dispatch design (`docs/superpowers/specs/2026-08-31-pandoc-gaps-and-reader-dispatch-design.md`)
+names us a first-class reader:
+- sitting_duck is the **fallback reader** for extensions no document/data reader claims
+  (`.py .rs .go .css` …); it is **never** chosen for `.md/.html/.json/.toml` (native
+  readers win), reachable for those only via `format := 'code'`. Dispatch is *derived*
+  from `ast_supported_languages()` — which we already expose
+  (`src/ast_supported_languages_function.cpp:82`) — so **no dispatch change is needed on
+  our side**; that ownership moves to panduck.
+- The design's `doc_select` exception states **"`ast_to_blocks_from` remains the only path
+  producing blocks from a selection."** i.e. the library asserts a hard dependency on our
+  reader's output shape *by name*. Our `level` non-conformance is therefore a real
+  cross-extension defect, not a latent one.
+
+## Recommendation — split settled from churning
+
+1. **Fix `level` now.** Stable since spec 3.0, reaffirmed v1-faithful, won't churn back.
+   TDD: flip the `duck_blocks.test` level assertions first, then the projections, then
+   regenerate `embedded_sql_macros.hpp`, then full suite.
+2. **Vendoring — Teague's call, defer.** The right long-term move is to vendor
+   `duck_block_vocabulary.hpp` + `vendor/duck_block_conformance.sql` and add a test that
+   runs `duck_blocks_validate()` over our output, so producer and tests stop citing the
+   same private version and drift gets caught. But SPEC_VERSION went 3.0→4.0→6.0→6.2 in
+   ~24h and 6.2 is a day old on an unreleased branch — pinning to a fast-moving version is
+   a deliberate decision, not a default. (This is tracker item #22.)
+3. Bump the `v0.4.0` citation comment to whatever version we vendor/target.


### PR DESCRIPTION
## Why

`ast_to_blocks` emitted `level = NULL` for heading/code/paragraph and `0` for the metadata block — the old "NULL-at-top-level" convention that duck_block_utils **SPEC_VERSION 3.0 explicitly reversed and calls "never approved"**. Under the current validator (`duck_block_is_valid`: `level >= 1`), **every block we emitted was non-conformant**. This is not hypothetical: the reader-dispatch design names us a first-class reader — *"`ast_to_blocks_from` remains the only path producing blocks from a selection."*

Reviewed against duck_block_utils `origin/main` @ SPEC_VERSION **6.2**; our reader cited **v0.4.0**. `level` was the **only** non-conformance — the 7-field STRUCT, `kind='block'`, element types (`metadata/heading/code/paragraph` all recognized), encodings (`yaml`/`text` both legal), `heading_level` string attribute, and 0-based `element_order` were already correct.

## Fix

Our outline is **flat** — headings are leaf blocks, not `section`/`div` containers — so every emitted block is a top-level sibling at **`level = 1`**. Heading rank stays in `attributes['heading_level']` (string). No schema change.

## Vendoring + drift guard

- Vendored duck_block_utils **SPEC 6.2** into `third_party/duck_block_utils/` (vocabulary header + conformance SQL + `PROVENANCE.md` @ upstream `3bd7ff8`).
- New `test/sql/duck_blocks_conformance.test` runs the vendored validator over real `ast_to_blocks` output across styles/languages — the existing tests couldn't catch this drift because producer and tests both cited the same private v0.4.0.

## Verification

Regenerated `embedded_sql_macros.hpp` (the "header in sync" CI gate). TDD: confirmed the conformance test failed on the old output (11 invalid blocks), then passed after the fix. **Full suite green: 13118 assertions / 236 cases** on a freshly built binary.

Not addressed (noted in `tracker/bugs/014`): emitting `section` containers to represent code hierarchy is a future enhancement, not a conformance requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)