### PR TITLE
compat: build against DuckDB v2.0 (main) as well as the pinned v1.5

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -117,10 +117,19 @@ jobs:
       - name: Run the test suite with the runtime-grammar tests enabled
         run: SITTING_DUCK_TEST_GRAMMAR_DIR=build/test_grammars make test
 
+  # Canary: builds AND tests against DuckDB main (the v2.0 line), which is what
+  # duckdb/community-extensions' `test_against_latest` runs on every release PR.
+  # Gated rather than disabled, so a port can drive it on demand:
+  #   gh workflow run MainDistributionPipeline.yml --ref <branch>
+  # It must not run on pull_request: a push and a PR both fire on the same commit
+  # and a PR's check rollup includes both, so an ungated canary shows red on every
+  # PR. Use `if:` and not `continue-on-error:` -- a job calling a reusable workflow
+  # accepts only a fixed key set, and `continue-on-error` makes the whole workflow
+  # fail to parse, scheduling zero jobs.
   duckdb-next-build:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
-    if: false
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     with:
       duckdb_version: main
       ci_tools_version: main

--- a/src/ast_helper_functions.cpp
+++ b/src/ast_helper_functions.cpp
@@ -99,7 +99,7 @@ void ASTFunctionsFunction::Execute(ClientContext &context, TableFunctionInput &d
 	auto param_count_data = CompatFlatDataMutable<int32_t>(output.data[3]);
 	auto is_method_data = CompatFlatDataMutable<bool>(output.data[4]);
 	auto parent_class_data = CompatFlatDataMutable<string_t>(output.data[5]);
-	auto &parent_class_validity = FlatVector::Validity(output.data[5]);
+	auto &parent_class_validity = CompatFlatValidityMutable<>(output.data[5]);
 
 	while (data.current_idx < data.nodes.size() && count < STANDARD_VECTOR_SIZE) {
 		const auto &func_node = data.nodes[data.current_idx];
@@ -254,7 +254,7 @@ void ASTImportsFunction::Execute(ClientContext &context, TableFunctionInput &dat
 	auto alias_data = CompatFlatDataMutable<string_t>(output.data[2]);
 	auto line_data = CompatFlatDataMutable<int32_t>(output.data[3]);
 	auto is_from_data = CompatFlatDataMutable<bool>(output.data[4]);
-	auto &alias_validity = FlatVector::Validity(output.data[2]);
+	auto &alias_validity = CompatFlatValidityMutable<>(output.data[2]);
 
 	while (data.current_idx < data.nodes.size() && count < STANDARD_VECTOR_SIZE) {
 		const auto &import_node = data.nodes[data.current_idx];

--- a/src/ast_helper_functions.cpp
+++ b/src/ast_helper_functions.cpp
@@ -61,7 +61,7 @@ TableFunction ASTFunctionsFunction::GetFunction() {
 }
 
 unique_ptr<FunctionData> ASTFunctionsFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
-                                                    vector<LogicalType> &return_types, vector<string> &names) {
+                                                    vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs.size() != 1) {
 		throw BinderException("ast_functions requires exactly 1 argument: ast");
 	}
@@ -93,12 +93,12 @@ void ASTFunctionsFunction::Execute(ClientContext &context, TableFunctionInput &d
 	}
 
 	idx_t count = 0;
-	auto name_data = FlatVector::GetData<string_t>(output.data[0]);
-	auto start_line_data = FlatVector::GetData<int32_t>(output.data[1]);
-	auto end_line_data = FlatVector::GetData<int32_t>(output.data[2]);
-	auto param_count_data = FlatVector::GetData<int32_t>(output.data[3]);
-	auto is_method_data = FlatVector::GetData<bool>(output.data[4]);
-	auto parent_class_data = FlatVector::GetData<string_t>(output.data[5]);
+	auto name_data = CompatFlatDataMutable<string_t>(output.data[0]);
+	auto start_line_data = CompatFlatDataMutable<int32_t>(output.data[1]);
+	auto end_line_data = CompatFlatDataMutable<int32_t>(output.data[2]);
+	auto param_count_data = CompatFlatDataMutable<int32_t>(output.data[3]);
+	auto is_method_data = CompatFlatDataMutable<bool>(output.data[4]);
+	auto parent_class_data = CompatFlatDataMutable<string_t>(output.data[5]);
 	auto &parent_class_validity = FlatVector::Validity(output.data[5]);
 
 	while (data.current_idx < data.nodes.size() && count < STANDARD_VECTOR_SIZE) {
@@ -145,7 +145,7 @@ TableFunction ASTClassesFunction::GetFunction() {
 }
 
 unique_ptr<FunctionData> ASTClassesFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
-                                                  vector<LogicalType> &return_types, vector<string> &names) {
+                                                  vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs.size() != 1) {
 		throw BinderException("ast_classes requires exactly 1 argument: ast");
 	}
@@ -174,10 +174,10 @@ void ASTClassesFunction::Execute(ClientContext &context, TableFunctionInput &dat
 	}
 
 	idx_t count = 0;
-	auto name_data = FlatVector::GetData<string_t>(output.data[0]);
-	auto start_line_data = FlatVector::GetData<int32_t>(output.data[1]);
-	auto end_line_data = FlatVector::GetData<int32_t>(output.data[2]);
-	auto method_count_data = FlatVector::GetData<int32_t>(output.data[3]);
+	auto name_data = CompatFlatDataMutable<string_t>(output.data[0]);
+	auto start_line_data = CompatFlatDataMutable<int32_t>(output.data[1]);
+	auto end_line_data = CompatFlatDataMutable<int32_t>(output.data[2]);
+	auto method_count_data = CompatFlatDataMutable<int32_t>(output.data[3]);
 
 	while (data.current_idx < data.nodes.size() && count < STANDARD_VECTOR_SIZE) {
 		const auto &class_node = data.nodes[data.current_idx];
@@ -198,7 +198,7 @@ void ASTClassesFunction::Execute(ClientContext &context, TableFunctionInput &dat
 
 		// Base classes - simplified for now
 		ListVector::SetListSize(output.data[4], 0);
-		auto list_entries = FlatVector::GetData<list_entry_t>(output.data[4]);
+		auto list_entries = CompatFlatDataMutable<list_entry_t>(output.data[4]);
 		list_entries[count].offset = 0;
 		list_entries[count].length = 0;
 
@@ -221,7 +221,7 @@ TableFunction ASTImportsFunction::GetFunction() {
 }
 
 unique_ptr<FunctionData> ASTImportsFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
-                                                  vector<LogicalType> &return_types, vector<string> &names) {
+                                                  vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs.size() != 1) {
 		throw BinderException("ast_imports requires exactly 1 argument: ast");
 	}
@@ -250,10 +250,10 @@ void ASTImportsFunction::Execute(ClientContext &context, TableFunctionInput &dat
 	}
 
 	idx_t count = 0;
-	auto module_data = FlatVector::GetData<string_t>(output.data[0]);
-	auto alias_data = FlatVector::GetData<string_t>(output.data[2]);
-	auto line_data = FlatVector::GetData<int32_t>(output.data[3]);
-	auto is_from_data = FlatVector::GetData<bool>(output.data[4]);
+	auto module_data = CompatFlatDataMutable<string_t>(output.data[0]);
+	auto alias_data = CompatFlatDataMutable<string_t>(output.data[2]);
+	auto line_data = CompatFlatDataMutable<int32_t>(output.data[3]);
+	auto is_from_data = CompatFlatDataMutable<bool>(output.data[4]);
 	auto &alias_validity = FlatVector::Validity(output.data[2]);
 
 	while (data.current_idx < data.nodes.size() && count < STANDARD_VECTOR_SIZE) {
@@ -270,7 +270,7 @@ void ASTImportsFunction::Execute(ClientContext &context, TableFunctionInput &dat
 
 		// Empty names list for now
 		ListVector::SetListSize(output.data[1], 0);
-		auto list_entries = FlatVector::GetData<list_entry_t>(output.data[1]);
+		auto list_entries = CompatFlatDataMutable<list_entry_t>(output.data[1]);
 		list_entries[count].offset = 0;
 		list_entries[count].length = 0;
 

--- a/src/ast_supported_languages_function.cpp
+++ b/src/ast_supported_languages_function.cpp
@@ -12,7 +12,7 @@ struct SupportedLanguagesData : public GlobalTableFunctionState {
 };
 
 static unique_ptr<FunctionData> SupportedLanguagesBind(ClientContext &context, TableFunctionBindInput &input,
-                                                       vector<LogicalType> &return_types, vector<string> &names) {
+                                                       vector<LogicalType> &return_types, vector<CompatName> &names) {
 	names.emplace_back("language");
 	return_types.emplace_back(LogicalType::VARCHAR);
 

--- a/src/ast_type_map_function.cpp
+++ b/src/ast_type_map_function.cpp
@@ -130,7 +130,7 @@ static string GetExtractionStrategyName(ExtractionStrategy strategy) {
 }
 
 static unique_ptr<FunctionData> TypeMapBind(ClientContext &context, TableFunctionBindInput &input,
-                                            vector<LogicalType> &return_types, vector<string> &names) {
+                                            vector<LogicalType> &return_types, vector<CompatName> &names) {
 	auto bind_data = make_uniq<TypeMapBindData>();
 
 	// Optional language parameter

--- a/src/include/ast_helper_functions.hpp
+++ b/src/include/ast_helper_functions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "ast_type.hpp"
 
@@ -19,7 +20,7 @@ public:
 
 private:
 	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
-	                                     vector<LogicalType> &return_types, vector<string> &names);
+	                                     vector<LogicalType> &return_types, vector<CompatName> &names);
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 };
 
@@ -30,7 +31,7 @@ public:
 
 private:
 	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
-	                                     vector<LogicalType> &return_types, vector<string> &names);
+	                                     vector<LogicalType> &return_types, vector<CompatName> &names);
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 };
 
@@ -41,7 +42,7 @@ public:
 
 private:
 	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
-	                                     vector<LogicalType> &return_types, vector<string> &names);
+	                                     vector<LogicalType> &return_types, vector<CompatName> &names);
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 };
 

--- a/src/include/duckdb_adapter.hpp
+++ b/src/include/duckdb_adapter.hpp
@@ -6,6 +6,7 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/tableref.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include <mutex>
 

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -131,6 +131,23 @@ inline CompatName CompatMakeName(string name) {
 
 //! Replace `names` with the element-wise conversion of a runtime-built
 //! vector<string>. Use where the pre-v2.0 code did `names = <helper>()`.
+// A child_list_t KEY is a THIRD container, derived separately on purpose.
+//
+// CompatName above comes from the bind out-parameter; child_list_t's key comes
+// from STRUCT/UNION field names. Those are independent upstream declarations and
+// they have already diverged in practice: on the DuckDB the stable CI leg builds,
+// bind names are Identifier while child_list_t keys are still string, so pairing
+// a bind name straight into a child_list_t stopped compiling. Deriving each from
+// its own container is what makes that a non-event.
+//
+// CompatChildKey(string) constructs correctly on both lines -- a copy where the
+// key is string, the explicit Identifier ctor where it is not.
+using CompatChildKey = typename child_list_t<LogicalType>::value_type::first_type;
+
+inline CompatChildKey CompatMakeChildKey(const CompatName &name) {
+	return CompatChildKey(CompatNameStr(name));
+}
+
 inline void CompatAssignNames(vector<CompatName> &names, const vector<string> &source) {
 	names.clear();
 	names.reserve(source.size());

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include <type_traits>
 
 // duckdb_compat.hpp — cross-version shim for DuckDB extensions.
 //
@@ -32,7 +33,293 @@
 #include <optional> // C++17, only needed on the new-API path
 #endif
 
+// --- DuckDB v2.0 (the `main` line) -------------------------------------------
+//
+// The shims below cover the v2.0 API breaks. They are probed SEPARATELY from
+// DUCKDB_HAS_NEW_VECTOR_HEADERS above and separately from each other: a version
+// macro says *when* something changed, a probe says whether it changed *here*,
+// which keeps working if a change is backported, reverted, or lands on a branch
+// we did not expect. Tying several changes to one macro silently picks the
+// wrong branch the moment they land in different releases.
+//
+// duckdb::Identifier replaced std::string as the name type in table-function
+// and COPY bind signatures. Identifier compares case-insensitively, and
+// construction from a RUNTIME string is explicit by design -- promoting a
+// string to an identifier is meant to be a deliberate act at the call site --
+// so boundary helpers are needed rather than an implicit conversion.
+#if __has_include("duckdb/common/identifier.hpp")
+#define DUCKDB_HAS_IDENTIFIER 1
+#include "duckdb/common/identifier.hpp"
+#endif
+
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/parser/expression/comparison_expression.hpp"
+#include "duckdb/parser/expression/conjunction_expression.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
+
+// The scalar bind-function signature collapsed its three parameters into one
+// input object on v2.0:
+//   v1.5: (ClientContext &, ScalarFunction &, vector<unique_ptr<Expression>> &)
+//   v2.0: (BindScalarFunctionInput &)
+// Declare bind functions with DUCKDB_SCALAR_BIND_PARAMS and reach the pieces
+// through DUCKDB_SCALAR_BIND_CONTEXT / DUCKDB_SCALAR_BIND_ARGS.
+#ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
+#define DUCKDB_SCALAR_BIND_PARAMS  duckdb::BindScalarFunctionInput &bind_input
+#define DUCKDB_SCALAR_BIND_CONTEXT bind_input.GetClientContext()
+#define DUCKDB_SCALAR_BIND_ARGS    bind_input.GetArguments()
+#else
+#define DUCKDB_SCALAR_BIND_PARAMS                                                                                      \
+	duckdb::ClientContext &context, duckdb::ScalarFunction &bound_function,                                            \
+	    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> &arguments
+#define DUCKDB_SCALAR_BIND_CONTEXT context
+#define DUCKDB_SCALAR_BIND_ARGS    arguments
+#endif
+
 namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// CompatName / CompatNameStr / CompatMakeName / CompatAssignNames
+//===--------------------------------------------------------------------===//
+//
+// The bind-signature name type. Every table-function bind callback declares its
+// names parameter as `vector<CompatName> &`; string LITERALS still work
+// unchanged (`Identifier(const char *)` is implicit), so only the signatures
+// move. Runtime strings crossing the boundary use CompatMakeName (in) and
+// CompatNameStr (out).
+//
+// sitting_duck builds several of its column-name lists at runtime from the
+// language/extraction configuration (UnifiedASTBackend::GetFlat...ColumnNames
+// returns vector<string>), so CompatAssignNames exists for that case: it is the
+// element-wise conversion that `names = helper()` used to be for free.
+
+#ifdef DUCKDB_HAS_IDENTIFIER
+using CompatName = Identifier;
+inline string CompatNameStr(const Identifier &id) {
+	return id.GetIdentifierName();
+}
+inline Identifier CompatMakeName(string name) {
+	return Identifier(std::move(name));
+}
+#else
+using CompatName = string;
+inline string CompatNameStr(const string &name) {
+	return name;
+}
+inline string CompatMakeName(string name) {
+	return name;
+}
+#endif
+
+//! Replace `names` with the element-wise conversion of a runtime-built
+//! vector<string>. Use where the pre-v2.0 code did `names = <helper>()`.
+inline void CompatAssignNames(vector<CompatName> &names, const vector<string> &source) {
+	names.clear();
+	names.reserve(source.size());
+	for (auto &name : source) {
+		names.push_back(CompatMakeName(name));
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// CompatWithAlias
+//===--------------------------------------------------------------------===//
+//
+// v1.5: void SetAlias(string)                -- mutates in place
+// v2.0: LogicalType WithAlias(string) const  -- returns a copy, never mutating
+//       a type whose type-info may be shared. SetAlias is REMOVED, not
+//       deprecated: on main the compiler says LogicalType "has no member named
+//       SetAlias".
+//
+// Dispatched on a tag rather than with `if constexpr`, so this header also
+// compiles at C++11 (see the linkage note at the top of the file -- forcing
+// C++17 on the extension but not on libduckdb produces multiple-definition
+// errors). Tag dispatch has the property that matters here: only the selected
+// overload is instantiated, so the branch naming the absent member is never
+// compiled. The member probe itself is valid C++11 in this form.
+
+template <class T, class = void>
+struct CompatHasWithAlias : std::false_type {};
+template <class T>
+struct CompatHasWithAlias<T, decltype(void(std::declval<const T &>().WithAlias(string())))> : std::true_type {};
+
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::true_type) {
+	return type.WithAlias(std::move(alias));
+}
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::false_type) {
+	type.SetAlias(std::move(alias));
+	return type;
+}
+template <class TYPE = LogicalType>
+inline LogicalType CompatWithAlias(TYPE type, string alias) {
+	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<TYPE>());
+}
+
+//===--------------------------------------------------------------------===//
+// CompatFlatDataMutable
+//===--------------------------------------------------------------------===//
+//
+// v1.5: FlatVector::GetData<T>(vec)         returns T*
+// v2.0: FlatVector::GetData<T>(vec)         returns const T*
+//       FlatVector::GetDataMutable<T>(vec)  returns T*
+//
+// Writing through the v2.0 read accessor is a compile error, which is the point
+// of the split -- the WRITE path must ask for mutability explicitly. Note that
+// ConstantVector::GetData<T> kept its non-const overload, so only FlatVector
+// needs this.
+
+template <class T, class = void>
+struct CompatHasFlatGetDataMutable : std::false_type {};
+template <class T>
+struct CompatHasFlatGetDataMutable<T, decltype(void(T::template GetDataMutable<bool>(std::declval<Vector &>())))>
+    : std::true_type {};
+
+template <class VALUE, class FV>
+inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::true_type) {
+	return FV::template GetDataMutable<VALUE>(vec);
+}
+template <class VALUE, class FV>
+inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::false_type) {
+	return FV::template GetData<VALUE>(vec);
+}
+template <class VALUE, class FV = FlatVector>
+inline VALUE *CompatFlatDataMutable(Vector &vec) {
+	return CompatFlatDataMutableImpl<VALUE, FV>(vec, CompatHasFlatGetDataMutable<FV>());
+}
+
+//===--------------------------------------------------------------------===//
+// CompatStructEntry / CompatStructGetField
+//===--------------------------------------------------------------------===//
+//
+// v1.5: StructVector::GetEntries(vec) -> vector<unique_ptr<Vector>> &
+// v2.0: StructVector::GetEntries(vec) -> vector<Vector> &
+//
+// So `*entries[i]` and `entries[i]->Foo()` stop compiling on v2.0. No probe is
+// needed here: plain overload resolution distinguishes the two element types,
+// and only the viable overload is ever selected. (A probe would also work, but
+// this cannot get its polarity backwards.)
+
+inline Vector &CompatStructEntry(Vector &entry) {
+	return entry;
+}
+inline const Vector &CompatStructEntry(const Vector &entry) {
+	return entry;
+}
+inline Vector &CompatStructEntry(const unique_ptr<Vector> &entry) {
+	return *entry;
+}
+
+//! Child vector `field_idx` of a STRUCT vector, on either version.
+inline Vector &CompatStructGetField(Vector &vec, idx_t field_idx) {
+	return CompatStructEntry(StructVector::GetEntries(vec)[field_idx]);
+}
+
+//===--------------------------------------------------------------------===//
+// CompatBoundBindInfo
+//===--------------------------------------------------------------------===//
+//
+// BoundFunctionExpression::bind_info became private on v2.0; BindInfo() /
+// BindInfoMutable() replace it. Execute callbacks read it through
+// ExpressionState::expr, which is a const reference, so the const overload is
+// the one that matters here.
+
+#ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
+inline const unique_ptr<FunctionData> &CompatBoundBindInfo(const BoundFunctionExpression &expr) {
+	return expr.BindInfo();
+}
+inline unique_ptr<FunctionData> &CompatBoundBindInfo(BoundFunctionExpression &expr) {
+	return expr.BindInfoMutable();
+}
+#else
+inline const unique_ptr<FunctionData> &CompatBoundBindInfo(const BoundFunctionExpression &expr) {
+	return expr.bind_info;
+}
+inline unique_ptr<FunctionData> &CompatBoundBindInfo(BoundFunctionExpression &expr) {
+	return expr.bind_info;
+}
+#endif
+
+//===--------------------------------------------------------------------===//
+// Parsed-expression accessors
+//===--------------------------------------------------------------------===//
+//
+// v2.0 made the parser expression hierarchy's data members private and added
+// accessors; v1.5 has the public fields and (for most of these) no accessor, so
+// a shim is needed in both directions rather than a straight rename.
+//
+//   ConstantExpression::value       -> GetValue()
+//   FunctionExpression::function_name -> FunctionName()          (an Identifier)
+//   FunctionExpression::children    -> GetArguments()            (vector<FunctionArgument>,
+//                                                                 each wrapping an expression)
+//   ComparisonExpression::left/right-> Left() / Right()
+//   ConjunctionExpression::children -> GetChildren()
+//
+// The argument/child helpers return a vector of raw pointers rather than
+// exposing either container shape, because the two versions no longer store the
+// same thing: v2.0's FunctionExpression holds named FunctionArguments, not bare
+// child expressions.
+
+#ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
+
+inline const Value &CompatConstantValue(const ConstantExpression &expr) {
+	return expr.GetValue();
+}
+inline string CompatFunctionName(const FunctionExpression &expr) {
+	return expr.FunctionName().GetIdentifierName();
+}
+inline vector<const ParsedExpression *> CompatFunctionArgExprs(const FunctionExpression &expr) {
+	vector<const ParsedExpression *> result;
+	for (auto &arg : expr.GetArguments()) {
+		result.push_back(&arg.GetExpression());
+	}
+	return result;
+}
+inline const ParsedExpression *CompatComparisonLeft(const ComparisonExpression &expr) {
+	return &expr.Left();
+}
+inline const ParsedExpression *CompatComparisonRight(const ComparisonExpression &expr) {
+	return &expr.Right();
+}
+inline vector<const ParsedExpression *> CompatConjunctionChildren(const ConjunctionExpression &expr) {
+	vector<const ParsedExpression *> result;
+	for (auto &child : expr.GetChildren()) {
+		result.push_back(child.get());
+	}
+	return result;
+}
+
+#else
+
+inline const Value &CompatConstantValue(const ConstantExpression &expr) {
+	return expr.value;
+}
+inline string CompatFunctionName(const FunctionExpression &expr) {
+	return expr.function_name;
+}
+inline vector<const ParsedExpression *> CompatFunctionArgExprs(const FunctionExpression &expr) {
+	vector<const ParsedExpression *> result;
+	for (auto &child : expr.children) {
+		result.push_back(child.get());
+	}
+	return result;
+}
+inline const ParsedExpression *CompatComparisonLeft(const ComparisonExpression &expr) {
+	return expr.left.get();
+}
+inline const ParsedExpression *CompatComparisonRight(const ComparisonExpression &expr) {
+	return expr.right.get();
+}
+inline vector<const ParsedExpression *> CompatConjunctionChildren(const ConjunctionExpression &expr) {
+	vector<const ParsedExpression *> result;
+	for (auto &child : expr.children) {
+		result.push_back(child.get());
+	}
+	return result;
+}
+
+#endif
 
 //===--------------------------------------------------------------------===//
 // CompatSetOutputCardinality

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -47,10 +47,21 @@
 // construction from a RUNTIME string is explicit by design -- promoting a
 // string to an identifier is meant to be a deliberate act at the call site --
 // so boundary helpers are needed rather than an implicit conversion.
+//
+// This __has_include gates only whether a CompatNameStr(const Identifier &)
+// overload can EXIST. It deliberately does NOT decide what CompatName is: the
+// header was BACKPORTED to the stable branch without changing
+// table_function_bind_t, so on v1.5-variegata's current tip identifier.hpp is
+// present while binds still take vector<string>. Keying CompatName off the
+// header would flip it to Identifier on the next submodule bump and break every
+// bind signature at once. See CompatName below for what is used instead.
 #if __has_include("duckdb/common/identifier.hpp")
 #define DUCKDB_HAS_IDENTIFIER 1
 #include "duckdb/common/identifier.hpp"
 #endif
+
+#include "duckdb/function/table_function.hpp"
+#include <utility>
 
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/parser/expression/comparison_expression.hpp"
@@ -93,23 +104,30 @@ namespace duckdb {
 // returns vector<string>), so CompatAssignNames exists for that case: it is the
 // element-wise conversion that `names = helper()` used to be for free.
 
-#ifdef DUCKDB_HAS_IDENTIFIER
-using CompatName = Identifier;
-inline string CompatNameStr(const Identifier &id) {
-	return id.GetIdentifierName();
-}
-inline Identifier CompatMakeName(string name) {
-	return Identifier(std::move(name));
-}
-#else
-using CompatName = string;
+// Ask DuckDB what its own bind-name type is, rather than inferring it from a
+// header's presence. TableFunctionBindInput::input_table_names has the same
+// element type as the bind out-parameter on both lines -- vector<string> on the
+// pin (table_function.hpp:110 / :288), vector<Identifier> on main (:123 / :319)
+// -- so this cannot drift from the thing that actually changed. A probe on
+// identifier.hpp can and does: that header is already present on
+// v1.5-variegata's tip, where binds still take strings.
+using CompatName = typename std::remove_reference<decltype(
+    std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
+
 inline string CompatNameStr(const string &name) {
 	return name;
 }
-inline string CompatMakeName(string name) {
-	return name;
+#ifdef DUCKDB_HAS_IDENTIFIER
+inline string CompatNameStr(const Identifier &id) {
+	return id.GetIdentifierName();
 }
 #endif
+
+//! Promote a runtime string to whatever the bind-name type is. Named rather
+//! than implicit because Identifier(const string &) is explicit by design.
+inline CompatName CompatMakeName(string name) {
+	return CompatName(std::move(name));
+}
 
 //! Replace `names` with the element-wise conversion of a runtime-built
 //! vector<string>. Use where the pre-v2.0 code did `names = <helper>()`.
@@ -152,9 +170,15 @@ inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::false_type)
 	type.SetAlias(std::move(alias));
 	return type;
 }
-template <class TYPE = LogicalType>
-inline LogicalType CompatWithAlias(TYPE type, string alias) {
-	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<TYPE>());
+// The entry point is deliberately NOT a template with a defaulted parameter.
+// A default template argument is inert when deduction succeeds, so
+// `CompatWithAlias(LogicalType::VARCHAR, "x")` would deduce TYPE =
+// LogicalTypeId -- LogicalType::VARCHAR is a static constexpr LogicalTypeId,
+// not a LogicalType -- and hard-error on the member lookup. Taking a concrete
+// LogicalType by value converts at the call site instead. Only the Impl
+// overloads are templates, which is all the tag dispatch needs.
+inline LogicalType CompatWithAlias(LogicalType type, string alias) {
+	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<LogicalType>());
 }
 
 //===--------------------------------------------------------------------===//
@@ -187,6 +211,44 @@ inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::false_type) {
 template <class VALUE, class FV = FlatVector>
 inline VALUE *CompatFlatDataMutable(Vector &vec) {
 	return CompatFlatDataMutableImpl<VALUE, FV>(vec, CompatHasFlatGetDataMutable<FV>());
+}
+
+//===--------------------------------------------------------------------===//
+// CompatFlatValidityMutable
+//===--------------------------------------------------------------------===//
+//
+// FlatVector::Validity got the same copy-on-write const split as GetData:
+//   v2.0: const ValidityMask &Validity(const Vector &)   -- through Buffer()
+//         ValidityMask &ValidityMutable(Vector &)        -- through BufferMutable()
+//
+// This one hides better than the GetData case. `auto &m = FlatVector::Validity(v);`
+// still COMPILES on v2.0, silently deducing a CONST reference; the error only
+// appears later at the mutation, as "passing 'const duckdb::ValidityMask' as
+// 'this' argument discards qualifiers" -- naming neither Validity nor
+// FlatVector. So grep for the MUTATION (SetInvalid / SetValid / SetAllInvalid /
+// SetAllValid) and walk back to where the reference was bound.
+//
+// Use this ONLY on vectors being written. Reading an INPUT vector's validity
+// through the mutable accessor would go through BufferMutable() and un-share a
+// copy-on-write buffer for no reason.
+
+template <class T, class = void>
+struct CompatHasFlatValidityMutable : std::false_type {};
+template <class T>
+struct CompatHasFlatValidityMutable<T, decltype(void(T::ValidityMutable(std::declval<Vector &>())))> : std::true_type {
+};
+
+template <class FV>
+inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::true_type) {
+	return FV::ValidityMutable(vec);
+}
+template <class FV>
+inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::false_type) {
+	return FV::Validity(vec);
+}
+template <class FV = FlatVector>
+inline ValidityMask &CompatFlatValidityMutable(Vector &vec) {
+	return CompatFlatValidityMutableImpl<FV>(vec, CompatHasFlatValidityMutable<FV>());
 }
 
 //===--------------------------------------------------------------------===//
@@ -325,6 +387,32 @@ inline vector<const ParsedExpression *> CompatConjunctionChildren(const Conjunct
 // CompatSetOutputCardinality
 //===--------------------------------------------------------------------===//
 
+// On v2.0 this forwards to SetChildCardinality, which does strictly MORE than
+// the deprecated SetCardinality (that one now just assigns the chunk's count via
+// SetCardinalityUnsafe). Two things worth knowing before touching a call site:
+//
+// It is not destructive. DuckDB main's doc comment on SetCardinality warns that
+// forwarding "would resize/overwrite their data", which reads alarming, but
+// every leaf on the path is a size assignment behind a bounds check --
+// DataChunk::SetChildCardinality -> FlatVector::SetSize ->
+// VectorBuffer::SetVectorSize assigns v_size and reallocates nothing, and
+// VectorStructBuffer::SetVectorSize only propagates the same count to children.
+// No element bytes are touched, and there is no VectorListBuffer override, so
+// LIST/MAP children are left alone too.
+//
+// It is also what makes this extension work at all under v2.0's per-vector size
+// tracking. Every call site here writes children by INDEX first (raw
+// CompatFlatDataMutable pointers, or Vector::SetValue) and sets the cardinality
+// afterwards. Index writes never touch v_size, so the child vectors are still
+// size 0 when the row loop ends; SetChildCardinality is what publishes them.
+//
+// The real hazard is LOUD, not silent: SetChildCardinality throws an
+// InternalException if a column is neither flat nor constant and its size
+// disagrees, or if the count exceeds a flat vector's capacity. Both are
+// satisfied here -- output columns stay flat (ResetStructVectorState forces
+// FLAT_VECTOR on struct children) and every producing loop is bounded by
+// STANDARD_VECTOR_SIZE. A future call site that appends with Vector::Append,
+// whose children are already sized, must not use this helper.
 inline void CompatSetOutputCardinality(DataChunk &chunk, idx_t count) {
 #ifdef DUCKDB_HAS_NEW_VECTOR_HEADERS
 	chunk.SetChildCardinality(count);

--- a/src/language_adapters/duckdb_adapter.cpp
+++ b/src/language_adapters/duckdb_adapter.cpp
@@ -34,6 +34,115 @@
 namespace duckdb {
 
 //==============================================================================
+// DuckDB v2.0 parser-object accessors (local to this file)
+//==============================================================================
+//
+// v2.0 closed the parser data structures' public name fields and moved them
+// behind a QualifiedName: CreateInfo & friends grew Get<Entry>Name() returning
+// an Identifier, and BaseTableRef::table_name became Table(). v1.5 has the bare
+// string fields and none of the accessors, so each needs a shim rather than a
+// rename.
+//
+// These live here rather than in duckdb_compat.hpp deliberately. They would
+// drag ten parser/parsed_data headers into a file that fourteen translation
+// units include, and this adapter -- the only code in the extension that walks
+// DuckDB's own parse tree -- is their only consumer.
+//
+// ONE probe for the whole refactor, because it IS one upstream change: the
+// entry names all moved into CreateInfo::qualified_name together. Probing
+// GetQualifiedName() asks for the v2.0-only API, never the one being replaced,
+// so it cannot be true on both lines the way a probe aimed at the old field
+// would be.
+namespace {
+
+template <class T, class = void>
+struct HasQualifiedName : std::false_type {};
+template <class T>
+struct HasQualifiedName<T, decltype(void(std::declval<const T &>().GetQualifiedName()))> : std::true_type {};
+
+typedef HasQualifiedName<CreateInfo> QualifiedNameTag;
+
+// Tag dispatch rather than `if constexpr`: this extension compiles at C++11 on
+// Linux (see CMakeLists.txt). Only the selected overload is instantiated, so the
+// branch naming the absent member is never compiled.
+template <class INFO>
+string CreateEntryName(const INFO &info, std::true_type) {
+	return info.GetFunctionName().GetIdentifierName();
+}
+template <class INFO>
+string CreateEntryName(const INFO &info, std::false_type) {
+	return info.name;
+}
+
+template <class INFO>
+string CreateTableEntryName(const INFO &info, std::true_type) {
+	return info.GetTableName().GetIdentifierName();
+}
+template <class INFO>
+string CreateTableEntryName(const INFO &info, std::false_type) {
+	return info.table;
+}
+
+template <class INFO>
+string CreateViewEntryName(const INFO &info, std::true_type) {
+	return info.GetViewName().GetIdentifierName();
+}
+template <class INFO>
+string CreateViewEntryName(const INFO &info, std::false_type) {
+	return info.view_name;
+}
+
+template <class INFO>
+string CreateSequenceEntryName(const INFO &info, std::true_type) {
+	return info.GetSequenceName().GetIdentifierName();
+}
+template <class INFO>
+string CreateSequenceEntryName(const INFO &info, std::false_type) {
+	return info.name;
+}
+
+template <class INFO>
+string CreateTypeEntryName(const INFO &info, std::true_type) {
+	return info.GetTypeName().GetIdentifierName();
+}
+template <class INFO>
+string CreateTypeEntryName(const INFO &info, std::false_type) {
+	return info.name;
+}
+
+template <class INFO>
+string CreateIndexEntryName(const INFO &info, std::true_type) {
+	return info.GetIndexName().GetIdentifierName();
+}
+template <class INFO>
+string CreateIndexEntryName(const INFO &info, std::false_type) {
+	return info.index_name;
+}
+
+// CREATE SCHEMA is the one entry whose name does NOT live in the Name() slot on
+// v2.0: CreateSchemaInfo encodes the path as [catalog, parents..., new_schema,
+// <empty name>] and exposes SchemaName() to read it back.
+template <class INFO>
+string CreateSchemaName(const INFO &info, std::true_type) {
+	return info.template Cast<CreateSchemaInfo>().SchemaName().GetIdentifierName();
+}
+template <class INFO>
+string CreateSchemaName(const INFO &info, std::false_type) {
+	return info.schema;
+}
+
+template <class REF>
+string BaseTableName(const REF &ref, std::true_type) {
+	return ref.Table().GetIdentifierName();
+}
+template <class REF>
+string BaseTableName(const REF &ref, std::false_type) {
+	return ref.table_name;
+}
+
+} // namespace
+
+//==============================================================================
 // DuckDB Native Parser Adapter - Architecture Plan Implementation
 //
 // Credit: Inspired by zacMode's duckdb_extension_parser_tools
@@ -286,7 +395,7 @@ vector<ASTNode> DuckDBAdapter::ConvertCreateStatement(const CreateStatement &stm
 	case CatalogType::MACRO_ENTRY: {
 		// CreateMacroInfo inherits from CreateFunctionInfo, so we can cast to the base
 		const auto &macro_info = info.Cast<CreateFunctionInfo>();
-		name = macro_info.name;
+		name = CreateEntryName(macro_info, QualifiedNameTag());
 		node_type = "create_macro";
 		semantic_type = SemanticTypes::DEFINITION_FUNCTION;
 		break;
@@ -294,42 +403,42 @@ vector<ASTNode> DuckDBAdapter::ConvertCreateStatement(const CreateStatement &stm
 	case CatalogType::TABLE_MACRO_ENTRY: {
 		// CreateMacroInfo inherits from CreateFunctionInfo, so we can cast to the base
 		const auto &macro_info = info.Cast<CreateFunctionInfo>();
-		name = macro_info.name;
+		name = CreateEntryName(macro_info, QualifiedNameTag());
 		node_type = "create_table_macro";
 		semantic_type = SemanticTypes::DEFINITION_FUNCTION;
 		break;
 	}
 	case CatalogType::TABLE_ENTRY: {
 		const auto &table_info = info.Cast<CreateTableInfo>();
-		name = table_info.table;
+		name = CreateTableEntryName(table_info, QualifiedNameTag());
 		node_type = "create_table";
 		semantic_type = SemanticTypes::DEFINITION_CLASS;
 		break;
 	}
 	case CatalogType::VIEW_ENTRY: {
 		const auto &view_info = info.Cast<CreateViewInfo>();
-		name = view_info.view_name;
+		name = CreateViewEntryName(view_info, QualifiedNameTag());
 		node_type = "create_view";
 		semantic_type = SemanticTypes::DEFINITION_CLASS;
 		break;
 	}
 	case CatalogType::SEQUENCE_ENTRY: {
 		const auto &seq_info = info.Cast<CreateSequenceInfo>();
-		name = seq_info.name;
+		name = CreateSequenceEntryName(seq_info, QualifiedNameTag());
 		node_type = "create_sequence";
 		semantic_type = SemanticTypes::DEFINITION_VARIABLE;
 		break;
 	}
 	case CatalogType::TYPE_ENTRY: {
 		const auto &type_info = info.Cast<CreateTypeInfo>();
-		name = type_info.name;
+		name = CreateTypeEntryName(type_info, QualifiedNameTag());
 		node_type = "create_type";
 		semantic_type = SemanticTypes::DEFINITION_CLASS;
 		break;
 	}
 	case CatalogType::INDEX_ENTRY: {
 		const auto &idx_info = info.Cast<CreateIndexInfo>();
-		name = idx_info.index_name;
+		name = CreateIndexEntryName(idx_info, QualifiedNameTag());
 		node_type = "create_index";
 		semantic_type = SemanticTypes::DEFINITION_VARIABLE;
 		break;
@@ -339,7 +448,7 @@ vector<ASTNode> DuckDBAdapter::ConvertCreateStatement(const CreateStatement &stm
 	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
 	case CatalogType::PRAGMA_FUNCTION_ENTRY: {
 		const auto &func_info = info.Cast<CreateFunctionInfo>();
-		name = func_info.name;
+		name = CreateEntryName(func_info, QualifiedNameTag());
 		node_type = "create_function";
 		semantic_type = SemanticTypes::DEFINITION_FUNCTION;
 		break;
@@ -347,7 +456,7 @@ vector<ASTNode> DuckDBAdapter::ConvertCreateStatement(const CreateStatement &stm
 	case CatalogType::SCHEMA_ENTRY: {
 		// For CREATE SCHEMA, the schema name is stored in the base CreateInfo::schema field
 		node_type = "create_schema";
-		name = info.schema;
+		name = CreateSchemaName(info, QualifiedNameTag());
 		semantic_type = SemanticTypes::DEFINITION_MODULE;
 		break;
 	}
@@ -577,7 +686,9 @@ vector<ASTNode> DuckDBAdapter::ConvertExpression(const ParsedExpression &expr, u
 
 vector<ASTNode> DuckDBAdapter::HandleColumnReference(const ParsedExpression &expr, uint32_t &node_counter) const {
 	const auto &col_ref = expr.Cast<ColumnRefExpression>();
-	auto node = CreateASTNode("column_reference", col_ref.GetColumnName(), col_ref.ToString(),
+	// GetColumnName() returns an Identifier on v2.0 and a string on v1.5;
+	// CompatNameStr has an overload for each, so no probe is needed here.
+	auto node = CreateASTNode("column_reference", CompatNameStr(col_ref.GetColumnName()), col_ref.ToString(),
 	                          SemanticTypes::NAME_IDENTIFIER, node_counter++, -1, 0);
 	return {node};
 }
@@ -827,8 +938,9 @@ vector<ASTNode> DuckDBAdapter::ConvertTableRef(const TableRef &table_ref, uint32
 	switch (table_ref.type) {
 	case TableReferenceType::BASE_TABLE: {
 		const auto &base_table = table_ref.Cast<BaseTableRef>();
-		auto node = CreateASTNode("table_reference", base_table.table_name, base_table.table_name,
-		                          SemanticTypes::NAME_QUALIFIED, node_counter++, -1, 0);
+		const auto base_table_name = BaseTableName(base_table, QualifiedNameTag());
+		auto node = CreateASTNode("table_reference", base_table_name, base_table_name, SemanticTypes::NAME_QUALIFIED,
+		                          node_counter++, -1, 0);
 		nodes.push_back(node);
 		break;
 	}

--- a/src/language_adapters/duckdb_adapter.cpp
+++ b/src/language_adapters/duckdb_adapter.cpp
@@ -1,4 +1,5 @@
 #include "duckdb_adapter.hpp"
+#include "duckdb_compat.hpp"
 #include "unified_ast_backend_impl.hpp"
 #include "semantic_types.hpp"
 #include "duckdb/common/exception.hpp"
@@ -583,11 +584,13 @@ vector<ASTNode> DuckDBAdapter::HandleColumnReference(const ParsedExpression &exp
 
 vector<ASTNode> DuckDBAdapter::HandleConstant(const ParsedExpression &expr, uint32_t &node_counter) const {
 	const auto &const_expr = expr.Cast<ConstantExpression>();
-	string value = const_expr.value.ToString();
+	// v2.0 made ConstantExpression::value private (GetValue()).
+	const auto &const_value = CompatConstantValue(const_expr);
+	string value = const_value.ToString();
 
 	// Determine appropriate semantic type based on value type
 	uint8_t semantic_type;
-	auto value_type = const_expr.value.type();
+	auto value_type = const_value.type();
 	if (value_type == LogicalType::VARCHAR) {
 		semantic_type = SemanticTypes::LITERAL_STRING;
 	} else if (value_type == LogicalType::INTEGER || value_type == LogicalType::BIGINT ||
@@ -605,13 +608,17 @@ vector<ASTNode> DuckDBAdapter::HandleConstant(const ParsedExpression &expr, uint
 
 vector<ASTNode> DuckDBAdapter::HandleFunction(const ParsedExpression &expr, uint32_t &node_counter) const {
 	const auto &func_expr = expr.Cast<FunctionExpression>();
-	string normalized_name = NormalizeFunctionName(func_expr.function_name);
+	// v2.0 made FunctionExpression::function_name private (an Identifier behind
+	// FunctionName()) and replaced `children` with a vector<FunctionArgument>.
+	const string function_name = CompatFunctionName(func_expr);
+	const auto func_args = CompatFunctionArgExprs(func_expr);
+	string normalized_name = NormalizeFunctionName(function_name);
 	vector<ASTNode> nodes;
 
 	// Skip internal constructor functions that users don't typically write explicitly
-	if (func_expr.function_name == "list_value" || func_expr.function_name == "struct_pack_internal") {
+	if (function_name == "list_value" || function_name == "struct_pack_internal") {
 		// Process arguments but don't create the function call node
-		for (const auto &arg : func_expr.children) {
+		for (const auto *arg : func_args) {
 			if (!arg) {
 				continue;
 			}
@@ -630,7 +637,7 @@ vector<ASTNode> DuckDBAdapter::HandleFunction(const ParsedExpression &expr, uint
 		nodes.push_back(node);
 
 		// Process function arguments
-		for (const auto &arg : func_expr.children) {
+		for (const auto *arg : func_args) {
 			if (!arg) {
 				continue; // Skip NULL function arguments
 			}
@@ -657,8 +664,11 @@ vector<ASTNode> DuckDBAdapter::HandleComparison(const ParsedExpression &expr, ui
 	nodes.push_back(comp_node);
 
 	// Process left and right operands
-	if (comp_expr.left) {
-		auto left_nodes = ConvertExpression(*comp_expr.left, node_counter);
+	// v2.0 made ComparisonExpression::left/right private (Left()/Right()).
+	const auto *comp_left = CompatComparisonLeft(comp_expr);
+	const auto *comp_right = CompatComparisonRight(comp_expr);
+	if (comp_left) {
+		auto left_nodes = ConvertExpression(*comp_left, node_counter);
 		for (auto &ln : left_nodes) {
 			if (ln.parent_id == -1) {
 				ln.parent_id = comp_node.node_id;
@@ -667,8 +677,8 @@ vector<ASTNode> DuckDBAdapter::HandleComparison(const ParsedExpression &expr, ui
 			nodes.push_back(ln);
 		}
 	}
-	if (comp_expr.right) {
-		auto right_nodes = ConvertExpression(*comp_expr.right, node_counter);
+	if (comp_right) {
+		auto right_nodes = ConvertExpression(*comp_right, node_counter);
 		for (auto &rn : right_nodes) {
 			if (rn.parent_id == -1) {
 				rn.parent_id = comp_node.node_id;
@@ -689,8 +699,9 @@ vector<ASTNode> DuckDBAdapter::HandleConjunction(const ParsedExpression &expr, u
 	    CreateASTNode("conjunction", "", expr.ToString(), SemanticTypes::OPERATOR_LOGICAL, node_counter++, -1, 0);
 	nodes.push_back(conj_node);
 
+	// v2.0 made ConjunctionExpression::children private (GetChildren()).
 	// Process all child expressions
-	for (const auto &child : conj_expr.children) {
+	for (const auto *child : CompatConjunctionChildren(conj_expr)) {
 		if (!child)
 			continue;
 		auto child_nodes = ConvertExpression(*child, node_counter);
@@ -740,7 +751,9 @@ vector<ASTNode> DuckDBAdapter::HandleOperator(const ParsedExpression &expr, uint
 	string operator_name = "";
 	uint8_t semantic_type = SemanticTypes::OPERATOR_LOGICAL;
 
-	switch (expr.type) {
+	// BaseExpression::type is protected on v2.0; GetExpressionType() exists on
+	// both versions, so no shim is needed -- just use the accessor.
+	switch (expr.GetExpressionType()) {
 	case ExpressionType::OPERATOR_IS_NULL:
 		operator_name = "is_null";
 		break;
@@ -790,7 +803,7 @@ vector<ASTNode> DuckDBAdapter::HandleIncompleteExpression(const ParsedExpression
 
 	// Try to get a meaningful type name
 	try {
-		expr_type_name = StringUtil::Format("ExpressionType_%d", static_cast<int>(expr.type));
+		expr_type_name = StringUtil::Format("ExpressionType_%d", static_cast<int>(expr.GetExpressionType()));
 	} catch (...) {
 		expr_type_name = "unknown_expression_type";
 	}

--- a/src/parse_ast_function.cpp
+++ b/src/parse_ast_function.cpp
@@ -20,7 +20,7 @@ struct ParseASTData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> ParseASTBind(ClientContext &context, TableFunctionBindInput &input,
-                                             vector<LogicalType> &return_types, vector<string> &names) {
+                                             vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs.size() != 2) {
 		throw BinderException("parse_ast requires exactly 2 arguments: code and language");
 	}
@@ -64,7 +64,10 @@ static unique_ptr<FunctionData> ParseASTBind(ClientContext &context, TableFuncti
 
 	// Use flat dynamic schema based on extraction config
 	return_types = UnifiedASTBackend::GetFlatDynamicTableSchema(config);
-	names = UnifiedASTBackend::GetFlatDynamicTableColumnNames(config);
+	// On DuckDB v2.0 `names` is a vector<Identifier>; the helper returns
+	// vector<string>, and promoting a runtime string to an Identifier is
+	// explicit by design, so the assignment is element-wise.
+	CompatAssignNames(names, UnifiedASTBackend::GetFlatDynamicTableColumnNames(config));
 
 	return make_uniq<ParseASTData>(code, language, config);
 }
@@ -96,7 +99,7 @@ static void ParseASTExecute(ClientContext &context, TableFunctionInput &data_p, 
 //==============================================================================
 
 static unique_ptr<FunctionData> ParseASTHierarchicalBind(ClientContext &context, TableFunctionBindInput &input,
-                                                         vector<LogicalType> &return_types, vector<string> &names) {
+                                                         vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs.size() != 2) {
 		throw BinderException("parse_ast requires exactly 2 arguments: code and language");
 	}
@@ -106,7 +109,10 @@ static unique_ptr<FunctionData> ParseASTHierarchicalBind(ClientContext &context,
 
 	// Use hierarchical STRUCT schema
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
-	names = UnifiedASTBackend::GetHierarchicalTableColumnNames();
+	// On DuckDB v2.0 `names` is a vector<Identifier>; the helper returns
+	// vector<string>, and promoting a runtime string to an Identifier is
+	// explicit by design, so the assignment is element-wise.
+	CompatAssignNames(names, UnifiedASTBackend::GetHierarchicalTableColumnNames());
 
 	// Parse extraction config parameters (same as read_ast)
 	string context_str = "native"; // Default to native for backward compatibility

--- a/src/parse_ast_list_function.cpp
+++ b/src/parse_ast_list_function.cpp
@@ -1,5 +1,6 @@
 #include "parse_ast_list_function.hpp"
 #include "unified_ast_backend.hpp"
+#include "duckdb_compat.hpp"
 #include "semantic_type_logical_type.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/scalar_function.hpp"
@@ -184,8 +185,10 @@ static Value ConvertASTResultToList(const ASTResult &result, const ExtractionCon
 // Bind Function
 //==============================================================================
 
-static unique_ptr<FunctionData> ParseASTListBind(ClientContext &context, ScalarFunction &bound_function,
-                                                 vector<unique_ptr<Expression>> &arguments) {
+// DuckDB v2.0 collapsed the scalar bind signature's three parameters into a
+// single BindScalarFunctionInput; DUCKDB_SCALAR_BIND_PARAMS expands to whichever
+// shape the DuckDB in scope declares. This bind reads none of them.
+static unique_ptr<FunctionData> ParseASTListBind(DUCKDB_SCALAR_BIND_PARAMS) {
 	return make_uniq<ParseASTListBindData>();
 }
 
@@ -194,7 +197,8 @@ static unique_ptr<FunctionData> ParseASTListBind(ClientContext &context, ScalarF
 //==============================================================================
 
 static void ParseASTListExecute(DataChunk &args, ExpressionState &state, Vector &result) {
-	auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<ParseASTListBindData>();
+	// BoundFunctionExpression::bind_info is private on v2.0 (BindInfo() replaces it).
+	auto &bind_data = CompatBoundBindInfo(state.expr.Cast<BoundFunctionExpression>())->Cast<ParseASTListBindData>();
 	auto &code_vector = args.data[0];
 	auto &language_vector = args.data[1];
 
@@ -204,8 +208,8 @@ static void ParseASTListExecute(DataChunk &args, ExpressionState &state, Vector 
 	code_vector.Flatten(count);
 	language_vector.Flatten(count);
 
-	auto code_data = FlatVector::GetData<string_t>(code_vector);
-	auto language_data = FlatVector::GetData<string_t>(language_vector);
+	auto code_data = CompatFlatDataMutable<string_t>(code_vector);
+	auto language_data = CompatFlatDataMutable<string_t>(language_vector);
 	auto &code_validity = FlatVector::Validity(code_vector);
 	auto &language_validity = FlatVector::Validity(language_vector);
 

--- a/src/parse_ast_list_function.cpp
+++ b/src/parse_ast_list_function.cpp
@@ -45,9 +45,9 @@ static LogicalType BuildASTStructType(const ExtractionConfig &config) {
 	for (idx_t i = 0; i < types.size(); i++) {
 		// Replace SEMANTIC_TYPE custom logical type with plain UTINYINT
 		if (IsSemanticType(types[i])) {
-			struct_children.push_back(make_pair(names[i], LogicalType::UTINYINT));
+			struct_children.push_back(make_pair(CompatMakeChildKey(names[i]), LogicalType::UTINYINT));
 		} else {
-			struct_children.push_back(make_pair(names[i], types[i]));
+			struct_children.push_back(make_pair(CompatMakeChildKey(names[i]), types[i]));
 		}
 	}
 
@@ -66,9 +66,9 @@ static Value ConvertASTResultToList(const ASTResult &result, const ExtractionCon
 	child_list_t<LogicalType> struct_children;
 	for (idx_t i = 0; i < types.size(); i++) {
 		if (IsSemanticType(types[i])) {
-			struct_children.push_back(make_pair(names[i], LogicalType::UTINYINT));
+			struct_children.push_back(make_pair(CompatMakeChildKey(names[i]), LogicalType::UTINYINT));
 		} else {
-			struct_children.push_back(make_pair(names[i], types[i]));
+			struct_children.push_back(make_pair(CompatMakeChildKey(names[i]), types[i]));
 		}
 	}
 	auto element_type = LogicalType::STRUCT(struct_children);

--- a/src/parse_ast_list_function.cpp
+++ b/src/parse_ast_list_function.cpp
@@ -245,6 +245,26 @@ void RegisterParseASTListFunction(ExtensionLoader &loader) {
 	ScalarFunction func("parse_ast_list", {LogicalType::VARCHAR, LogicalType::VARCHAR}, return_type,
 	                    ParseASTListExecute, ParseASTListBind);
 
+	// This function can throw at EXECUTION time: ParseToASTResult raises
+	// InternalException when tree-sitter fails to produce a tree, and the parse
+	// timeout / node cap surface the same way. Only InvalidInputException is
+	// caught and turned into a NULL row. DuckDB v2.0 requires a scalar function
+	// that can throw to declare it -- otherwise the throw is re-raised as
+	// "threw an execution error, but the function is not marked as fallible".
+	// Enforcement is an assertion, so an unmarked function is green wherever
+	// assertions are off and red where they are on, and only on error-path
+	// tests. Set before registering: on v2.0 a FunctionSet's members are
+	// shared_ptr<const T> and cannot be configured after being added.
+	//
+	// Nothing else here needs it: the semantic-type scalar functions are pure
+	// table lookups that signal "unknown" by returning NULL, and semantic_types.cpp
+	// contains no throw at all. Marking precisely matters on BOTH lines -- the
+	// pinned v1.5 has SetFallible too (function.hpp:211) and `errors` feeds
+	// CanThrow(), which gates conjunct reordering, filter pushdown and dictionary
+	// caching. No shim: the method is identical on both, so calling it directly
+	// is both simpler and honest about there being nothing to adapt.
+	func.SetFallible();
+
 	loader.RegisterFunction(func);
 }
 

--- a/src/read_ast_streaming_function.cpp
+++ b/src/read_ast_streaming_function.cpp
@@ -13,7 +13,7 @@ namespace duckdb {
 // Bind function for flat streaming two-argument version (explicit language)
 static unique_ptr<FunctionData> ReadASTFlatStreamingBindTwoArg(ClientContext &context, TableFunctionBindInput &input,
                                                                vector<LogicalType> &return_types,
-                                                               vector<string> &names) {
+                                                               vector<CompatName> &names) {
 	if (input.inputs.size() != 2) {
 		throw BinderException("read_ast requires exactly 2 arguments: file_path and language");
 	}
@@ -48,10 +48,13 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindTwoArg(ClientContext &co
 	// Check for duplicate parameters (following DuckDB YAML extension pattern)
 	std::unordered_set<std::string> seen_parameters;
 	for (auto &param : input.named_parameters) {
-		if (seen_parameters.find(param.first) != seen_parameters.end()) {
-			throw BinderException("Duplicate parameter name: " + param.first);
+		// param.first is an Identifier on DuckDB v2.0 (a string on v1.5);
+		// seen_parameters is a plain set of strings, so convert at the boundary.
+		const auto param_name = CompatNameStr(param.first);
+		if (seen_parameters.find(param_name) != seen_parameters.end()) {
+			throw BinderException("Duplicate parameter name: " + param_name);
 		}
-		seen_parameters.insert(param.first);
+		seen_parameters.insert(param_name);
 	}
 
 	// Parse optional named parameters
@@ -134,7 +137,10 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindTwoArg(ClientContext &co
 
 	// Use flat dynamic schema based on extraction config
 	return_types = UnifiedASTBackend::GetFlatDynamicTableSchema(extraction_config);
-	names = UnifiedASTBackend::GetFlatDynamicTableColumnNames(extraction_config);
+	// On DuckDB v2.0 `names` is a vector<Identifier>; the helper returns
+	// vector<string>, and promoting a runtime string to an Identifier is
+	// explicit by design, so the assignment is element-wise.
+	CompatAssignNames(names, UnifiedASTBackend::GetFlatDynamicTableColumnNames(extraction_config));
 
 	// Use the new ExtractionConfig constructor
 	return make_uniq<ReadASTStreamingBindData>(file_patterns, language, ignore_errors, extraction_config, batch_size);
@@ -143,7 +149,7 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindTwoArg(ClientContext &co
 // Bind function for flat streaming one-argument version (auto-detect language)
 static unique_ptr<FunctionData> ReadASTFlatStreamingBindOneArg(ClientContext &context, TableFunctionBindInput &input,
                                                                vector<LogicalType> &return_types,
-                                                               vector<string> &names) {
+                                                               vector<CompatName> &names) {
 	if (input.inputs.size() != 1) {
 		throw BinderException("read_ast requires exactly 1 argument: file_path");
 	}
@@ -172,10 +178,13 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindOneArg(ClientContext &co
 	// Check for duplicate parameters (following DuckDB YAML extension pattern)
 	std::unordered_set<std::string> seen_parameters;
 	for (auto &param : input.named_parameters) {
-		if (seen_parameters.find(param.first) != seen_parameters.end()) {
-			throw BinderException("Duplicate parameter name: " + param.first);
+		// param.first is an Identifier on DuckDB v2.0 (a string on v1.5);
+		// seen_parameters is a plain set of strings, so convert at the boundary.
+		const auto param_name = CompatNameStr(param.first);
+		if (seen_parameters.find(param_name) != seen_parameters.end()) {
+			throw BinderException("Duplicate parameter name: " + param_name);
 		}
-		seen_parameters.insert(param.first);
+		seen_parameters.insert(param_name);
 	}
 
 	// Parse optional named parameters
@@ -261,7 +270,10 @@ static unique_ptr<FunctionData> ReadASTFlatStreamingBindOneArg(ClientContext &co
 
 	// Use flat dynamic schema based on extraction config
 	return_types = UnifiedASTBackend::GetFlatDynamicTableSchema(extraction_config);
-	names = UnifiedASTBackend::GetFlatDynamicTableColumnNames(extraction_config);
+	// On DuckDB v2.0 `names` is a vector<Identifier>; the helper returns
+	// vector<string>, and promoting a runtime string to an Identifier is
+	// explicit by design, so the assignment is element-wise.
+	CompatAssignNames(names, UnifiedASTBackend::GetFlatDynamicTableColumnNames(extraction_config));
 
 	// Use the new ExtractionConfig constructor
 	return make_uniq<ReadASTStreamingBindData>(file_patterns, language, ignore_errors, extraction_config, batch_size);
@@ -427,7 +439,7 @@ static void ReadASTFlatStreamingFunction(ClientContext &context, TableFunctionIn
 // Hierarchical bind function for two-argument version (explicit language)
 static unique_ptr<FunctionData> ReadASTHierarchicalBindTwoArg(ClientContext &context, TableFunctionBindInput &input,
                                                               vector<LogicalType> &return_types,
-                                                              vector<string> &names) {
+                                                              vector<CompatName> &names) {
 	if (input.inputs.size() != 2) {
 		throw BinderException("read_ast requires exactly 2 arguments: file_path and language");
 	}
@@ -477,7 +489,10 @@ static unique_ptr<FunctionData> ReadASTHierarchicalBindTwoArg(ClientContext &con
 
 	// Use hierarchical backend schema for structured access
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
-	names = UnifiedASTBackend::GetHierarchicalTableColumnNames();
+	// On DuckDB v2.0 `names` is a vector<Identifier>; the helper returns
+	// vector<string>, and promoting a runtime string to an Identifier is
+	// explicit by design, so the assignment is element-wise.
+	CompatAssignNames(names, UnifiedASTBackend::GetHierarchicalTableColumnNames());
 
 	return make_uniq<ReadASTStreamingBindData>(file_patterns, language, ignore_errors, peek_size, peek_mode,
 	                                           batch_size);
@@ -486,7 +501,7 @@ static unique_ptr<FunctionData> ReadASTHierarchicalBindTwoArg(ClientContext &con
 // Hierarchical bind function for one-argument version (auto-detect language)
 static unique_ptr<FunctionData> ReadASTHierarchicalBindOneArg(ClientContext &context, TableFunctionBindInput &input,
                                                               vector<LogicalType> &return_types,
-                                                              vector<string> &names) {
+                                                              vector<CompatName> &names) {
 	if (input.inputs.size() != 1) {
 		throw BinderException("read_ast requires exactly 1 argument: file_path");
 	}
@@ -538,7 +553,10 @@ static unique_ptr<FunctionData> ReadASTHierarchicalBindOneArg(ClientContext &con
 
 	// Use hierarchical backend schema for structured access
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
-	names = UnifiedASTBackend::GetHierarchicalTableColumnNames();
+	// On DuckDB v2.0 `names` is a vector<Identifier>; the helper returns
+	// vector<string>, and promoting a runtime string to an Identifier is
+	// explicit by design, so the assignment is element-wise.
+	CompatAssignNames(names, UnifiedASTBackend::GetHierarchicalTableColumnNames());
 
 	return make_uniq<ReadASTStreamingBindData>(file_patterns, language, ignore_errors, peek_size, peek_mode,
 	                                           batch_size);
@@ -715,7 +733,7 @@ static TableFunction GetReadASTStreamingFunctionOneArg() {
 static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindTwoArg(ClientContext &context,
                                                                        TableFunctionBindInput &input,
                                                                        vector<LogicalType> &return_types,
-                                                                       vector<string> &names) {
+                                                                       vector<CompatName> &names) {
 	if (input.inputs.size() != 2) {
 		throw BinderException("read_ast requires exactly 2 arguments: file_path and language");
 	}
@@ -745,10 +763,13 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindTwoArg(ClientCon
 	// Check for duplicate parameters (following DuckDB YAML extension pattern)
 	std::unordered_set<std::string> seen_parameters;
 	for (auto &param : input.named_parameters) {
-		if (seen_parameters.find(param.first) != seen_parameters.end()) {
-			throw BinderException("Duplicate parameter name: " + param.first);
+		// param.first is an Identifier on DuckDB v2.0 (a string on v1.5);
+		// seen_parameters is a plain set of strings, so convert at the boundary.
+		const auto param_name = CompatNameStr(param.first);
+		if (seen_parameters.find(param_name) != seen_parameters.end()) {
+			throw BinderException("Duplicate parameter name: " + param_name);
 		}
-		seen_parameters.insert(param.first);
+		seen_parameters.insert(param_name);
 	}
 
 	// Parse optional named parameters
@@ -831,7 +852,10 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindTwoArg(ClientCon
 
 	// Use hierarchical backend schema
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
-	names = UnifiedASTBackend::GetHierarchicalTableColumnNames();
+	// On DuckDB v2.0 `names` is a vector<Identifier>; the helper returns
+	// vector<string>, and promoting a runtime string to an Identifier is
+	// explicit by design, so the assignment is element-wise.
+	CompatAssignNames(names, UnifiedASTBackend::GetHierarchicalTableColumnNames());
 
 	// Use the new ExtractionConfig constructor
 	return make_uniq<ReadASTStreamingBindData>(file_patterns, language, ignore_errors, extraction_config, batch_size);
@@ -841,7 +865,7 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindTwoArg(ClientCon
 static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindOneArg(ClientContext &context,
                                                                        TableFunctionBindInput &input,
                                                                        vector<LogicalType> &return_types,
-                                                                       vector<string> &names) {
+                                                                       vector<CompatName> &names) {
 	if (input.inputs.size() != 1) {
 		throw BinderException("read_ast requires exactly 1 argument: file_path");
 	}
@@ -870,10 +894,13 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindOneArg(ClientCon
 	// Check for duplicate parameters (following DuckDB YAML extension pattern)
 	std::unordered_set<std::string> seen_parameters;
 	for (auto &param : input.named_parameters) {
-		if (seen_parameters.find(param.first) != seen_parameters.end()) {
-			throw BinderException("Duplicate parameter name: " + param.first);
+		// param.first is an Identifier on DuckDB v2.0 (a string on v1.5);
+		// seen_parameters is a plain set of strings, so convert at the boundary.
+		const auto param_name = CompatNameStr(param.first);
+		if (seen_parameters.find(param_name) != seen_parameters.end()) {
+			throw BinderException("Duplicate parameter name: " + param_name);
 		}
-		seen_parameters.insert(param.first);
+		seen_parameters.insert(param_name);
 	}
 
 	// Parse optional named parameters
@@ -959,7 +986,10 @@ static unique_ptr<FunctionData> ReadASTHierarchicalStreamingBindOneArg(ClientCon
 
 	// Use hierarchical backend schema
 	return_types = UnifiedASTBackend::GetHierarchicalTableSchema();
-	names = UnifiedASTBackend::GetHierarchicalTableColumnNames();
+	// On DuckDB v2.0 `names` is a vector<Identifier>; the helper returns
+	// vector<string>, and promoting a runtime string to an Identifier is
+	// explicit by design, so the assignment is element-wise.
+	CompatAssignNames(names, UnifiedASTBackend::GetHierarchicalTableColumnNames());
 
 	// Use the new ExtractionConfig constructor
 	return make_uniq<ReadASTStreamingBindData>(file_patterns, language, ignore_errors, extraction_config, batch_size);

--- a/src/register_language_function.cpp
+++ b/src/register_language_function.cpp
@@ -1,5 +1,6 @@
 #include "ast_file_utils.hpp"
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -38,7 +39,7 @@ static bool IsValidLanguageName(const string &name) {
 }
 
 static unique_ptr<FunctionData> RegisterLanguageBind(ClientContext &context, TableFunctionBindInput &input,
-                                                     vector<LogicalType> &return_types, vector<string> &names) {
+                                                     vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
 		throw BinderException("register_language: name and library path cannot be NULL");
 	}
@@ -50,7 +51,7 @@ static unique_ptr<FunctionData> RegisterLanguageBind(ClientContext &context, Tab
 
 	for (auto &kv : input.named_parameters) {
 		if (kv.second.IsNull()) {
-			throw BinderException("register_language: %s cannot be NULL", kv.first);
+			throw BinderException("register_language: %s cannot be NULL", CompatNameStr(kv.first));
 		}
 		if (kv.first == "config") {
 			result->config_path = kv.second.GetValue<string>();

--- a/src/register_language_function.cpp
+++ b/src/register_language_function.cpp
@@ -100,7 +100,10 @@ static unique_ptr<GlobalTableFunctionState> RegisterLanguageInit(ClientContext &
 static void RegisterLanguageFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &state = data_p.global_state->Cast<RegisterLanguageGlobalState>();
 	if (state.done) {
-		output.SetCardinality(0);
+		// CompatSetOutputCardinality, not DataChunk::SetCardinality: on DuckDB
+		// v2.0 the per-vector sizes must be set too (SetChildCardinality). Same
+		// call as SetCardinality on the pinned v1.5.
+		CompatSetOutputCardinality(output, 0);
 		return;
 	}
 	state.done = true;
@@ -176,7 +179,7 @@ static void RegisterLanguageFunction(ClientContext &context, TableFunctionInput 
 	output.SetValue(1, 0, Value::INTEGER(static_cast<int32_t>(abi_version)));
 	output.SetValue(2, 0, Value::INTEGER(node_type_count));
 	output.SetValue(3, 0, Value("registered"));
-	output.SetCardinality(1);
+	CompatSetOutputCardinality(output, 1);
 }
 
 void RegisterLanguageRegistrationFunction(ExtensionLoader &loader) {

--- a/src/semantic_type_codes_function.cpp
+++ b/src/semantic_type_codes_function.cpp
@@ -16,7 +16,7 @@ struct SemanticTypeCodesGlobalState : public GlobalTableFunctionState {
 };
 
 static unique_ptr<FunctionData> SemanticTypeCodesBind(ClientContext &context, TableFunctionBindInput &input,
-                                                      vector<LogicalType> &return_types, vector<string> &names) {
+                                                      vector<LogicalType> &return_types, vector<CompatName> &names) {
 	return_types = {
 	    LogicalType::UTINYINT, // code
 	    LogicalType::VARCHAR,  // super_kind_name
@@ -46,11 +46,11 @@ static void SemanticTypeCodesFunction(ClientContext &context, TableFunctionInput
 	idx_t output_count = 0;
 
 	// Get output vectors
-	auto code_vec = FlatVector::GetData<uint8_t>(output.data[0]);
-	auto super_kind_vec = FlatVector::GetData<string_t>(output.data[1]);
-	auto kind_vec = FlatVector::GetData<string_t>(output.data[2]);
-	auto super_type_vec = FlatVector::GetData<string_t>(output.data[3]);
-	auto full_name_vec = FlatVector::GetData<string_t>(output.data[4]);
+	auto code_vec = CompatFlatDataMutable<uint8_t>(output.data[0]);
+	auto super_kind_vec = CompatFlatDataMutable<string_t>(output.data[1]);
+	auto kind_vec = CompatFlatDataMutable<string_t>(output.data[2]);
+	auto super_type_vec = CompatFlatDataMutable<string_t>(output.data[3]);
+	auto full_name_vec = CompatFlatDataMutable<string_t>(output.data[4]);
 
 	while (output_count < STANDARD_VECTOR_SIZE && global_state.current_code <= 252) {
 		uint8_t code = global_state.current_code;

--- a/src/semantic_type_functions.cpp
+++ b/src/semantic_type_functions.cpp
@@ -477,7 +477,7 @@ static void StringContainsAnyFunction(DataChunk &args, ExpressionState &state, V
 	auto patterns_child_entries = UnifiedVectorFormat::GetData<string_t>(patterns_child_data);
 
 	auto result_data = CompatFlatDataMutable<bool>(result);
-	auto &result_validity = FlatVector::Validity(result);
+	auto &result_validity = CompatFlatValidityMutable<>(result);
 
 	for (idx_t i = 0; i < count; i++) {
 		auto str_idx = str_data.sel->get_index(i);
@@ -533,7 +533,7 @@ static void StringContainsAnyIFunction(DataChunk &args, ExpressionState &state, 
 	auto patterns_child_entries = UnifiedVectorFormat::GetData<string_t>(patterns_child_data);
 
 	auto result_data = CompatFlatDataMutable<bool>(result);
-	auto &result_validity = FlatVector::Validity(result);
+	auto &result_validity = CompatFlatValidityMutable<>(result);
 
 	// Helper to convert string to lowercase
 	auto to_lower = [](const string &s) {

--- a/src/semantic_type_functions.cpp
+++ b/src/semantic_type_functions.cpp
@@ -476,7 +476,7 @@ static void StringContainsAnyFunction(DataChunk &args, ExpressionState &state, V
 	patterns_child.ToUnifiedFormat(ListVector::GetListSize(patterns_vector), patterns_child_data);
 	auto patterns_child_entries = UnifiedVectorFormat::GetData<string_t>(patterns_child_data);
 
-	auto result_data = FlatVector::GetData<bool>(result);
+	auto result_data = CompatFlatDataMutable<bool>(result);
 	auto &result_validity = FlatVector::Validity(result);
 
 	for (idx_t i = 0; i < count; i++) {
@@ -532,7 +532,7 @@ static void StringContainsAnyIFunction(DataChunk &args, ExpressionState &state, 
 	patterns_child.ToUnifiedFormat(ListVector::GetListSize(patterns_vector), patterns_child_data);
 	auto patterns_child_entries = UnifiedVectorFormat::GetData<string_t>(patterns_child_data);
 
-	auto result_data = FlatVector::GetData<bool>(result);
+	auto result_data = CompatFlatDataMutable<bool>(result);
 	auto &result_validity = FlatVector::Validity(result);
 
 	// Helper to convert string to lowercase
@@ -583,13 +583,13 @@ static void GetSearchableTypesFunction(DataChunk &args, ExpressionState &state, 
 
 	// Create a list value for each row
 	auto &list_vector = result;
-	auto list_entries = FlatVector::GetData<list_entry_t>(list_vector);
+	auto list_entries = CompatFlatDataMutable<list_entry_t>(list_vector);
 
 	// Create child vector to hold the semantic type values
 	auto list_size = searchable_types.size();
 	ListVector::Reserve(list_vector, list_size * count);
 	auto &child_vector = ListVector::GetEntry(list_vector);
-	auto child_data = FlatVector::GetData<uint8_t>(child_vector);
+	auto child_data = CompatFlatDataMutable<uint8_t>(child_vector);
 
 	idx_t offset = 0;
 	for (idx_t i = 0; i < count; i++) {

--- a/src/semantic_type_logical_type.cpp
+++ b/src/semantic_type_logical_type.cpp
@@ -11,9 +11,10 @@ static constexpr const char *SEMANTIC_TYPE_NAME = "SEMANTIC_TYPE";
 
 // Create the SEMANTIC_TYPE logical type (UTINYINT with alias)
 LogicalType SemanticTypeLogicalType() {
-	auto semantic_type = LogicalType(LogicalTypeId::UTINYINT);
-	semantic_type.SetAlias(SEMANTIC_TYPE_NAME);
-	return semantic_type;
+	// DuckDB v2.0 removed LogicalType::SetAlias (it mutated a type whose
+	// type-info may be shared) in favour of WithAlias, which returns a copy.
+	// CompatWithAlias picks whichever exists; the resulting type is identical.
+	return CompatWithAlias(LogicalType(LogicalTypeId::UTINYINT), SEMANTIC_TYPE_NAME);
 }
 
 // Check if a type is SEMANTIC_TYPE

--- a/src/unified_ast_backend.cpp
+++ b/src/unified_ast_backend.cpp
@@ -1,4 +1,5 @@
 #include "unified_ast_backend.hpp"
+#include "duckdb_compat.hpp"
 #include "unified_ast_backend_impl.hpp"
 #include "language_adapter.hpp"
 #include "semantic_types.hpp"
@@ -781,25 +782,25 @@ void UnifiedASTBackend::ProjectToTable(const ASTResult &result, DataChunk &outpu
 	//   14:scope (STRUCT) 15:peek 16:semantic_type 17:flags 18:qualified_name
 
 	// Get output vectors
-	auto node_id_vec = FlatVector::GetData<int64_t>(output.data[0]);
-	auto type_vec = FlatVector::GetData<string_t>(output.data[1]);
-	auto name_vec = FlatVector::GetData<string_t>(output.data[2]);
-	auto file_path_vec = FlatVector::GetData<string_t>(output.data[3]);
-	auto language_vec = FlatVector::GetData<string_t>(output.data[4]);
-	auto start_line_vec = FlatVector::GetData<uint32_t>(output.data[5]);
-	auto start_column_vec = FlatVector::GetData<uint32_t>(output.data[6]);
-	auto end_line_vec = FlatVector::GetData<uint32_t>(output.data[7]);
-	auto end_column_vec = FlatVector::GetData<uint32_t>(output.data[8]);
-	auto parent_id_vec = FlatVector::GetData<int64_t>(output.data[9]);
-	auto depth_vec = FlatVector::GetData<uint32_t>(output.data[10]);
-	auto sibling_index_vec = FlatVector::GetData<int32_t>(output.data[11]);
-	auto children_count_vec = FlatVector::GetData<uint32_t>(output.data[12]);
-	auto descendant_count_vec = FlatVector::GetData<uint32_t>(output.data[13]);
+	auto node_id_vec = CompatFlatDataMutable<int64_t>(output.data[0]);
+	auto type_vec = CompatFlatDataMutable<string_t>(output.data[1]);
+	auto name_vec = CompatFlatDataMutable<string_t>(output.data[2]);
+	auto file_path_vec = CompatFlatDataMutable<string_t>(output.data[3]);
+	auto language_vec = CompatFlatDataMutable<string_t>(output.data[4]);
+	auto start_line_vec = CompatFlatDataMutable<uint32_t>(output.data[5]);
+	auto start_column_vec = CompatFlatDataMutable<uint32_t>(output.data[6]);
+	auto end_line_vec = CompatFlatDataMutable<uint32_t>(output.data[7]);
+	auto end_column_vec = CompatFlatDataMutable<uint32_t>(output.data[8]);
+	auto parent_id_vec = CompatFlatDataMutable<int64_t>(output.data[9]);
+	auto depth_vec = CompatFlatDataMutable<uint32_t>(output.data[10]);
+	auto sibling_index_vec = CompatFlatDataMutable<int32_t>(output.data[11]);
+	auto children_count_vec = CompatFlatDataMutable<uint32_t>(output.data[12]);
+	auto descendant_count_vec = CompatFlatDataMutable<uint32_t>(output.data[13]);
 	// scope (col 14) is STRUCT<current, function, class, module, stack>; written via SetValue.
-	auto peek_vec = FlatVector::GetData<string_t>(output.data[15]);
+	auto peek_vec = CompatFlatDataMutable<string_t>(output.data[15]);
 	// Semantic type fields
-	auto semantic_type_vec = FlatVector::GetData<uint8_t>(output.data[16]);
-	auto flags_vec = FlatVector::GetData<uint8_t>(output.data[17]);
+	auto semantic_type_vec = CompatFlatDataMutable<uint8_t>(output.data[16]);
+	auto flags_vec = CompatFlatDataMutable<uint8_t>(output.data[17]);
 	// qualified_name is LIST<STRUCT>; written via SetValue, not a direct data pointer.
 
 	// Get validity masks for nullable fields
@@ -924,8 +925,8 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 	idx_t type_col = col_idx++;
 
 	// Get vectors for core columns (always present)
-	auto *node_id_vec = FlatVector::GetData<int64_t>(output.data[node_id_col]);
-	auto *type_vec = FlatVector::GetData<string_t>(output.data[type_col]);
+	auto *node_id_vec = CompatFlatDataMutable<int64_t>(output.data[node_id_col]);
+	auto *type_vec = CompatFlatDataMutable<string_t>(output.data[type_col]);
 
 	// Context columns based on schema_config.context (AGENT J FIX: Track indices)
 	idx_t semantic_type_col = 0, flags_col = 0, name_col = 0;
@@ -942,12 +943,12 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 		if (schema_config.context >= ContextLevel::NODE_TYPES_ONLY) {
 			semantic_type_col = col_idx++;
 			flags_col = col_idx++;
-			semantic_type_vec = FlatVector::GetData<uint8_t>(output.data[semantic_type_col]);
-			flags_vec = FlatVector::GetData<uint8_t>(output.data[flags_col]);
+			semantic_type_vec = CompatFlatDataMutable<uint8_t>(output.data[semantic_type_col]);
+			flags_vec = CompatFlatDataMutable<uint8_t>(output.data[flags_col]);
 		}
 		if (schema_config.context >= ContextLevel::NORMALIZED) {
 			name_col = col_idx++;
-			name_vec = FlatVector::GetData<string_t>(output.data[name_col]);
+			name_vec = CompatFlatDataMutable<string_t>(output.data[name_col]);
 			qualified_name_col = col_idx++;
 			have_qualified_name_col = true;
 		}
@@ -965,8 +966,8 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 		parameters_col = col_idx++;
 		modifiers_col = col_idx++;
 		annotations_col = col_idx++;
-		signature_type_vec = FlatVector::GetData<string_t>(output.data[signature_type_col]);
-		annotations_vec = FlatVector::GetData<string_t>(output.data[annotations_col]);
+		signature_type_vec = CompatFlatDataMutable<string_t>(output.data[signature_type_col]);
+		annotations_vec = CompatFlatDataMutable<string_t>(output.data[annotations_col]);
 		signature_type_validity = &FlatVector::Validity(output.data[signature_type_col]);
 		annotations_validity = &FlatVector::Validity(output.data[annotations_col]);
 		// Note: parameters and modifiers columns are LIST types, handled separately
@@ -985,21 +986,21 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 	if (schema_config.source != SourceLevel::NONE) {
 		file_path_col = col_idx++;
 		language_col = col_idx++;
-		file_path_vec = FlatVector::GetData<string_t>(output.data[file_path_col]);
-		language_vec = FlatVector::GetData<string_t>(output.data[language_col]);
+		file_path_vec = CompatFlatDataMutable<string_t>(output.data[file_path_col]);
+		language_vec = CompatFlatDataMutable<string_t>(output.data[language_col]);
 
 		if (schema_config.source >= SourceLevel::LINES_ONLY) {
 			start_line_col = col_idx++;
 			end_line_col = col_idx++;
-			start_line_vec = FlatVector::GetData<uint32_t>(output.data[start_line_col]);
-			end_line_vec = FlatVector::GetData<uint32_t>(output.data[end_line_col]);
+			start_line_vec = CompatFlatDataMutable<uint32_t>(output.data[start_line_col]);
+			end_line_vec = CompatFlatDataMutable<uint32_t>(output.data[end_line_col]);
 		}
 
 		if (schema_config.source >= SourceLevel::FULL) {
 			start_column_col = col_idx++;
 			end_column_col = col_idx++;
-			start_column_vec = FlatVector::GetData<uint32_t>(output.data[start_column_col]);
-			end_column_vec = FlatVector::GetData<uint32_t>(output.data[end_column_col]);
+			start_column_vec = CompatFlatDataMutable<uint32_t>(output.data[start_column_col]);
+			end_column_vec = CompatFlatDataMutable<uint32_t>(output.data[end_column_col]);
 		}
 	}
 
@@ -1018,9 +1019,9 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 		if (schema_config.structure >= StructureLevel::MINIMAL) {
 			parent_id_col = col_idx++;
 			depth_col = col_idx++;
-			parent_id_vec = FlatVector::GetData<int64_t>(output.data[parent_id_col]);
+			parent_id_vec = CompatFlatDataMutable<int64_t>(output.data[parent_id_col]);
 			parent_validity = &FlatVector::Validity(output.data[parent_id_col]);
-			depth_vec = FlatVector::GetData<uint32_t>(output.data[depth_col]);
+			depth_vec = CompatFlatDataMutable<uint32_t>(output.data[depth_col]);
 		}
 
 		if (schema_config.structure >= StructureLevel::FULL) {
@@ -1028,9 +1029,9 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 			children_count_col = col_idx++;
 			descendant_count_col = col_idx++;
 			scope_col = col_idx++;
-			sibling_index_vec = FlatVector::GetData<int32_t>(output.data[sibling_index_col]);
-			children_count_vec = FlatVector::GetData<uint32_t>(output.data[children_count_col]);
-			descendant_count_vec = FlatVector::GetData<uint32_t>(output.data[descendant_count_col]);
+			sibling_index_vec = CompatFlatDataMutable<int32_t>(output.data[sibling_index_col]);
+			children_count_vec = CompatFlatDataMutable<uint32_t>(output.data[children_count_col]);
+			descendant_count_vec = CompatFlatDataMutable<uint32_t>(output.data[descendant_count_col]);
 			has_scope_col = true;
 		}
 	}
@@ -1042,7 +1043,7 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 
 	if (schema_config.peek != PeekLevel::NONE) {
 		peek_col = col_idx++;
-		peek_vec = FlatVector::GetData<string_t>(output.data[peek_col]);
+		peek_vec = CompatFlatDataMutable<string_t>(output.data[peek_col]);
 		peek_validity = &FlatVector::Validity(output.data[peek_col]);
 	}
 
@@ -1109,9 +1110,9 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 						                            std::move(param_structs)));
 
 						// Same for modifiers
-						auto modifiers_list_data = FlatVector::GetData<list_entry_t>(output.data[modifiers_col]);
+						auto modifiers_list_data = CompatFlatDataMutable<list_entry_t>(output.data[modifiers_col]);
 						auto &modifiers_child = ListVector::GetEntry(output.data[modifiers_col]);
-						auto modifiers_child_data = FlatVector::GetData<string_t>(modifiers_child);
+						auto modifiers_child_data = CompatFlatDataMutable<string_t>(modifiers_child);
 
 						modifiers_list_data[count].offset = ListVector::GetListSize(output.data[modifiers_col]);
 						modifiers_list_data[count].length = node.native.modifiers.size();
@@ -1121,7 +1122,7 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 							if (child_idx >= ListVector::GetListCapacity(output.data[modifiers_col])) {
 								ListVector::Reserve(output.data[modifiers_col], (child_idx + 1) * 2);
 								modifiers_child_data =
-								    FlatVector::GetData<string_t>(ListVector::GetEntry(output.data[modifiers_col]));
+								    CompatFlatDataMutable<string_t>(ListVector::GetEntry(output.data[modifiers_col]));
 							}
 							modifiers_child_data[child_idx] =
 							    StringVector::AddString(modifiers_child, node.native.modifiers[i]);
@@ -1142,8 +1143,8 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 						annotations_validity->SetInvalid(count);
 
 						// For LIST types, create empty lists with proper indexing
-						auto list_data = FlatVector::GetData<list_entry_t>(output.data[parameters_col]);
-						auto modifiers_list_data = FlatVector::GetData<list_entry_t>(output.data[modifiers_col]);
+						auto list_data = CompatFlatDataMutable<list_entry_t>(output.data[parameters_col]);
+						auto modifiers_list_data = CompatFlatDataMutable<list_entry_t>(output.data[modifiers_col]);
 
 						// Set empty list entries for both parameters and modifiers
 						list_data[count].offset = ListVector::GetListSize(output.data[parameters_col]);
@@ -1158,8 +1159,8 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 					annotations_validity->SetInvalid(count);
 
 					// For LIST types, create empty lists with proper indexing
-					auto list_data = FlatVector::GetData<list_entry_t>(output.data[parameters_col]);
-					auto modifiers_list_data = FlatVector::GetData<list_entry_t>(output.data[modifiers_col]);
+					auto list_data = CompatFlatDataMutable<list_entry_t>(output.data[parameters_col]);
+					auto modifiers_list_data = CompatFlatDataMutable<list_entry_t>(output.data[modifiers_col]);
 
 					list_data[count].offset = ListVector::GetListSize(output.data[parameters_col]);
 					list_data[count].length = 0;
@@ -1343,12 +1344,12 @@ void UnifiedASTBackend::ProjectToHierarchicalTable(const ASTResult &result, Data
 	}
 
 	// Get output vectors for hierarchical schema: node_id, type, source, structure, context, peek
-	auto node_id_vec = FlatVector::GetData<int64_t>(output.data[0]);
-	auto type_vec = FlatVector::GetData<string_t>(output.data[1]);
+	auto node_id_vec = CompatFlatDataMutable<int64_t>(output.data[0]);
+	auto type_vec = CompatFlatDataMutable<string_t>(output.data[1]);
 	auto &source_vector = output.data[2];    // STRUCT column
 	auto &structure_vector = output.data[3]; // STRUCT column
 	auto &context_vector = output.data[4];   // STRUCT column
-	auto peek_vec = FlatVector::GetData<string_t>(output.data[5]);
+	auto peek_vec = CompatFlatDataMutable<string_t>(output.data[5]);
 
 	// Get validity masks
 	auto &peek_validity = FlatVector::Validity(output.data[5]);
@@ -1376,7 +1377,7 @@ void UnifiedASTBackend::ProjectToHierarchicalTable(const ASTResult &result, Data
 		source_values.push_back(make_pair("end_line", Value::UINTEGER(node.end_line)));
 		source_values.push_back(make_pair("end_column", Value::UINTEGER(node.end_column)));
 		Value source_struct = Value::STRUCT(source_values);
-		FlatVector::GetData<Value>(source_vector)[row_idx] = source_struct;
+		CompatFlatDataMutable<Value>(source_vector)[row_idx] = source_struct;
 
 		// Create structure STRUCT (use legacy fields for now)
 		child_list_t<Value> structure_values;
@@ -1391,7 +1392,7 @@ void UnifiedASTBackend::ProjectToHierarchicalTable(const ASTResult &result, Data
 		structure_values.push_back(make_pair("descendant_count", Value::UINTEGER(node.legacy_descendant_count)));
 		structure_values.push_back(make_pair("scope", ScopeValue(node.scope)));
 		Value structure_struct = Value::STRUCT(structure_values);
-		FlatVector::GetData<Value>(structure_vector)[row_idx] = structure_struct;
+		CompatFlatDataMutable<Value>(structure_vector)[row_idx] = structure_struct;
 
 		// Create context STRUCT (use legacy fields for now)
 		child_list_t<Value> context_values;
@@ -1405,7 +1406,7 @@ void UnifiedASTBackend::ProjectToHierarchicalTable(const ASTResult &result, Data
 		context_values.push_back(make_pair("semantic_type", Value::UTINYINT(node.semantic_type)));
 		context_values.push_back(make_pair("flags", Value::UTINYINT(node.universal_flags)));
 		Value context_struct = Value::STRUCT(context_values);
-		FlatVector::GetData<Value>(context_vector)[row_idx] = context_struct;
+		CompatFlatDataMutable<Value>(context_vector)[row_idx] = context_struct;
 
 		// Content Preview
 		if (!node.peek.empty()) {
@@ -1544,9 +1545,9 @@ void UnifiedASTBackend::ProjectToHierarchicalTableStreaming(const vector<ASTNode
 	// PASS 2: Build all DuckDB vectors using collected data (SAFE - no interference)
 
 	// Get output vectors for new 6-column schema: node_id, type, source, structure, context, peek
-	auto node_id_vec = FlatVector::GetData<int64_t>(output.data[0]);
-	auto type_vec = FlatVector::GetData<string_t>(output.data[1]);
-	auto peek_vec = FlatVector::GetData<string_t>(output.data[5]);
+	auto node_id_vec = CompatFlatDataMutable<int64_t>(output.data[0]);
+	auto type_vec = CompatFlatDataMutable<string_t>(output.data[1]);
+	auto peek_vec = CompatFlatDataMutable<string_t>(output.data[5]);
 	auto &peek_validity = FlatVector::Validity(output.data[5]);
 
 	// Get STRUCT child vectors using StructVector::GetEntries()
@@ -1555,44 +1556,44 @@ void UnifiedASTBackend::ProjectToHierarchicalTableStreaming(const vector<ASTNode
 	auto &context_entries = StructVector::GetEntries(output.data[4]);
 
 	// Source STRUCT child vectors
-	auto source_file_path_vec = FlatVector::GetData<string_t>(*source_entries[0]);
-	auto source_language_vec = FlatVector::GetData<string_t>(*source_entries[1]);
-	auto source_start_line_vec = FlatVector::GetData<uint32_t>(*source_entries[2]);
-	auto source_start_column_vec = FlatVector::GetData<uint32_t>(*source_entries[3]);
-	auto source_end_line_vec = FlatVector::GetData<uint32_t>(*source_entries[4]);
-	auto source_end_column_vec = FlatVector::GetData<uint32_t>(*source_entries[5]);
+	auto source_file_path_vec = CompatFlatDataMutable<string_t>(CompatStructEntry(source_entries[0]));
+	auto source_language_vec = CompatFlatDataMutable<string_t>(CompatStructEntry(source_entries[1]));
+	auto source_start_line_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(source_entries[2]));
+	auto source_start_column_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(source_entries[3]));
+	auto source_end_line_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(source_entries[4]));
+	auto source_end_column_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(source_entries[5]));
 
 	// Structure STRUCT child vectors
-	auto structure_parent_id_vec = FlatVector::GetData<int64_t>(*structure_entries[0]);
-	auto &structure_parent_validity = FlatVector::Validity(*structure_entries[0]);
-	auto structure_depth_vec = FlatVector::GetData<uint32_t>(*structure_entries[1]);
-	auto structure_sibling_index_vec = FlatVector::GetData<int32_t>(*structure_entries[2]);
-	auto structure_children_count_vec = FlatVector::GetData<uint32_t>(*structure_entries[3]);
-	auto structure_descendant_count_vec = FlatVector::GetData<uint32_t>(*structure_entries[4]);
+	auto structure_parent_id_vec = CompatFlatDataMutable<int64_t>(CompatStructEntry(structure_entries[0]));
+	auto &structure_parent_validity = FlatVector::Validity(CompatStructEntry(structure_entries[0]));
+	auto structure_depth_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(structure_entries[1]));
+	auto structure_sibling_index_vec = CompatFlatDataMutable<int32_t>(CompatStructEntry(structure_entries[2]));
+	auto structure_children_count_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(structure_entries[3]));
+	auto structure_descendant_count_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(structure_entries[4]));
 	// structure_entries[5] is scope STRUCT<current, function, class, module, stack>;
 	// written via SetValue on the containing struct.
-	auto &structure_scope_vec = *structure_entries[5];
+	auto &structure_scope_vec = CompatStructEntry(structure_entries[5]);
 
 	// Context STRUCT child vectors
-	auto context_name_vec = FlatVector::GetData<string_t>(*context_entries[0]);
-	auto &context_name_validity = FlatVector::Validity(*context_entries[0]);
+	auto context_name_vec = CompatFlatDataMutable<string_t>(CompatStructEntry(context_entries[0]));
+	auto &context_name_validity = FlatVector::Validity(CompatStructEntry(context_entries[0]));
 	// qualified_name (context_entries[1]) is LIST<STRUCT>; written via SetValue.
-	auto context_semantic_type_vec = FlatVector::GetData<uint8_t>(*context_entries[2]);
-	auto context_flags_vec = FlatVector::GetData<uint8_t>(*context_entries[3]);
+	auto context_semantic_type_vec = CompatFlatDataMutable<uint8_t>(CompatStructEntry(context_entries[2]));
+	auto context_flags_vec = CompatFlatDataMutable<uint8_t>(CompatStructEntry(context_entries[3]));
 
 	// Native context STRUCT child vectors
-	auto &native_entries = StructVector::GetEntries(*context_entries[4]);
-	auto &native_validity = FlatVector::Validity(*context_entries[4]);
+	auto &native_entries = StructVector::GetEntries(CompatStructEntry(context_entries[4]));
+	auto &native_validity = FlatVector::Validity(CompatStructEntry(context_entries[4]));
 
 	// Get native field vectors
-	auto native_signature_type_vec = FlatVector::GetData<string_t>(*native_entries[0]);
-	auto &native_signature_type_validity = FlatVector::Validity(*native_entries[0]);
-	auto native_annotations_vec = FlatVector::GetData<string_t>(*native_entries[3]);
-	auto &native_annotations_validity = FlatVector::Validity(*native_entries[3]);
+	auto native_signature_type_vec = CompatFlatDataMutable<string_t>(CompatStructEntry(native_entries[0]));
+	auto &native_signature_type_validity = FlatVector::Validity(CompatStructEntry(native_entries[0]));
+	auto native_annotations_vec = CompatFlatDataMutable<string_t>(CompatStructEntry(native_entries[3]));
+	auto &native_annotations_validity = FlatVector::Validity(CompatStructEntry(native_entries[3]));
 
 	// Get ListVectors for separate processing - TODO: restore when implementing parameter/modifier arrays
-	// auto &parameters_list_vector = *native_entries[1];
-	// auto &modifiers_list_vector = *native_entries[2];
+	// auto &parameters_list_vector = CompatStructEntry(native_entries[1]);
+	// auto &modifiers_list_vector = CompatStructEntry(native_entries[2]);
 
 	// Process all collected rows - populate basic fields first
 	for (idx_t i = 0; i < collected_rows.size(); i++) {
@@ -1635,7 +1636,7 @@ void UnifiedASTBackend::ProjectToHierarchicalTableStreaming(const vector<ASTNode
 			context_name_validity.SetInvalid(row_idx);
 		}
 		// Qualified name (top-level context field, LIST<STRUCT<semantic_type, name, index>>)
-		context_entries[1]->SetValue(row_idx, QualifiedNameValue(row_data.qualified_name_segments));
+		CompatStructEntry(context_entries[1]).SetValue(row_idx, QualifiedNameValue(row_data.qualified_name_segments));
 		context_semantic_type_vec[row_idx] = row_data.semantic_type;
 		context_flags_vec[row_idx] = row_data.flags;
 
@@ -1999,19 +2000,21 @@ void UnifiedASTBackend::ResetStructVectorState(Vector &vector) {
 		// Get struct child vectors
 		auto &entries = StructVector::GetEntries(vector);
 
-		// Recursively reset each child vector
+		// Recursively reset each child vector.
+		// `entries[i]` is a unique_ptr<Vector> on v1.5 and a Vector on v2.0;
+		// CompatStructEntry yields the Vector& either way.
 		for (idx_t i = 0; i < entries.size(); i++) {
-			auto &entry = entries[i];
+			auto &entry = CompatStructEntry(entries[i]);
 
 			// Always set vector type for child vectors
-			entry->SetVectorType(VectorType::FLAT_VECTOR);
+			entry.SetVectorType(VectorType::FLAT_VECTOR);
 
-			if (entry->GetType().id() == LogicalTypeId::LIST) {
+			if (entry.GetType().id() == LogicalTypeId::LIST) {
 				// Get child vector to check its state
-				auto &list_child = ListVector::GetEntry(*entry);
+				auto &list_child = ListVector::GetEntry(entry);
 
 				// Try more aggressive reset - not just size but the underlying buffer
-				ListVector::SetListSize(*entry, 0);
+				ListVector::SetListSize(entry, 0);
 
 				// Force reset of the child vector data buffer completely
 				list_child.SetVectorType(VectorType::FLAT_VECTOR);
@@ -2021,9 +2024,9 @@ void UnifiedASTBackend::ResetStructVectorState(Vector &vector) {
 					ResetStructVectorState(list_child);
 				}
 
-			} else if (entry->GetType().id() == LogicalTypeId::STRUCT) {
+			} else if (entry.GetType().id() == LogicalTypeId::STRUCT) {
 				// Recursively reset nested struct vectors
-				ResetStructVectorState(*entry);
+				ResetStructVectorState(entry);
 			}
 			// For simple types, ensure they're flat vectors
 		}

--- a/src/unified_ast_backend.cpp
+++ b/src/unified_ast_backend.cpp
@@ -804,9 +804,9 @@ void UnifiedASTBackend::ProjectToTable(const ASTResult &result, DataChunk &outpu
 	// qualified_name is LIST<STRUCT>; written via SetValue, not a direct data pointer.
 
 	// Get validity masks for nullable fields
-	auto &name_validity = FlatVector::Validity(output.data[2]);
-	auto &parent_validity = FlatVector::Validity(output.data[9]);
-	auto &peek_validity = FlatVector::Validity(output.data[15]);
+	auto &name_validity = CompatFlatValidityMutable<>(output.data[2]);
+	auto &parent_validity = CompatFlatValidityMutable<>(output.data[9]);
+	auto &peek_validity = CompatFlatValidityMutable<>(output.data[15]);
 
 	idx_t count = 0;
 	idx_t max_count = STANDARD_VECTOR_SIZE;
@@ -968,8 +968,8 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 		annotations_col = col_idx++;
 		signature_type_vec = CompatFlatDataMutable<string_t>(output.data[signature_type_col]);
 		annotations_vec = CompatFlatDataMutable<string_t>(output.data[annotations_col]);
-		signature_type_validity = &FlatVector::Validity(output.data[signature_type_col]);
-		annotations_validity = &FlatVector::Validity(output.data[annotations_col]);
+		signature_type_validity = &CompatFlatValidityMutable<>(output.data[signature_type_col]);
+		annotations_validity = &CompatFlatValidityMutable<>(output.data[annotations_col]);
 		// Note: parameters and modifiers columns are LIST types, handled separately
 	}
 
@@ -1020,7 +1020,7 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 			parent_id_col = col_idx++;
 			depth_col = col_idx++;
 			parent_id_vec = CompatFlatDataMutable<int64_t>(output.data[parent_id_col]);
-			parent_validity = &FlatVector::Validity(output.data[parent_id_col]);
+			parent_validity = &CompatFlatValidityMutable<>(output.data[parent_id_col]);
 			depth_vec = CompatFlatDataMutable<uint32_t>(output.data[depth_col]);
 		}
 
@@ -1044,7 +1044,7 @@ void UnifiedASTBackend::ProjectToDynamicTable(const ASTResult &result, DataChunk
 	if (schema_config.peek != PeekLevel::NONE) {
 		peek_col = col_idx++;
 		peek_vec = CompatFlatDataMutable<string_t>(output.data[peek_col]);
-		peek_validity = &FlatVector::Validity(output.data[peek_col]);
+		peek_validity = &CompatFlatValidityMutable<>(output.data[peek_col]);
 	}
 
 	// Handle file_path and language per row (not as constant vectors)
@@ -1352,7 +1352,7 @@ void UnifiedASTBackend::ProjectToHierarchicalTable(const ASTResult &result, Data
 	auto peek_vec = CompatFlatDataMutable<string_t>(output.data[5]);
 
 	// Get validity masks
-	auto &peek_validity = FlatVector::Validity(output.data[5]);
+	auto &peek_validity = CompatFlatValidityMutable<>(output.data[5]);
 
 	idx_t count = 0;
 	idx_t max_count = STANDARD_VECTOR_SIZE;
@@ -1548,7 +1548,7 @@ void UnifiedASTBackend::ProjectToHierarchicalTableStreaming(const vector<ASTNode
 	auto node_id_vec = CompatFlatDataMutable<int64_t>(output.data[0]);
 	auto type_vec = CompatFlatDataMutable<string_t>(output.data[1]);
 	auto peek_vec = CompatFlatDataMutable<string_t>(output.data[5]);
-	auto &peek_validity = FlatVector::Validity(output.data[5]);
+	auto &peek_validity = CompatFlatValidityMutable<>(output.data[5]);
 
 	// Get STRUCT child vectors using StructVector::GetEntries()
 	auto &source_entries = StructVector::GetEntries(output.data[2]);
@@ -1565,7 +1565,7 @@ void UnifiedASTBackend::ProjectToHierarchicalTableStreaming(const vector<ASTNode
 
 	// Structure STRUCT child vectors
 	auto structure_parent_id_vec = CompatFlatDataMutable<int64_t>(CompatStructEntry(structure_entries[0]));
-	auto &structure_parent_validity = FlatVector::Validity(CompatStructEntry(structure_entries[0]));
+	auto &structure_parent_validity = CompatFlatValidityMutable<>(CompatStructEntry(structure_entries[0]));
 	auto structure_depth_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(structure_entries[1]));
 	auto structure_sibling_index_vec = CompatFlatDataMutable<int32_t>(CompatStructEntry(structure_entries[2]));
 	auto structure_children_count_vec = CompatFlatDataMutable<uint32_t>(CompatStructEntry(structure_entries[3]));
@@ -1576,20 +1576,20 @@ void UnifiedASTBackend::ProjectToHierarchicalTableStreaming(const vector<ASTNode
 
 	// Context STRUCT child vectors
 	auto context_name_vec = CompatFlatDataMutable<string_t>(CompatStructEntry(context_entries[0]));
-	auto &context_name_validity = FlatVector::Validity(CompatStructEntry(context_entries[0]));
+	auto &context_name_validity = CompatFlatValidityMutable<>(CompatStructEntry(context_entries[0]));
 	// qualified_name (context_entries[1]) is LIST<STRUCT>; written via SetValue.
 	auto context_semantic_type_vec = CompatFlatDataMutable<uint8_t>(CompatStructEntry(context_entries[2]));
 	auto context_flags_vec = CompatFlatDataMutable<uint8_t>(CompatStructEntry(context_entries[3]));
 
 	// Native context STRUCT child vectors
 	auto &native_entries = StructVector::GetEntries(CompatStructEntry(context_entries[4]));
-	auto &native_validity = FlatVector::Validity(CompatStructEntry(context_entries[4]));
+	auto &native_validity = CompatFlatValidityMutable<>(CompatStructEntry(context_entries[4]));
 
 	// Get native field vectors
 	auto native_signature_type_vec = CompatFlatDataMutable<string_t>(CompatStructEntry(native_entries[0]));
-	auto &native_signature_type_validity = FlatVector::Validity(CompatStructEntry(native_entries[0]));
+	auto &native_signature_type_validity = CompatFlatValidityMutable<>(CompatStructEntry(native_entries[0]));
 	auto native_annotations_vec = CompatFlatDataMutable<string_t>(CompatStructEntry(native_entries[3]));
-	auto &native_annotations_validity = FlatVector::Validity(CompatStructEntry(native_entries[3]));
+	auto &native_annotations_validity = CompatFlatValidityMutable<>(CompatStructEntry(native_entries[3]));
 
 	// Get ListVectors for separate processing - TODO: restore when implementing parameter/modifier arrays
 	// auto &parameters_list_vector = CompatStructEntry(native_entries[1]);


### PR DESCRIPTION
## What

Make sitting_duck compile against **both** its pinned DuckDB (v1.5.4, what it
ships) and DuckDB `main` (the v2.0 line). This is source compatibility, not a
migration — the pinned submodule does not move and shipped behaviour does not
change.

`duckdb/community-extensions` builds every release PR against `v2.0-cyanoptera`
via `build_next.yml`, triggered by exactly the `description.yml` change that
every release PR makes, with no per-extension opt-out. An extension that does
not build there has a red check on every release.

## How

Every difference is selected by a **feature probe** — `__has_include`, member
detection, or asking DuckDB for its own type — never a version macro, and each
change is probed **separately** so a backport or revert of one does not silently
pick the wrong branch for another.

`CompatName` is worth singling out, because the obvious probe is a time bomb.
`__has_include("duckdb/common/identifier.hpp")` is correct *today* only because
our pin predates a backport: that header is already on `v1.5-variegata`'s tip,
where binds still take `vector<string>`. Keying `CompatName` off it would flip it
to `Identifier` on the next submodule bump and break all 19 bind signatures at
once. So it is derived from DuckDB instead:

```cpp
using CompatName = typename std::remove_reference<decltype(
    std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
```

`input_table_names` has the same element type as the bind out-parameter on both
lines — `vector<string>` on the pin (`table_function.hpp:110` / `:288`),
`vector<Identifier>` on main (`:123` / `:319`). Asking DuckDB what its own name
type is cannot drift from the thing that actually changed.

`src/include/duckdb_compat.hpp` keeps all of its existing helpers — several
translation units call `CompatUnaryExecuteWithNulls`,
`CompatSetOutputCardinality` and `SetValueCasted` by name — and gains the v2.0
shims. It is dispatched by tag, not `if constexpr`: this extension compiles its
TUs at **C++11** on Linux on purpose (see the note in `CMakeLists.txt` about
static-const members acquiring implicit inline linkage in one set of TUs and not
the other).

| shim | change it covers |
|---|---|
| `CompatName` / `CompatNameStr` / `CompatMakeName` / `CompatAssignNames` | `Identifier` replaced `string` in bind signatures |
| `CompatWithAlias` | `LogicalType::SetAlias` removed in favour of `WithAlias` |
| `CompatFlatDataMutable` | `FlatVector::GetData<T>` is const-only; writes need `GetDataMutable<T>` |
| `CompatStructEntry` / `CompatStructGetField` | `StructVector::GetEntries` yields `vector<Vector>`, was `vector<unique_ptr<Vector>>` |
| `CompatBoundBindInfo`, `DUCKDB_SCALAR_BIND_PARAMS/_CONTEXT/_ARGS` | `BoundFunctionExpression::bind_info` private; scalar bind signature collapsed |
| `CompatConstantValue`, `CompatFunctionName`, `CompatFunctionArgExprs`, `CompatComparisonLeft/Right`, `CompatConjunctionChildren` | parser expression hierarchy closed its data members |
| `CompatFlatValidityMutable` | `FlatVector::Validity` got the same const split as `GetData` |
| file-local shims in `duckdb_adapter.cpp` | `CreateInfo` & friends moved entry names behind a `QualifiedName` |

`SetFallible()` is called **directly**, not shimmed: it exists identically on the
pin (`function.hpp:211`) and on main. It is applied to `parse_ast_list` only —
the extension's one scalar function that can throw at execution — rather than
blanket-applied, because `errors` is not inert on v1.5 either: it feeds
`CanThrow()`, which gates conjunct reordering, filter pushdown and dictionary
caching.

Two of these are more than renames and are worth a second look in review:

* **`FunctionExpression`** on v2.0 holds named `FunctionArgument`s rather than
  bare child expressions, so `CompatFunctionArgExprs` returns a vector of raw
  pointers rather than trying to expose either container shape.
* **`CompatStructEntry`** is resolved by plain **overload resolution**, not a
  probe — `Vector&` and `const unique_ptr<Vector>&` are distinguishable, and an
  overload cannot get its polarity backwards the way a probe can.

`CompatWithAlias`'s entry point is deliberately a non-template taking a concrete
`LogicalType`. A `template <class TYPE = LogicalType>` entry point looks
equivalent but is not: the default argument is inert when deduction succeeds, so
`CompatWithAlias(LogicalType::VARCHAR, "x")` would deduce `TYPE = LogicalTypeId`
(`LogicalType::VARCHAR` is a `static constexpr LogicalTypeId`) and hard-error.

## Deliberately not ported

These are `[[deprecated]]` on `main` but **still present**, so porting them costs
effort and buys nothing (verified against the headers on
`raw.githubusercontent.com/duckdb/duckdb/main`):

`Vector::ToUnifiedFormat(count, data)`, `DataChunk::SetCardinality`,
`DataChunk::SetValue`, `Vector::Flatten(count)`, `ListVector::GetEntry`
(which forwards to `GetChildMutable`, so writes through it are still correct).

The existing `CompatUnary/BinaryExecuteWithNulls` call sites are untouched. Their
v2.0 path routes through `UnaryExecutor::Execute`'s optional-returning overload,
which is the correct replacement — a hand-rolled loop would write a *value* on
null rows where `ExecuteWithNulls` left them NULL.

## One real bug found on the way

`register_language()` set its output cardinality with
`DataChunk::SetCardinality` while every other table function in the extension
already used `CompatSetOutputCardinality`. On v2.0 that skips the per-vector size
tracking (`SetChildCardinality`). Identical call on the pinned v1.5, so no
behaviour change ships; it is a latent v2.0-only defect that the canary would not
have caught, since the `register_language` tests are gated behind
`SITTING_DUCK_TEST_GRAMMAR_DIR`.

## Canary

The `duckdb-next-build` job was `if: false`. It is now gated on
`workflow_dispatch` or a push to `main`, so it can be driven on demand:

```
gh workflow run MainDistributionPipeline.yml --ref <branch>
```

It must not run on `pull_request` — a push and a PR both fire on the same commit
and a PR's check rollup includes both, so an ungated canary is red on every PR.
`if:` and not `continue-on-error:`: a job calling a *reusable* workflow accepts
only a fixed key set, and the extra key makes the whole workflow fail to parse.

## Verification

**Pinned v1.5.4 (what ships):** built from the pinned submodule and ran the full
suite after every batch — `All tests passed (4 skipped, 6508 assertions in 114
test cases)`. The 4 skips are the pre-existing `require-env
SITTING_DUCK_TEST_GRAMMAR_DIR` gate. Behaviour on the version this extension
actually ships does not move.

**DuckDB main (v2.0):** verified by the canary.

The first canary round is worth stating precisely, because it says where the risk
is concentrated: it reported **exactly seven errors, all in one file** —
`src/language_adapters/duckdb_adapter.cpp`, the only code here that walks
DuckDB's *own* parse tree. Every other translation unit compiled.

One of those seven was load-bearing beyond itself, and is the reason this branch
changes more of that adapter than the canary asked for. `duckdb_adapter.hpp`
declared `ConvertCreateStatement(const CreateStatement &)` without including
`create_statement.hpp` — available transitively on v1.5, not on main. The
out-of-class definition then matched no declaration, so GCC **discarded the
function and never type-checked its body**. That body contains seven further
`CreateInfo` name-field accesses that are all broken on v2.0 and produced zero
diagnostics. They are fixed here from reading main's headers, not because a build
named them. A `no declaration matches` error is worth treating as "this whole
function is unchecked", not as one error.

**Format:** checked against the repo's own clang-format 11.0.1 rather than
assumed. Every file this branch touches is format-clean. `duckdb_compat.hpp`
reports one drifting hunk — but the same hunk drifts identically on `main`, so it
predates this branch and is not mine; it is left alone rather than reformatted,
so the diff stays reviewable.

## One thing that is intentionally not verified

`src/ast_helper_functions.cpp` is updated for consistency but is **not** in
`EXTENSION_SOURCES`, so nothing here compiles it. (It does not compile on `main`
either, for reasons that predate this branch: `ASTNode` has no `type` or `name`
member.) Its changes are signature-only.
