### PR TITLE
duck_blocks: sync vendored vocabulary + conformance to 6.5 (PR duck_block_utils#26)

### DIFF
--- a/test/sql/duck_blocks_conformance.test
+++ b/test/sql/duck_blocks_conformance.test
@@ -5,7 +5,7 @@
 # Runs the duck_block_utils conformance validator over real ast_to_blocks output,
 # so producer/spec drift is caught (tracker/bugs/014). The three macros below are
 # copied VERBATIM from third_party/duck_block_utils/duck_block_conformance.sql
-# (SPEC_VERSION 6.2, upstream 3bd7ff8) — resync BOTH together when the vendored
+# (SPEC_VERSION 6.5, upstream 5017b86) — resync BOTH together when the vendored
 # copy is bumped. See third_party/duck_block_utils/PROVENANCE.md.
 
 require sitting_duck

--- a/third_party/duck_block_utils/PROVENANCE.md
+++ b/third_party/duck_block_utils/PROVENANCE.md
@@ -3,8 +3,8 @@
 These files are a **vendored copy** — do not edit here; re-sync from upstream.
 
 - **Source repo:** teaguesterling/duckdb_duck_block_utils
-- **Commit:** `3bd7ff8a2bbe` (origin/main, 2026-09-01)
-- **SPEC_VERSION:** 6.2
+- **Commit:** `5017b86` (fix/duckdb-v2-compat, PR #26, 2026-09-05)
+- **SPEC_VERSION:** 6.5
 - **Files:** `duck_block_vocabulary.hpp` (type/encoding vocabulary + SPEC_VERSION),
   `duck_block_conformance.sql` (`duck_blocks_validate()` and friends — pure SQL,
   requires no extension loaded).
@@ -12,3 +12,12 @@ These files are a **vendored copy** — do not edit here; re-sync from upstream.
 sitting_duck's `ast_to_blocks` emits duck_blocks conforming to this version; the
 conformance test in `test/sql/duck_blocks_conformance.test` runs the validator here
 over real `ast_to_blocks` output so producer/spec drift is caught (see tracker/bugs/014).
+
+**6.5 note (PR #26):** the 6.4→6.5 change is BREAKING on the FUNCTION SURFACE only —
+`duck_blocks_toc`/`_headings`/`_code_blocks`/`_links`/`get_section`/`get_pages`/
+`sections_like` now return `LIST(duck_block)`; the old projections live on as `_structs`
+siblings and the old strings as `_text` siblings; named params removed. **The struct
+shape is unchanged.** sitting_duck is a *producer* (`ast_to_blocks`) and calls none of
+those functions, so it is unaffected — this sync is a vocabulary/conformance refresh, not
+a migration. Any future consumer of those functions must move to the `_structs`/`_text`
+siblings (a binder error, never a wrong answer, if missed).

--- a/third_party/duck_block_utils/duck_block_conformance.sql
+++ b/third_party/duck_block_utils/duck_block_conformance.sql
@@ -215,6 +215,14 @@ CREATE OR REPLACE MACRO duck_blocks_warnings(blocks) AS TABLE (
     FROM e WHERE el.element_type = 'table'
       AND coalesce(el.content, '') <> '' AND position('"headers"' IN el.content) = 0
     UNION ALL
+    -- A `list` carrying content is the pre-structural shape: items in a JSON array
+    -- instead of `list_item` children. The list case is more damaging than the table
+    -- one -- a nested list comes back as one run-together string that a consumer
+    -- cannot tell from real text.
+    SELECT el.element_order, 'list_not_structural',
+           'list carries content; its items belong in list_item children at level + 1'
+    FROM e WHERE el.element_type = 'list' AND coalesce(el.content, '') <> ''
+    UNION ALL
     SELECT el.element_order, 'deflist_superseded',
            'deflist is superseded by list with list_type=''definition'''
     FROM e WHERE el.element_type = 'deflist'
@@ -223,6 +231,23 @@ CREATE OR REPLACE MACRO duck_blocks_warnings(blocks) AS TABLE (
            'heading without attributes[''heading_level'']: do NOT fall back to level'
     FROM e WHERE el.element_type = 'heading'
       AND coalesce(el.attributes['heading_level'], '') = ''
+    UNION ALL
+    -- POSITION. Metadata keeps its SOURCE position: front matter at the front,
+    -- everything the source did not position at the end. The role is authoritative and
+    -- the position corroborates it, so a role that contradicts the position means one
+    -- of the two is lying and a consumer cannot tell which.
+    SELECT el.element_order, 'frontmatter_not_first',
+           'metadata with role=''frontmatter'' has body blocks before it; front matter '
+           'is at the front, or the role is wrong'
+    FROM e WHERE el.element_type = 'metadata' AND el.attributes['role'] = 'frontmatter'
+      AND EXISTS (SELECT 1 FROM e b WHERE b.el.kind = 'block' AND b.el.level = 1
+                  AND b.el.element_type <> 'metadata' AND b.el.element_order < e.el.element_order)
+    UNION ALL
+    SELECT el.element_order, 'body_after_metadata',
+           'a top-level block follows kind=''value'' metadata; values are appended '
+           'after the body, so nothing may come after them'
+    FROM e WHERE el.kind = 'block' AND el.level = 1
+      AND EXISTS (SELECT 1 FROM e v WHERE v.el.kind = 'value' AND v.el.element_order < e.el.element_order)
     UNION ALL
     SELECT el.element_order, 'undeclared_element_type',
            'element_type ' || el.element_type || ' is not in the vocabulary'

--- a/third_party/duck_block_utils/duck_block_vocabulary.hpp
+++ b/third_party/duck_block_utils/duck_block_vocabulary.hpp
@@ -1,4 +1,5 @@
 #pragma once
+// VENDORED from duckdb_duck_block_utils@5017b86 (fix/duckdb-v2-compat, PR #26, SPEC_VERSION 6.5), synced 2026-09-05.
 
 // ============================================================================
 // The duck_block vocabulary -- PUBLISHED INTERFACE.
@@ -158,9 +159,16 @@ struct DuckBlockVocabulary {
 	static constexpr uint64_t ATTRIBUTES_IDX = 5;
 	static constexpr uint64_t ELEMENT_ORDER_IDX = 6;
 
-	// Additional field indices for duck_block_ext
-	static constexpr uint64_t SOURCE_FORMAT_IDX = 7;
-	static constexpr uint64_t FILE_PATH_IDX = 8;
+	// The one OPTIONAL trailing field. A reader that emits a `filename` column makes
+	// `list(b)` an 8-field struct; consumers accept exactly that shape -- the seven
+	// canonical fields, then this -- and nothing else. Optional fields append in
+	// ADOPTION order: a later one takes index 8. Reserving slots ahead of adoption is
+	// what put `source_format` at 7 and `file_path` at 8 for a type nothing ever
+	// produced, and that reservation is why the first real optional field could not
+	// simply take the next index. Those two constants are gone; `duck_block_ext`
+	// itself stays registered, deprecated, for one release.
+	static constexpr uint64_t FILENAME_IDX = 7;
+	static constexpr const char *FIELD_FILENAME = "filename";
 
 	// Kind values
 	static constexpr const char *KIND_BLOCK = "block";
@@ -288,8 +296,71 @@ struct DuckBlockVocabulary {
 	//
 	//               Nothing renamed, nothing removed; a consumer on 6.1 is unaffected.
 	//
+	//   6.3 -> 6.4  ADDITIVE for the shape, with ONE REMOVAL and ONE DEPRECATION.
+	//               duck_block gains an optional trailing 8th field, `filename VARCHAR`,
+	//               so a reader can say which file each row came from without breaking
+	//               the `list(b)` idiom. Consumers MUST accept both the 7-field and the
+	//               8-field shape; producers MAY emit the 8th, opt-in behind
+	//               `filename := true`, DuckDB core's own convention. It is TRAILING
+	//               ONLY and the widened shape is exactly one type: a differently
+	//               named or differently placed extra field stays a binder error.
+	//               Functions that RETURN blocks return the 7-field shape: provenance
+	//               lives on the reader's rows and survives GROUP BY filename, not
+	//               duck_blocks_merge.
+	//
+	//               ROLLOUT ORDER, which is why the rule is stated: land acceptance in
+	//               every consumer BEFORE any reader emits, or every
+	//               `duck_blocks_toc(list(b))` in the field breaks with the binder
+	//               error the day the reader ships.
+	//
+	//               REMOVED: SOURCE_FORMAT_IDX (7) and FILE_PATH_IDX (8), the offsets
+	//               of a `duck_block_ext` type no function ever produced or consumed.
+	//               `filename` at 7 would otherwise contradict a published constant.
+	//               DEPRECATED: the `duck_block_ext` catalog type stays registered
+	//               for one release because a user's own `CAST(x AS duck_block_ext)`
+	//               is invisible to any grep of ours; it goes in 6.5.
+	//
+	//               A consumer on 6.3 that never referenced the two offsets is
+	//               unaffected until a reader it depends on starts emitting.
+	//
+	//   6.4 -> 6.5  BREAKING on the FUNCTION SURFACE, nothing in the struct shape.
+	//               Retrieval returns blocks, and a suffix names what the ORIGINAL
+	//               returned, so nobody is stranded:
+	//
+	//               * duck_blocks_get_section and duck_blocks_get_pages return
+	//                 LIST(duck_block) instead of VARCHAR; duck_blocks_sections_like's
+	//                 third column is `blocks` LIST(duck_block) instead of `content`
+	//                 VARCHAR, rows unchanged; named parameters removed entirely
+	//                 (output_format was the only one, on all three); page_rows gains
+	//                 a `blocks` column beside its existing four. The originals live
+	//                 on as duck_blocks_get_section_text, duck_blocks_get_pages_text,
+	//                 duck_blocks_sections_like_text -- defined as duck_blocks_to_text
+	//                 over the blocks form, which is byte-identical to the old default
+	//                 because that is literally what the old default computed.
+	//               * duck_blocks_headings, _toc, _code_blocks, _links return
+	//                 LIST(duck_block); today's projections live on, byte-for-byte and
+	//                 permanently, as duck_blocks_headings_structs, _toc_structs,
+	//                 _code_blocks_structs, _links_structs. toc_rows and page_rows keep
+	//                 their row shapes.
+	//               * ATTR_OUTLINE and ATTR_INDENT: the first attributes a function here
+	//                 COMPUTES rather than copies. Only on the output of the heading
+	//                 constructions.
+	//               * RECOVERY CONTRACT, now normative: element_order is dense from 0
+	//                 over the list a reader EMITS, synthetic markers included. Every
+	//                 projection or construction FROM a document carries it through
+	//                 unrenumbered, with gaps -- it is the join key back to the source
+	//                 and between the blocks and _structs forms. Only functions that
+	//                 build a standalone document (assemble, merge, reorder) renumber.
+	//               * Restated, because producers asked: `level` is never NULL (a flat
+	//                 format emits 1 everywhere); `filename` is opt-in and boolean-only.
+	//
+	//               Migration: a caller reading a projection field off duck_blocks_toc
+	//               (panduck's doc_toc) renames to duck_blocks_toc_structs; a caller
+	//               wanting text renames to the _text sibling. Failure to migrate is a
+	//               binder error, never a wrong answer.
+	//
 	// The rule above is what will be followed from here.
-	static constexpr const char *SPEC_VERSION = "6.2";
+	static constexpr const char *SPEC_VERSION = "6.5";
 
 	// ========================================================================
 	// Block type names
@@ -416,13 +487,29 @@ struct DuckBlockVocabulary {
 	static constexpr const char *ATTR_LIST_TYPE = "list_type";
 	static constexpr const char *ATTR_SOURCE_TYPE = "source_type";
 	static constexpr const char *ATTR_PANDOC_AST = "pandoc_ast";
+	// COMPUTED attributes -- set only by duck_block_utils' heading constructions
+	// (duck_blocks_headings / duck_blocks_toc), never emitted by a reader as if
+	// sourced. `outline` is the heading's position in the outline ("1.2.1"):
+	// positions, not the heading's own digit, so h1 -> h3 -> h2 reads 1, 1.1, 1.2.
+	// `indent` is heading level minus the document's minimum heading level.
+	static constexpr const char *ATTR_OUTLINE = "outline";
+	static constexpr const char *ATTR_INDENT = "indent";
 
 	// ========================================================================
 	// Role values, per the type that carries them
 	// ========================================================================
 	// `metadata` -- which verbatim blob this is
 	static constexpr const char *ROLE_FRONTMATTER = "frontmatter"; // has a document body after it
-	static constexpr const char *ROLE_DOCUMENT = "document";       // the blob IS the whole document
+	// The author put the blob at the END on purpose. Added in 6.3 because the spec
+	// already named `tailmatter` in its position rules while the vocabulary declared no
+	// such constant -- so a producer following the prose had to invent a literal, which
+	// is the drift the vendoring exists to catch. Requested by the webbed session, who
+	// declined to invent it locally for exactly that reason.
+	//
+	// Without it, a blob the author deliberately placed last is indistinguishable from
+	// metadata the FORMAT supplied with no position at all: both appended, both roleless.
+	static constexpr const char *ROLE_TAILMATTER = "tailmatter";
+	static constexpr const char *ROLE_DOCUMENT = "document"; // the blob IS the whole document
 
 	// ========================================================================
 	// `list_type` values -- the attribute is ATTR_LIST_TYPE


### PR DESCRIPTION
Re-vendors duck_block_utils @ `5017b86` (fix/duckdb-v2-compat, PR #26, **SPEC_VERSION 6.5**) from 6.2.

## What 6.5 is
BREAKING on the **function surface** only — retrieval/projection functions (`duck_blocks_toc`/`_headings`/`_code_blocks`/`_links`/`get_section`/`get_pages`/`sections_like`) now return `LIST(duck_block)`; the old projections live on as `_structs` siblings and the old strings as `_text` siblings; named params removed. **Nothing changes in the struct shape.**

## Why sitting_duck is unaffected
`ast_to_blocks` is a **producer** and calls none of the reshaped functions (grep-verified), so this is a vocabulary/conformance refresh, not a migration. The producer already emits what 6.5 restates as normative: `level` never NULL (flat = 1), dense `element_order`, leading frontmatter metadata.

## Changes
- `duck_block_vocabulary.hpp` → mirrored to 6.5 (SPEC_VERSION 6.5, `FILENAME_IDX`, `ROLE_TAILMATTER`) + provenance line. Not compiled in — it is the drift reference.
- `duck_block_conformance.sql` → synced to 6.5.
- `duck_blocks_conformance.test` → the three embedded validator macros were already 6.5-identical (`value` kind, `toml` encoding, `is_valid`); only the stale `SPEC_VERSION 6.2 / 3bd7ff8` label needed updating.
- `PROVENANCE.md` → bumped to 6.5 @ `5017b86` + a 6.5 function-surface note for future consumers.

## Verification
Full release build against **DuckDB v2.0.0** source (729/729, exit 0). On the fresh binary:
- `duck_blocks_conformance.test` — 10/10 ✓
- `duck_blocks.test` — 119/119 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)