### PR TITLE
DuckDB v2.0 (cyanoptera) compatibility: bump submodule, one shim fix, cross-version tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,11 +4,11 @@
 [submodule "duckdb"]
 	path = duckdb
 	url = https://github.com/duckdb/duckdb
-	branch = v1.5-variegata
+	branch = v2.0-cyanoptera
 [submodule "extension-ci-tools"]
 	path = extension-ci-tools
 	url = https://github.com/duckdb/extension-ci-tools
-	branch = v1.5-variegata
+	branch = v2.0-cyanoptera
 [submodule "grammars/tree-sitter-python"]
 	path = grammars/tree-sitter-python
 	url = https://github.com/tree-sitter/tree-sitter-python.git

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -144,8 +144,13 @@ inline CompatName CompatMakeName(string name) {
 // key is string, the explicit Identifier ctor where it is not.
 using CompatChildKey = typename child_list_t<LogicalType>::value_type::first_type;
 
-inline CompatChildKey CompatMakeChildKey(const CompatName &name) {
-	return CompatChildKey(CompatNameStr(name));
+// Input is a runtime column-name STRING (struct/union field names are strings),
+// not a bind CompatName. Taking CompatName here compiled on v1.5.x only because
+// CompatName aliased string there; on v2.0 it aliases Identifier, whose
+// `Identifier(const string&)` is explicit, so a std::string call site (every one
+// of them) failed to bind. `CompatChildKey(string)` constructs on both lines.
+inline CompatChildKey CompatMakeChildKey(const string &name) {
+	return CompatChildKey(name);
 }
 
 inline void CompatAssignNames(vector<CompatName> &names, const vector<string> &source) {

--- a/test/sql/ast_patch.test
+++ b/test/sql/ast_patch.test
@@ -100,8 +100,8 @@ true
 # Baseline: original has exactly 1 return_statement (greet's) and no integer 42
 query II
 SELECT
-    len(list_filter(l, x -> x.type = 'return_statement')),
-    len(list_filter(l, x -> x.type = 'integer' AND x.peek = '42'))
+    len(list_filter(l, lambda x: x.type = 'return_statement')),
+    len(list_filter(l, lambda x: x.type = 'integer' AND x.peek = '42'))
 FROM (SELECT parse_ast_list(content, 'python') AS l
       FROM read_text('test/data/python/macros/patch_demo.py'));
 ----
@@ -120,8 +120,8 @@ SELECT * FROM ast_patch('body_edit', 'test/data/python/macros/patch_demo.py');
 # Re-parse: now 2 return_statements, and the 42 lives inside function 'unused'
 query II
 SELECT
-    len(list_filter(l, x -> x.type = 'return_statement')),
-    len(list_filter(l, x -> x.type = 'integer' AND x.peek = '42'))
+    len(list_filter(l, lambda x: x.type = 'return_statement')),
+    len(list_filter(l, lambda x: x.type = 'integer' AND x.peek = '42'))
 FROM (SELECT parse_ast_list(patched_source, 'python') AS l FROM body_patched);
 ----
 2	1
@@ -147,7 +147,7 @@ WHERE r.type = 'expression_statement' AND r.start_line = 7;
 
 query I
 SELECT len(list_filter(parse_ast_list(patched_source, 'python'),
-                       x -> x.type = 'identifier' AND x.name = 'total'))
+                       lambda x: x.type = 'identifier' AND x.name = 'total'))
 FROM ast_patch('delete_edit', 'test/data/python/macros/patch_demo.py');
 ----
 0
@@ -165,7 +165,7 @@ WHERE r.type = 'function_definition' AND r.name = 'greet';
 # Re-parse: greet is now decorated
 query I
 SELECT len(list_filter(parse_ast_list(patched_source, 'python'),
-                       x -> x.type = 'decorator'))
+                       lambda x: x.type = 'decorator'))
 FROM ast_patch('insert_edits', 'test/data/python/macros/patch_demo.py');
 ----
 1
@@ -178,7 +178,7 @@ WHERE r.type = 'expression_statement' AND r.start_line = 7;
 
 query I
 SELECT len(list_filter(parse_ast_list(patched_source, 'python'),
-                       x -> x.type = 'comment' AND x.peek = '# checked'))
+                       lambda x: x.type = 'comment' AND x.peek = '# checked'))
 FROM ast_patch('append_edits', 'test/data/python/macros/patch_demo.py');
 ----
 1
@@ -204,8 +204,8 @@ SELECT * FROM (
 query I
 SELECT list_sort(list_transform(
            list_filter(parse_ast_list(patched_source, 'python'),
-                       x -> x.type = 'function_definition'),
-           x -> x.name))
+                       lambda x: x.type = 'function_definition'),
+           lambda x: x.name))
 FROM ast_patch('multi_edits', 'test/data/python/macros/patch_demo.py');
 ----
 [retired, salute]
@@ -393,8 +393,8 @@ SELECT * FROM ast_replace('test/data/python/macros/patch_demo.py',
 
 query II
 SELECT
-    len(list_filter(l, x -> x.type = 'function_definition' AND x.name = 'salute')),
-    len(list_filter(l, x -> x.type = 'function_definition' AND x.name = 'greet'))
+    len(list_filter(l, lambda x: x.type = 'function_definition' AND x.name = 'salute')),
+    len(list_filter(l, lambda x: x.type = 'function_definition' AND x.name = 'greet'))
 FROM (SELECT parse_ast_list(patched_source, 'python') AS l FROM renamed);
 ----
 1	0
@@ -402,7 +402,7 @@ FROM (SELECT parse_ast_list(patched_source, 'python') AS l FROM renamed);
 # Multi-match replacement: every integer literal in the file becomes 9
 query I
 SELECT len(list_filter(parse_ast_list(patched_source, 'python'),
-                       x -> x.type = 'integer' AND x.peek != '9'))
+                       lambda x: x.type = 'integer' AND x.peek != '9'))
 FROM ast_replace('test/data/python/macros/patch_demo.py', 'integer', '9');
 ----
 0

--- a/test/sql/duckdb_advanced_features.test
+++ b/test/sql/duckdb_advanced_features.test
@@ -14,7 +14,7 @@ query III
 SELECT type, name, peek
 FROM parse_ast('
 SELECT 
-    list_transform([1,2,3], x -> x * 2) as doubled,
+    list_transform([1,2,3], lambda x: x * 2) as doubled,
     struct_pack(name := ''John'', age := 30) as person,
     map {''key1'': ''value1'', ''key2'': ''value2''} as my_map
 ', 'duckdb')
@@ -132,9 +132,12 @@ table_reference	NAME_QUALIFIED	4
 
 # Test 7: Query optimization hints and pragmas
 # ============================================
+# replace('"') normalizes an upstream deparse difference: DuckDB v2.0 quotes the
+# identifier in a deparsed PRAGMA->SET (SET "profiling_output") where v1.5 did not.
+# The node type + reconstructed statement are what this asserts, not the quoting.
 
 query II
-SELECT type, peek
+SELECT type, replace(peek, '"', '')
 FROM parse_ast('
 PRAGMA enable_profiling;
 PRAGMA profiling_output = ''/tmp/profile.json'';

--- a/test/sql/duckdb_parser_test.test
+++ b/test/sql/duckdb_parser_test.test
@@ -35,18 +35,22 @@ LIMIT 10;
 # Test 3: Complex query with JOIN and WHERE
 # ==========================================
 
+# Cross-version: DuckDB v2.0 parses the boolean literal `true` as a `literal`
+# (LITERAL_ATOMIC) where v1.5 emitted a `cast_expression` (COMPUTATION_EXPRESSION).
+# That `true` is the only literal/cast node in this query, so excluding both types
+# drops exactly the divergent node on each line and the rest matches on both.
 query III
 SELECT type, semantic_type_to_string(semantic_type) as semantic_type, COUNT(*) as count
 FROM parse_ast('
-SELECT u.name, p.title 
-FROM users u 
-JOIN posts p ON u.id = p.user_id 
+SELECT u.name, p.title
+FROM users u
+JOIN posts p ON u.id = p.user_id
 WHERE u.active = true
 ', 'duckdb')
+WHERE type NOT IN ('cast_expression', 'literal')
 GROUP BY type, semantic_type
 ORDER BY type ASC, semantic_type ASC;
 ----
-cast_expression	COMPUTATION_EXPRESSION	1
 column_reference	NAME_IDENTIFIER	3
 comparison	OPERATOR_COMPARISON	1
 join	TRANSFORM_ITERATION	1

--- a/test/sql/parse_ast_list.test
+++ b/test/sql/parse_ast_list.test
@@ -69,7 +69,7 @@ SELECT COUNT(*) FROM (
 # scope is STRUCT<current, function, class, module, stack>; stack is a
 # LIST<STRUCT<id, kind>> populated only on IS_SCOPE nodes.
 query III
-SELECT node.type, node.scope.current, list_transform(node.scope.stack, s -> s.id) FROM (
+SELECT node.type, node.scope.current, list_transform(node.scope.stack, lambda s: s.id) FROM (
     SELECT unnest(parse_ast_list('def foo():
     pass', 'python')) as node
 ) WHERE node.type IN ('module', 'function_definition')

--- a/test/sql/qualified_name.test
+++ b/test/sql/qualified_name.test
@@ -332,7 +332,7 @@ query I
 SELECT COUNT(*) > 0
 FROM read_ast('test/data/python/qualified_names.py', 'python')
 WHERE len(list_filter(qualified_name,
-                      s -> is_class_definition(s.semantic_type))) > 0;
+                      lambda s: is_class_definition(s.semantic_type))) > 0;
 ----
 true
 
@@ -343,7 +343,7 @@ true
 query II
 SELECT name,
        (list_reverse(list_filter(qualified_name,
-                                 s -> is_class_definition(s.semantic_type))))[1].name
+                                 lambda s: is_class_definition(s.semantic_type))))[1].name
 FROM read_ast('test/data/python/qualified_names.py', 'python')
 WHERE name = 'validate' AND is_function_definition(semantic_type);
 ----


### PR DESCRIPTION
Bumps the duckdb submodule **v1.5.4 → v2.0-cyanoptera** (the v2.0/main line) and makes the extension build + full suite green against it. The compat shim (`duckdb_compat.hpp`) already covered the v2.0 API breaks; this is the residual the first real v2.0 build surfaced.

## Build — one fix
`CompatMakeChildKey` took `const CompatName&` (= `Identifier` on v2.0) but every call site passes a column-name `std::string` (STRUCT/UNION field names are strings). It compiled on v1.5.x only because `CompatName` aliased string there. Corrected to `const string&`, matching the shim's own documented intent.

## Tests — cross-version (CI runs a v1.5.4 leg **and** a v2.0 canary, so both must pass)
- **Lambda arrow**: v2.0 makes deprecated `x -> …` a hard binder error → migrated test SQL to `lambda x:` (`ast_patch`, `parse_ast_list`, `qualified_name`, `duckdb_advanced_features`). Extension macros were already lambda-modern; the `lambda_syntax` guard still passes.
- **PRAGMA→SET deparse**: v2.0 quotes the identifier (`SET "profiling_output"`) → assertion normalizes quotes, matches both lines.
- **Boolean literal**: v2.0 parses `true` as `literal` (LITERAL_ATOMIC) vs v1.5's `cast_expression` → excluded that single divergent node from the aggregate.

## Verification
- Full release build against `v2.0-cyanoptera`: **0 errors**.
- Full suite: **6556 assertions, 0 failed, 4 skipped** (grammar-dir env only).

## Note / decision for the reviewer
This **flips the default duckdb pin to v2.0** (`.gitmodules` NOTE previously said "currently v1.5.x"). Merging makes v2.0 the default build target. Two deprecation warnings remain (`ListVector::GetEntry`→`GetChild`, `DataChunk::SetValue`) — non-blocking, easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)