### PR TITLE
fix(#64): for-loop targets are NAME_DEFINITION (Python, Rust, Java)

### DIFF
--- a/src/include/native_context_extraction.hpp
+++ b/src/include/native_context_extraction.hpp
@@ -212,6 +212,32 @@ inline bool IsBareNameDefinitionField<RAdapter>(TSNode self, TSNode parent, cons
 	return std::strcmp(parent_type, "parameter") == 0 && ts_node_eq(self, ts_node_child_by_field_name(parent, "name", 4));
 }
 
+// #64 for-loop targets — the loop variable binds a name; it is a specific field of the
+// for/range node (the iterable is a different field, so it stays a reference). Only the
+// simple-identifier target is caught; tuple/destructured targets (for a,b in ...) under-
+// match. These are the UNAMBIGUOUS binding forms (the target is always a fresh binding).
+// Go is intentionally omitted: its range_clause `left` is a definition with `:=` but a
+// reassignment with `=`, and the field doesn't distinguish them (would risk a false DEF).
+// (These languages also specialize IsBareNameDefinitionParent for parameters; the walker
+// consults both, so a language can define parameter and for-target rules independently.)
+template <>
+inline bool IsBareNameDefinitionField<PythonAdapter>(TSNode self, TSNode parent, const char *parent_type) {
+	if (std::strcmp(parent_type, "for_statement") != 0 && std::strcmp(parent_type, "for_in_clause") != 0) {
+		return false;
+	}
+	return ts_node_eq(self, ts_node_child_by_field_name(parent, "left", 4));
+}
+template <>
+inline bool IsBareNameDefinitionField<RustAdapter>(TSNode self, TSNode parent, const char *parent_type) {
+	return std::strcmp(parent_type, "for_expression") == 0 &&
+	       ts_node_eq(self, ts_node_child_by_field_name(parent, "pattern", 7));
+}
+template <>
+inline bool IsBareNameDefinitionField<JavaAdapter>(TSNode self, TSNode parent, const char *parent_type) {
+	return std::strcmp(parent_type, "enhanced_for_statement") == 0 &&
+	       ts_node_eq(self, ts_node_child_by_field_name(parent, "name", 4));
+}
+
 // Specializations for each language adapter
 template <>
 struct NativeExtractionTraits<PythonAdapter> {

--- a/test/sql/ast_select_pseudo_classes.test
+++ b/test/sql/ast_select_pseudo_classes.test
@@ -125,13 +125,13 @@ true
 # =============================================================================
 
 # :named:definition — named definitions only
-# #64: bare parameters are now NAME_DEFINITION (8 params here), added to the 10
-# named function definitions.
+# #64: named definitions = 10 function definitions + 8 bare parameters + 1 for-loop
+# target (the `i` at line 12) — all NAME_DEFINITION now.
 query I
 SELECT COUNT(*) FROM ast_select('test/data/python/macros/recursive_match.py',
     ':named:definition');
 ----
-18
+19
 
 # function_definition:first-child:has(return_statement) — first-child functions with returns
 # The inner functions are first-child and have no returns themselves

--- a/test/sql/name_role_for_targets.test
+++ b/test/sql/name_role_for_targets.test
@@ -1,0 +1,47 @@
+# name: test/sql/name_role_for_targets.test
+# description: #64 — for-loop targets are NAME_DEFINITION (python/rust/java); the iterable stays REF
+# group: [sql]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# python: `for xx in items` — xx binds (definition), items is a reference
+query II
+SELECT name, CASE WHEN is_name_definition(flags) THEN 'DEF'
+                  WHEN is_name_reference(flags) THEN 'REF' ELSE '-' END
+FROM parse_ast('for xx in items: pass', 'python')
+WHERE type = 'identifier' AND name IN ('xx','items') ORDER BY name;
+----
+items	REF
+xx	DEF
+
+# python comprehension: the for-clause target `cc` is a definition. `cc` appears twice
+# (the binding in `for cc`, and its use in the output expression) — exactly one is a def.
+query I
+SELECT COUNT(*) FILTER (WHERE is_name_definition(flags))
+FROM parse_ast('y = [cc for cc in data]', 'python')
+WHERE type = 'identifier' AND name = 'cc';
+----
+1
+
+# rust: `for xx in items`
+query II
+SELECT name, CASE WHEN is_name_definition(flags) THEN 'DEF'
+                  WHEN is_name_reference(flags) THEN 'REF' ELSE '-' END
+FROM parse_ast('fn f(){ for xx in items { } }', 'rust')
+WHERE type = 'identifier' AND name IN ('xx','items') ORDER BY name;
+----
+items	REF
+xx	DEF
+
+# java: enhanced for-each `for (int xx : items)`
+query II
+SELECT name, CASE WHEN is_name_definition(flags) THEN 'DEF'
+                  WHEN is_name_reference(flags) THEN 'REF' ELSE '-' END
+FROM parse_ast('class C{void m(){ for(int xx : items){} }}', 'java')
+WHERE type = 'identifier' AND name IN ('xx','items') ORDER BY name;
+----
+items	REF
+xx	DEF


### PR DESCRIPTION
Continues #64 (parameters landed in #115 + #118). A loop variable **binds** a name but was flagged `NAME_REFERENCE`; scope resolution missed it.

Added for-target rules to the field-precise hook (`IsBareNameDefinitionField`) — the loop target is a specific field of the loop node, and the iterable is a *different* field, so it correctly stays a reference:
- **python**: `for_statement` / `for_in_clause` (comprehensions) field `left`
- **rust**: `for_expression` field `pattern`
- **java**: `enhanced_for_statement` field `name`

Only the simple-identifier target is caught; tuple/destructured targets (`for a,b in …`) under-match. **Go is intentionally omitted** — its `range_clause` `left` is a definition with `:=` but a reassignment with `=`, and the field can't distinguish them (would risk a false definition).

## Verified
Loop var → `DEF`, iterable → `REF`; python comprehension binds its for-clause variable. New `test/sql/name_role_for_targets.test`; updated `ast_select_pseudo_classes` `:named:definition` 18→19 (recursive_match.py's `for i` at line 12). Full suite green (6317 assertions).

## Still deferred within #64 (tracker/039)
Go for-targets, walrus/assignment-expression targets, destructuring bind targets, per-language binding-wrapper nodes (import aliases / catch vars / field decls), and the `IS_SCOPE` model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)