### PR TITLE
fix(#64): exception-handler variables are NAME_DEFINITION (js/ts/c#/ruby/java)

### DIFF
--- a/src/include/native_context_extraction.hpp
+++ b/src/include/native_context_extraction.hpp
@@ -130,15 +130,29 @@ inline bool IsBareNameDefinitionParent<PythonAdapter>(const char *parent_type) {
 // JavaScript: formal_parameters. Ruby: method_parameters. Lua: parameters.
 template <>
 inline bool IsBareNameDefinitionParent<JavaScriptAdapter>(const char *parent_type) {
-	return std::strcmp(parent_type, "formal_parameters") == 0;
+	// params (formal_parameters) + exception variable (`catch (ex)` — ex is a direct
+	// identifier child of catch_clause; the body is a nested block, so no over-match).
+	return std::strcmp(parent_type, "formal_parameters") == 0 || std::strcmp(parent_type, "catch_clause") == 0;
 }
 template <>
 inline bool IsBareNameDefinitionParent<RubyAdapter>(const char *parent_type) {
-	return std::strcmp(parent_type, "method_parameters") == 0;
+	// params + rescue exception variable (`rescue => ex`, wrapped in exception_variable).
+	return std::strcmp(parent_type, "method_parameters") == 0 || std::strcmp(parent_type, "exception_variable") == 0;
 }
 template <>
 inline bool IsBareNameDefinitionParent<LuaAdapter>(const char *parent_type) {
 	return std::strcmp(parent_type, "parameters") == 0;
+}
+// TypeScript/C# handle params via the field hook; their exception variable is a plain
+// identifier under catch_clause / catch_declaration (the exception TYPE is a non-identifier
+// node, and the body is nested), so a parent-type rule is safe and precise here.
+template <>
+inline bool IsBareNameDefinitionParent<TypeScriptAdapter>(const char *parent_type) {
+	return std::strcmp(parent_type, "catch_clause") == 0;
+}
+template <>
+inline bool IsBareNameDefinitionParent<CSharpAdapter>(const char *parent_type) {
+	return std::strcmp(parent_type, "catch_declaration") == 0;
 }
 // #64 Phase 3 — wrapper-based languages: the param NAME identifier's direct parent is
 // the per-param wrapper node. Safe (verified) because the type is a non-identifier node
@@ -165,7 +179,10 @@ inline bool IsBareNameDefinitionParent<RustAdapter>(const char *parent_type) {
 }
 template <>
 inline bool IsBareNameDefinitionParent<JavaAdapter>(const char *parent_type) {
-	return std::strcmp(parent_type, "formal_parameter") == 0;
+	// params (formal_parameter) + exception variable (catch_formal_parameter) — both
+	// wrap a single name identifier (the type is a non-identifier node).
+	return std::strcmp(parent_type, "formal_parameter") == 0 ||
+	       std::strcmp(parent_type, "catch_formal_parameter") == 0;
 }
 template <>
 inline bool IsBareNameDefinitionParent<KotlinAdapter>(const char *parent_type) {

--- a/test/sql/name_role_catch_vars.test
+++ b/test/sql/name_role_catch_vars.test
@@ -1,0 +1,53 @@
+# name: test/sql/name_role_catch_vars.test
+# description: #64 — exception-handler variables are NAME_DEFINITION across languages
+# group: [sql]
+
+require sitting_duck
+
+statement ok
+LOAD sitting_duck;
+
+# The caught exception variable `ex` binds a name -> NAME_DEFINITION. The exception TYPE
+# is a non-identifier node and the handler body is nested, so `ex` is unambiguous.
+
+query I
+SELECT CASE WHEN is_name_definition(flags) THEN 'DEF' ELSE 'REF' END
+FROM parse_ast('try { x() } catch (ex) { }', 'javascript')
+WHERE type = 'identifier' AND name = 'ex';
+----
+DEF
+
+query I
+SELECT CASE WHEN is_name_definition(flags) THEN 'DEF' ELSE 'REF' END
+FROM parse_ast('try { x() } catch (ex) { }', 'typescript')
+WHERE type = 'identifier' AND name = 'ex';
+----
+DEF
+
+query I
+SELECT CASE WHEN is_name_definition(flags) THEN 'DEF' ELSE 'REF' END
+FROM parse_ast('class C{void M(){ try{} catch(Exception ex){} }}', 'csharp')
+WHERE type = 'identifier' AND name = 'ex';
+----
+DEF
+
+query I
+SELECT CASE WHEN is_name_definition(flags) THEN 'DEF' ELSE 'REF' END
+FROM parse_ast('begin; rescue => ex; end', 'ruby')
+WHERE type = 'identifier' AND name = 'ex';
+----
+DEF
+
+query I
+SELECT CASE WHEN is_name_definition(flags) THEN 'DEF' ELSE 'REF' END
+FROM parse_ast('class C{void m(){ try{} catch(Exception ex){} }}', 'java')
+WHERE type = 'identifier' AND name = 'ex';
+----
+DEF
+
+query I
+SELECT CASE WHEN is_name_definition(flags) THEN 'DEF' ELSE 'REF' END
+FROM parse_ast('void f(){ try{} catch(int ex){} }', 'cpp')
+WHERE type = 'identifier' AND name = 'ex';
+----
+DEF


### PR DESCRIPTION
Next #64 binding-site slice: the caught exception variable (`catch (ex)`) binds a name but was flagged `NAME_REFERENCE`. Added catch contexts to the per-adapter `IsBareNameDefinitionParent` rule — all clean parent-type contexts (the exception type is a non-identifier node; the handler body is nested, so the variable is unambiguous):
- **javascript / typescript**: `catch_clause`
- **c#**: `catch_declaration`
- **ruby**: `exception_variable` (`rescue => ex`)
- **java**: `catch_formal_parameter` (identifier-level DEF, consistent with java params)
- **c++**: already covered (its `catch` uses `parameter_declaration`, handled by the param rule)

Verified `ex` → `DEF` in all six; new `test/sql/name_role_catch_vars.test`; full suite green (6324 assertions).

Deferred (tracker/039): PHP catch (`variable_name`), variable/field declarations, walrus/destructuring, `IS_SCOPE` model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)