### PR TITLE
docs(duck_blocks): correct stale SPEC_VERSION references in the SQL macros

### DIFF
--- a/src/include/embedded_sql_macros.hpp
+++ b/src/include/embedded_sql_macros.hpp
@@ -4681,7 +4681,7 @@ CREATE OR REPLACE MACRO ast_find_references(
 --
 -- ast_to_blocks converts parsed ASTs into duck_blocks — the document-element
 -- STRUCT spec shared by the markdown / webbed / duck_block_utils extensions
--- (duck_block_utils SPEC_VERSION 6.2; vendored vocabulary + conformance macros
+-- (duck_block_utils SPEC_VERSION 1.2; vendored vocabulary + conformance macros
 -- in third_party/duck_block_utils/, validated by test/sql/duck_blocks_conformance.test).
 --
 -- duck_blocks is a SPEC, not a dependency: these macros emit conforming
@@ -4692,7 +4692,7 @@ CREATE OR REPLACE MACRO ast_find_references(
 --   PRAGMA duck_block_render;
 --   SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
 --
--- Element shape (SPEC_VERSION 6.2):
+-- Element shape (SPEC_VERSION 1.2):
 --   STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER,
 --          encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR),
 --          element_order INTEGER)
@@ -4701,7 +4701,7 @@ CREATE OR REPLACE MACRO ast_find_references(
 --   * kind is always 'block' (we emit no inlines).
 --   * A heading's semantic level lives in attributes['heading_level'] as a
 --     STRING ('1'..'6'), NOT in the `level` field. `level` is structural
---     nesting depth: SPEC_VERSION 3.0+ requires it >= 1 for every element
+--     nesting depth: required >= 1 for every element since internal 3.0
 --     (no NULLs, never semantic). This outline is flat — no section/div
 --     containers — so every block we emit is a top-level sibling at level 1.
 --   * code blocks carry attributes['language']; metadata uses encoding 'yaml'.

--- a/src/sql_macros/duck_blocks.sql
+++ b/src/sql_macros/duck_blocks.sql
@@ -4,7 +4,7 @@
 --
 -- ast_to_blocks converts parsed ASTs into duck_blocks — the document-element
 -- STRUCT spec shared by the markdown / webbed / duck_block_utils extensions
--- (duck_block_utils SPEC_VERSION 6.2; vendored vocabulary + conformance macros
+-- (duck_block_utils SPEC_VERSION 1.2; vendored vocabulary + conformance macros
 -- in third_party/duck_block_utils/, validated by test/sql/duck_blocks_conformance.test).
 --
 -- duck_blocks is a SPEC, not a dependency: these macros emit conforming
@@ -15,7 +15,7 @@
 --   PRAGMA duck_block_render;
 --   SELECT db_render_blocks(blocks) FROM ast_to_blocks_list('src/main.py');
 --
--- Element shape (SPEC_VERSION 6.2):
+-- Element shape (SPEC_VERSION 1.2):
 --   STRUCT(kind VARCHAR, element_type VARCHAR, content VARCHAR, level INTEGER,
 --          encoding VARCHAR, attributes MAP(VARCHAR, VARCHAR),
 --          element_order INTEGER)
@@ -24,7 +24,7 @@
 --   * kind is always 'block' (we emit no inlines).
 --   * A heading's semantic level lives in attributes['heading_level'] as a
 --     STRING ('1'..'6'), NOT in the `level` field. `level` is structural
---     nesting depth: SPEC_VERSION 3.0+ requires it >= 1 for every element
+--     nesting depth: required >= 1 for every element since internal 3.0
 --     (no NULLs, never semantic). This outline is flat — no section/div
 --     containers — so every block we emit is a top-level sibling at level 1.
 --   * code blocks carry attributes['language']; metadata uses encoding 'yaml'.


### PR DESCRIPTION
**Rescoped.** This PR originally re-vendored the vocabulary header to spec 1.2, but #122 landed that first. The header change is dropped; what remains is the part #122 did not cover.

## The stale comments #122 left behind

`src/sql_macros/duck_blocks.sql` documents the vocabulary it consumes, and its version references had drifted:

```
-- (duck_block_utils SPEC_VERSION 6.2; ...    ->  1.2
-- Element shape (SPEC_VERSION 6.2):          ->  1.2
```

These claimed **6.2** while the vendored header was already at **6.5** *before* the 1.2 sync — three minors behind the file they describe, and six behind it now.

## The third reference is deliberately not renumbered

```
-- nesting depth: SPEC_VERSION 3.0+ requires it >= 1 for every element
```

That describes **when the rule was introduced**, and `3.0` is a point on the *internal* line duck_block_utils retired when it renumbered 6.6 to public 1.2. Relabelling it `1.2` would assert something false — internal 3.0 and public 1.2 are different points on different lines. It becomes:

```
-- nesting depth: required >= 1 for every element since internal 3.0
```

which stays true under both numberings.

## Verification

`embedded_sql_macros.hpp` regenerated via `scripts/embed_sql_macros.py`. `duck_blocks_conformance.test` (14 assertions) and `duck_blocks.test` (119) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjgU52vGS3mpSAwwgJD5C4
