### PR TITLE
chore(duck_blocks): sync vendored duck_block_utils to spec 1.2

### DIFF
--- a/test/sql/duck_blocks_conformance.test
+++ b/test/sql/duck_blocks_conformance.test
@@ -3,10 +3,10 @@
 # group: [sql]
 #
 # Runs the duck_block_utils conformance validator over real ast_to_blocks output,
-# so producer/spec drift is caught (tracker/bugs/014). The three macros below are
-# copied VERBATIM from third_party/duck_block_utils/duck_block_conformance.sql
-# (SPEC_VERSION 6.5, upstream 5017b86) — resync BOTH together when the vendored
-# copy is bumped. See third_party/duck_block_utils/PROVENANCE.md.
+# so producer/spec drift is caught (tracker/bugs/014). The macros below are copied
+# VERBATIM from third_party/duck_block_utils/duck_block_conformance.sql
+# (SPEC_VERSION 1.2, upstream 1c5f2a6) — resync BOTH together when the vendored copy
+# is bumped. See third_party/duck_block_utils/PROVENANCE.md.
 
 require sitting_duck
 
@@ -34,8 +34,58 @@ CREATE OR REPLACE MACRO duck_block_is_valid(elem) AS (
     AND elem.element_order >= 0
 );
 
+# 1.2 list-level validator (field='list' rules L1-L3 expressible without an ancestor
+# stack: dense element_order from 0, shallowest level 1, no level jump > 1), plus the
+# per-element rules. Verbatim from the vendored duck_blocks_errors.
+statement ok
+CREATE OR REPLACE MACRO duck_blocks_errors(blocks) AS TABLE (
+    WITH e AS (SELECT unnest(blocks) AS el, generate_subscripts(blocks, 1) AS pos),
+    lv AS (SELECT el, pos, el.level AS lvl, lag(el.level) OVER (ORDER BY pos) AS prev FROM e),
+    dup AS (SELECT el.element_order AS ord FROM e GROUP BY 1 HAVING count(*) > 1)
+    SELECT el.element_order AS element_order, 'kind' AS field,
+           'Invalid kind ' || chr(39) || coalesce(el.kind, 'NULL') || chr(39)
+             || '; see duck_block_kind_names()' AS message
+      FROM e WHERE NOT list_contains(duck_block_declared_kinds(), el.kind)
+    UNION ALL
+    SELECT el.element_order, 'list',
+           'element_order starts at ' || el.element_order || '; must start at 0'
+      FROM e WHERE pos = 1 AND el.element_order <> 0
+    UNION ALL
+    SELECT ord, 'list', 'element_order gap after ' || prev
+      FROM (SELECT el.element_order AS ord, lag(el.element_order) OVER (ORDER BY pos) AS prev FROM e)
+     WHERE prev IS NOT NULL AND ord <> prev + 1
+    UNION ALL
+    SELECT (SELECT el.element_order FROM e ORDER BY el.level, pos LIMIT 1), 'list',
+           'shallowest element is at level ' || min(el.level) || '; top level is 1'
+      FROM e HAVING min(el.level) > 1
+    UNION ALL
+    SELECT el.element_order, 'element_type', 'element_type is NULL'
+      FROM e WHERE el.element_type IS NULL
+    UNION ALL
+    SELECT el.element_order, 'encoding',
+           'Invalid encoding ' || chr(39) || el.encoding || chr(39)
+      FROM e WHERE el.encoding IS NOT NULL
+        AND NOT list_contains(duck_block_declared_encodings(), el.encoding)
+    UNION ALL
+    SELECT el.element_order, 'level',
+           CASE WHEN el.level IS NULL
+                THEN 'level is NULL; every element carries an explicit depth, top level is 1'
+                ELSE 'level ' || el.level || ' is below 1; top level is 1' END
+      FROM e WHERE el.level IS NULL OR el.level < 1
+    UNION ALL
+    SELECT el.element_order, 'level',
+           'level jumps from ' || prev || ' to ' || lvl
+             || '; depth-first ordering descends one at a time, so this element''s parent is missing'
+      FROM lv WHERE prev IS NOT NULL AND lvl > prev + 1
+    UNION ALL
+    SELECT el.element_order, 'element_order', 'element_order must be non-negative'
+      FROM e WHERE el.element_order IS NULL OR el.element_order < 0
+    UNION ALL
+    SELECT ord, 'element_order', 'Duplicate element_order value' FROM dup
+);
+
 # =============================================================================
-# Every emitted block is conformant (level >= 1, valid kind/encoding, order >= 0)
+# Per-element: every emitted block is conformant (level >= 1, valid kind/encoding, order >= 0)
 # =============================================================================
 
 # Python (classes + nested defs + module metadata)
@@ -77,5 +127,28 @@ WHERE NOT duck_block_is_valid(block);
 query I
 SELECT count(*) FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')
 WHERE block.level IS NULL OR block.level < 1;
+----
+0
+
+# =============================================================================
+# 1.2 list-level conformance: ast_to_blocks output has ZERO validator errors
+# (dense element_order from 0, shallowest level 1, no level jumps, valid kinds/encodings)
+# =============================================================================
+
+query I
+SELECT count(*) FROM duck_blocks_errors(
+    (SELECT list(block) FROM ast_to_blocks('test/data/python/macros/blocks_demo.py')));
+----
+0
+
+query I
+SELECT count(*) FROM duck_blocks_errors(
+    (SELECT list(block) FROM ast_to_blocks('test/data/go/simple.go', 'go')));
+----
+0
+
+query I
+SELECT count(*) FROM duck_blocks_errors(
+    (SELECT list(block) FROM ast_to_blocks('test/data/python/macros/blocks_demo.py', style := 'flat')));
 ----
 0

--- a/third_party/duck_block_utils/PROVENANCE.md
+++ b/third_party/duck_block_utils/PROVENANCE.md
@@ -3,21 +3,32 @@
 These files are a **vendored copy** — do not edit here; re-sync from upstream.
 
 - **Source repo:** teaguesterling/duckdb_duck_block_utils
-- **Commit:** `5017b86` (fix/duckdb-v2-compat, PR #26, 2026-09-05)
-- **SPEC_VERSION:** 6.5
-- **Files:** `duck_block_vocabulary.hpp` (type/encoding vocabulary + SPEC_VERSION),
-  `duck_block_conformance.sql` (`duck_blocks_validate()` and friends — pure SQL,
-  requires no extension loaded).
+- **Commit:** `1c5f2a6` (main, PR #30, 2026-09-10)
+- **SPEC_VERSION:** `1.2` (public; supersedes the retired internal `6.6` line — see the
+  "TWO NUMBER LINES" note in `duck_block_vocabulary.hpp`. sitting_duck previously
+  vendored `6.5` = public `1.1`.)
+- **Files:** `duck_block_vocabulary.hpp` (type/encoding vocabulary + SPEC_VERSION +
+  `ImplicitParentOf`/`RequiresAncestor`; from upstream `src/include/`),
+  `duck_block_conformance.sql` (`duck_blocks_validate()` + list-level rules; from
+  upstream `vendor/`).
 
 sitting_duck's `ast_to_blocks` emits duck_blocks conforming to this version; the
 conformance test in `test/sql/duck_blocks_conformance.test` runs the validator here
 over real `ast_to_blocks` output so producer/spec drift is caught (see tracker/bugs/014).
 
-**6.5 note (PR #26):** the 6.4→6.5 change is BREAKING on the FUNCTION SURFACE only —
-`duck_blocks_toc`/`_headings`/`_code_blocks`/`_links`/`get_section`/`get_pages`/
-`sections_like` now return `LIST(duck_block)`; the old projections live on as `_structs`
-siblings and the old strings as `_text` siblings; named params removed. **The struct
-shape is unchanged.** sitting_duck is a *producer* (`ast_to_blocks`) and calls none of
-those functions, so it is unaffected — this sync is a vocabulary/conformance refresh, not
-a migration. Any future consumer of those functions must move to the `_structs`/`_text`
-siblings (a binder error, never a wrong answer, if missed).
+**1.2 note (PR #30):** version guidance changed to `major == 1 AND minor >= N` (not
+whole-string equality). The spec adds, over 6.5:
+- **Fragments are legal input** — a consumer must handle/wrap a fragment, never drop it.
+- **Implicit-parent table** — `ImplicitParentOf(type, kind)` / `RequiresAncestor(...)`
+  (constexpr, C++11-safe); exposed upstream as `duck_block_implicit_parent`.
+- **Validation over the LIST** (`field = 'list'`): L1 dense `element_order` from 0 in
+  list position, L2 shallowest level 1, L3 no level jump > 1, L4 required ancestor,
+  L5 inline under a block/value.
+- **One shape per element_type binds EVERY producer** (tight list item: content = Plain,
+  paragraph child = Para).
+
+The **struct shape is unchanged** (same 7-field layout / index constants). This sync
+therefore updates the vocabulary + validator; whether `ast_to_blocks` output already
+satisfies the new list-level rules is checked by the conformance test. The optional
+`vendor/duck_block_normalize.hpp` transform (collapse a lone `plain` into its container)
+is NOT vendored here — add it only if the producer needs to normalize its output.

--- a/third_party/duck_block_utils/duck_block_conformance.sql
+++ b/third_party/duck_block_utils/duck_block_conformance.sql
@@ -151,6 +151,23 @@ CREATE OR REPLACE MACRO duck_blocks_errors(blocks) AS TABLE (
              || '; see duck_block_kind_names()' AS message
       FROM e WHERE NOT list_contains(duck_block_declared_kinds(), el.kind)
     UNION ALL
+    -- Rules over the LIST (field = 'list'): the two expressible without an ancestor
+    -- stack. L1: element_order dense from 0 in LIST POSITION order (not sorted by
+    -- order -- a list whose orders are out of sequence is the thing being caught).
+    SELECT el.element_order, 'list',
+           'element_order starts at ' || el.element_order || '; must start at 0'
+      FROM e WHERE pos = 1 AND el.element_order <> 0
+    UNION ALL
+    SELECT ord, 'list', 'element_order gap after ' || prev
+      FROM (SELECT el.element_order AS ord, lag(el.element_order) OVER (ORDER BY pos) AS prev FROM e)
+     WHERE prev IS NOT NULL AND ord <> prev + 1
+    UNION ALL
+    -- L2: the shallowest element is at level 1. L4/L5 (required ancestors) need a
+    -- stack and are reported by duck_blocks_validate() only.
+    SELECT (SELECT el.element_order FROM e ORDER BY el.level, pos LIMIT 1), 'list',
+           'shallowest element is at level ' || min(el.level) || '; top level is 1'
+      FROM e HAVING min(el.level) > 1
+    UNION ALL
     SELECT el.element_order, 'element_type', 'element_type is NULL'
       FROM e WHERE el.element_type IS NULL
     UNION ALL

--- a/third_party/duck_block_utils/duck_block_vocabulary.hpp
+++ b/third_party/duck_block_utils/duck_block_vocabulary.hpp
@@ -1,5 +1,4 @@
 #pragma once
-// VENDORED from duckdb_duck_block_utils@5017b86 (fix/duckdb-v2-compat, PR #26, SPEC_VERSION 6.5), synced 2026-09-05.
 
 // ============================================================================
 // The duck_block vocabulary -- PUBLISHED INTERFACE.
@@ -207,15 +206,26 @@ struct DuckBlockVocabulary {
 	// Equality goes red on every release including ones that cannot affect you,
 	// and a check that cries wolf gets muted:
 	//
-	//     major(duck_block_spec_version()) == 2   AND   minor(...) >= <what you need>
+	//     major(duck_block_spec_version()) == 1   AND   minor(...) >= <what you need>
 	//
 	// (Asked by panduck, who noticed the guidance said "compare against
 	// SPEC_VERSION" without saying compare HOW, and whose readers are untouched by
 	// 2.0 apart from lists.)
 	//
 	// HONEST HISTORY, because the numbers only mean something if they were applied
-	// consistently and one of these was not:
+	// consistently and one of these was not.
 	//
+	// TWO NUMBER LINES. Every entry below up to 6.6 is on this repo's INTERNAL line,
+	// retired on 2026-09-10 (last entry). The internal line had its own 1.1 and 1.2,
+	// which are NOT the public 1.2 that SPEC_VERSION now carries: internal 1.2 lacked
+	// explicit levels, `plain`, one shape per element_type and the native table
+	// schema; public 1.2 has all of them. A check written against internal 1.x
+	// (`major == 1 AND minor >= 2`) is satisfied by public 1.2 and is therefore not
+	// discriminating; no consumer in the fleet carries one (checked 2026-09-10:
+	// every vendored copy was on 6.5), which is why the number was reused rather
+	// than skipped. (Zim-Dev's finding, 2026-09-10.)
+	//
+	//   -- internal line --
 	//   1.1 -> 1.2  list and blockquote became structural. BREAKING -- it broke
 	//               duckdb_markdown's writer in three places. It should have been
 	//               2.0 and the minor bump was wrong. A consumer pinning "major 1"
@@ -359,8 +369,53 @@ struct DuckBlockVocabulary {
 	//               wanting text renames to the _text sibling. Failure to migrate is a
 	//               binder error, never a wrong answer.
 	//
+	//   6.5 -> 6.6  ADDITIVE for consumers; producers gain two obligations, named here.
+	//               Issue #29 (duckeye): every validation rule was a predicate on ONE
+	//               element and the one-shape rule bound only this repo, while the
+	//               divergences consumers hit are properties of a LIST and run between
+	//               repos. Four things:
+	//               * Fragments are legal input. ImplicitParentOf() below declares the
+	//                 wrapper a fragment gets (list_item -> list, caption -> figure,
+	//                 inline -> plain). duck_blocks_to_pandoc_ast used to return [] for an
+	//                 orphan inline run that duck_blocks_validate called valid.
+	//               * List-level validation (field = 'list'): element_order dense from 0,
+	//                 shallowest level 1, no level jump, required ancestors present.
+	//               * duck_blocks_repair(blocks): the deterministic fixes for those rules,
+	//                 idempotent, never touching an existing element's content, attributes
+	//                 or element_type. Composes with duck_blocks_normalize.
+	//               * ONE shape per element_type binds EVERY producer. First instance: a
+	//                 tight list item carries content (Pandoc Plain); a loose one has a
+	//                 paragraph child (Para). markdown emitted loose for both (markdown#60)
+	//                 and starts element_order at 1 (markdown#59); both are producer bugs
+	//                 under this note, not new rules.
+	//               A consumer on 6.5 is unaffected. A producer that vendored `plain` and
+	//               never emitted it has been non-conformant since 4.0; this note names it.
+	//
+	//   internal 6.6 -> public 1.2  RENUMBERED, NO SHAPE CHANGE. Teague, 2026-09-10: "I don't want to
+	//               keep numbering up into the 6.6s; this should be at most 1.2; stop
+	//               with the internal numbering." The 6.x line was this repo's internal
+	//               count of spec revisions, one per ruling, and it had climbed to a
+	//               number that says "sixth major redesign" about a vocabulary whose
+	//               public name has been duck_blocks 1.1 throughout. The public name
+	//               is now the number: 1.2 is 6.6 with a different label. Nothing
+	//               renamed, removed, or reshaped between them.
+	//
+	//               RECORDED, NOT QUIET, for the same reason the mis-numbered 1.1 -> 1.2
+	//               above is recorded: every consumer compares major equality plus a
+	//               minor floor (panduck's check implements exactly that rule), so a
+	//               major going DOWN from 6 to 1 reads as a breaking change to a rule
+	//               that is working correctly. SPEC_VERSION_SUPERSEDES below names the
+	//               last number of the retired line so a check can accept either side
+	//               of the renumbering; a consumer re-vendoring this header updates its
+	//               major-equality constant from 6 to 1 once and is done. The next
+	//               breaking change is 2.0; the next additive one is 1.3.
+	//
 	// The rule above is what will be followed from here.
-	static constexpr const char *SPEC_VERSION = "6.5";
+	static constexpr const char *SPEC_VERSION = "1.2";
+	// The last number of the internal 6.x line that 1.2 replaces. A consumer check
+	// that reads MAJOR from SPEC_VERSION treats this line's major as equivalent to
+	// the current one for the one release it takes to re-vendor. Removed at 2.0.
+	static constexpr const char *SPEC_VERSION_SUPERSEDES = "6.6";
 
 	// ========================================================================
 	// Block type names
@@ -414,6 +469,41 @@ struct DuckBlockVocabulary {
 	// rather than figure-specific: Pandoc's Table also carries a Caption, and can
 	// adopt this later without another vocabulary change.
 	static constexpr const char *TYPE_CAPTION = "caption";
+
+	// ========================================================================
+	// Implicit parents (spec: "Fragments are legal input")
+	//
+	// A fragment -- the items of one list, the inline run of one paragraph --
+	// is legal input everywhere. When an element that REQUIRES an ancestor has
+	// none, this is the wrapper it gets, declared once so duck_blocks_repair,
+	// the exporter and a sibling's vendored copy agree. Empty string = none.
+	// Constexpr and std-free so the header stays <cstdint>-only.
+	// ========================================================================
+	// Single-return recursion, not a loop: the extension compiles as C++11, where a
+	// constexpr body must be one return statement. (The standalone header probe
+	// compiles with a newer standard and cannot catch a C++14-only body.)
+	static constexpr bool SameName(const char *a, const char *b) {
+		return *a == *b && (*a == '\0' || SameName(a + 1, b + 1));
+	}
+
+	static constexpr const char *ImplicitParentOf(const char *element_type, const char *kind) {
+		return SameName(kind, KIND_INLINE)                                            ? TYPE_PLAIN
+		       : SameName(kind, KIND_BLOCK) && SameName(element_type, TYPE_LIST_ITEM) ? TYPE_LIST
+		       : SameName(kind, KIND_BLOCK) && SameName(element_type, TYPE_CAPTION)   ? TYPE_FIGURE
+		                                                                              : "";
+	}
+
+	// Does an ancestor of block type `ancestor_type` satisfy this element's
+	// requirement? Only meaningful when ImplicitParentOf() is non-empty. An inline
+	// needs any non-inline (block or value) above it, which callers check by kind.
+	static constexpr bool RequiresAncestor(const char *element_type, const char *kind, const char *ancestor_type) {
+		return SameName(kind, KIND_INLINE) ? true
+		       : SameName(element_type, TYPE_LIST_ITEM)
+		           ? (SameName(ancestor_type, TYPE_LIST) || SameName(ancestor_type, TYPE_DEFLIST))
+		       : SameName(element_type, TYPE_CAPTION)
+		           ? (SameName(ancestor_type, TYPE_FIGURE) || SameName(ancestor_type, TYPE_TABLE))
+		           : false;
+	}
 	// A structurally-valid element whose type is not in the standard vocabulary.
 	// Distinct from TYPE_RAW, which is literal content in a *named* format; this is a
 	// structured element we cannot name. Format-neutral on purpose: any reader


### PR DESCRIPTION
Updates sitting_duck's vendored duck_block_utils from **6.5 (public 1.1) → public 1.2** (upstream `1c5f2a6`, PR #30). Part of the pre-v2.0 clean-slate.

**1.2 adds** (over 6.5): fragments are legal input; an implicit-parent table (`ImplicitParentOf`/`RequiresAncestor`); **list-level validation** (`field='list'`: dense `element_order` from 0, shallowest level 1, no level-jump > 1, required-ancestor, inline-under-block); and "one shape per element_type binds every producer." Struct shape unchanged.

**Producer impact: none.** sitting_duck is a producer (`ast_to_blocks`). I verified empirically that its output already satisfies the 1.2 list-level rules — **0 validator errors** across python/go and the summary/flat/no-bodies styles — so this is a vocabulary/conformance refresh, not a migration. The optional `duck_block_normalize.hpp` transform isn't vendored (unneeded).

**Changes:**
- Re-vendored `duck_block_vocabulary.hpp` + `duck_block_conformance.sql`; updated `PROVENANCE.md`.
- `duck_blocks_conformance.test`: header → 1.2, and added the **list-level** check (`duck_blocks_errors` over `ast_to_blocks` output = 0) verbatim from the vendored validator. Passes (14 assertions).

No compiled code changed (the vendored vocabulary header isn't `#include`d by sitting_duck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)